### PR TITLE
Clean .*.aux files in Cava

### DIFF
--- a/cava/Makefile
+++ b/cava/Makefile
@@ -70,4 +70,5 @@ clean:
 		rm -rf Makefile.coq .Makefile.coq.conf \
                        *.hi *.o ExamplesSV FixupAscii dist work-obj93.cf
 		xargs rm -rf < .gitignore
+		rm -rf Cava/.*.aux
 


### PR DESCRIPTION
Works just for the Cava directory for now. Perhaps there is a way to use in information in the `.gitignore` of the parent directory.