### PR TITLE
Add SystemVerilog compilation for xorArrow.sv

### DIFF
--- a/cava/.gitignore
+++ b/cava/.gitignore
@@ -53,6 +53,8 @@ StateMonad.hs
 Arrow.hs
 ArrowExamples.hs
 xorArrow.sv
+xorArrow.vcd
+xorArrow.vvp
 loopedNAND.sv
 loopedNAND.vcd
 loopedNAND.vvp

--- a/cava/Makefile
+++ b/cava/Makefile
@@ -16,7 +16,7 @@
 
 .PHONY: cava all clean
 
-all:		cava nand2.vcd loopedNAND.vcd
+all:		cava nand2.vcd loopedNAND.vcd xorArrow.vcd
 
 cava:		Makefile.coq FixupAscii
 		$(MAKE) -f Makefile.coq
@@ -38,11 +38,18 @@ ExamplesSV:	ExamplesSV.hs
 nand2.sv:	cava ExamplesSV
 		./ExamplesSV
 
-loopedNAND.sv:	nand2.sv
 
 nand2.vcd:	nand2.sv nand2_tb.sv
 		iverilog -g2012 -o nand2.vvp nand2.sv nand2_tb.sv
 		./nand2.vvp
+
+xorArrow.sv:	nand2.sv
+
+xorArrow.vcd:	xorArrow.sv xorArrow_tb.sv
+		iverilog -g2012 -o xorArrow.vvp xorArrow.sv xorArrow_tb.sv
+		./xorArrow.vvp
+
+loopedNAND.sv:	nand2.sv
 
 loopedNAND.vcd:	loopedNAND.sv loopedNAND_tb.sv
 		iverilog -g2012 -o loopedNAND.vvp loopedNAND.sv loopedNAND_tb.sv

--- a/cava/xorArrow_tb.sv
+++ b/cava/xorArrow_tb.sv
@@ -1,0 +1,64 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module xorArrow_test;
+  
+  timeunit 1ns; timeprecision 1ns;
+
+  logic input1, input2, output1;
+  logic rst;
+  logic clk;
+  
+  xorArrow xorArrow_dut  (.*);
+
+  initial begin
+    clk <= 0;
+    forever #5 clk = ~clk;
+  end
+ 
+  initial $monitor($time, " input1 = %b, input2 = %b, output1 = %b",
+                   input1, input2, output1);
+
+  initial begin
+    assign input1 = 1'b0;
+    assign input2 = 1'b0;
+    assign rst = 1'b1;
+    @(posedge clk);
+    @(posedge clk);
+    assign rst = 1'b0;
+    @(posedge clk);
+    assign input1 = 1'b1;
+    assign input2 = 1'b0;
+    @(posedge clk);
+    assign input1 = 1'b0;
+    assign input2 = 1'b1;
+    @(posedge clk);
+    assign input1 = 1'b1;
+    assign input2 = 1'b1;
+    @(posedge clk);
+    assign input1 = 1'b0;
+    assign input2 = 1'b0;
+    @(posedge clk);
+    @(negedge clk) $finish;
+  end
+  
+  initial
+  begin
+    $dumpfile("xorArrow.vcd");
+    $dumpvars;
+  end
+
+endmodule


### PR DESCRIPTION
This PR adds code to check that the generated `xorArrow.sv` circuit can be compiled and uses it in a test bench (but currently the test does not fail if the functionality is wrong). It also generates a VCD waveform. 
```
./xorArrow.vvp
VCD info: dumpfile xorArrow.vcd opened for output.
VCD warning: $dumpvars: Unsupported argument type (vpiPackage)
                   0 input1 = 0, input2 = 0, output1 = 0
                  25 input1 = 1, input2 = 0, output1 = 1
                  35 input1 = 0, input2 = 1, output1 = 1
                  45 input1 = 1, input2 = 1, output1 = 0
                  55 input1 = 0, input2 = 0, output1 = 0
```
