### PR TITLE
Specify exactly the same version of Verilator as required by OpenTitan

### DIFF
--- a/cava/README.md
+++ b/cava/README.md
@@ -26,7 +26,8 @@ Please install the following components:
 * The [Icarus Verilog](http://iverilog.icarus.com/) circuit simulator version
   11.0 or later. GitHub link:
   [https://github.com/steveicarus/iverilog](https://github.com/steveicarus/iverilog)
-* [Verilator](https://www.veripool.org/wiki/verilator) version 4.030 or later.
+* [Verilator](https://www.veripool.org/wiki/verilator) version 4.028 (as specified by the
+  [OpenTitan](https://docs.opentitan.org/doc/ug/install_instructions/#verilator) documentation).
 
 ## Building
 


### PR DESCRIPTION
At some point the `nix` configuration files should install exactly this version of Verilator.