### PR TITLE
 `-rule` instead of `-msg` required by verilator version 4.030

### DIFF
--- a/cava/Makefile
+++ b/cava/Makefile
@@ -70,4 +70,5 @@ clean:
 		rm -rf Makefile.coq .Makefile.coq.conf \
                        *.hi *.o ExamplesSV FixupAscii dist work-obj93.cf
 		xargs rm -rf < .gitignore
+		rm -rf Cava/.*.aux
 

--- a/cava/README.md
+++ b/cava/README.md
@@ -26,7 +26,7 @@ Please install the following components:
 * The [Icarus Verilog](http://iverilog.icarus.com/) circuit simulator version
   11.0 or later. GitHub link:
   [https://github.com/steveicarus/iverilog](https://github.com/steveicarus/iverilog)
-* [Verilator](https://www.veripool.org/wiki/verilator) version 3.911 or later.
+* [Verilator](https://www.veripool.org/wiki/verilator) version 4.030 or later.
 
 ## Building
 

--- a/cava/verilator.vlt
+++ b/cava/verilator.vlt
@@ -1,3 +1,3 @@
 `verilator_config
-lint_off -msg UNOPTFLAT
-lint_off -msg BLKANDNBLK
+lint_off -rule UNOPTFLAT
+lint_off -rule BLKANDNBLK


### PR DESCRIPTION
Use `-rule` instead of `-msg` required by verilator version 4.030.