### PR TITLE
Make adder used Vector type

### DIFF
--- a/cava-examples/ExamplesExtraction.v
+++ b/cava-examples/ExamplesExtraction.v
@@ -21,6 +21,7 @@ From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
 From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 

--- a/cava-examples/FullAdder.v
+++ b/cava-examples/FullAdder.v
@@ -27,7 +27,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.BitVector.
+Require Import Cava.BitArithmetic.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.

--- a/cava-examples/FullAdderNat.v
+++ b/cava-examples/FullAdderNat.v
@@ -32,8 +32,9 @@ Local Open Scope list_scope.
 Local Open Scope monad_scope.
 
 Require Import Cava.Cava.
+Require Import Cava.BitArithmetic.
 Require Import FullAdder.
-Require Import BitVector.
+
 
 Lemma halfAdderNat_correct :
   forall (a : nat) (b : nat), a < 2 -> b < 2 ->

--- a/cava-examples/UnsignedAdder.v
+++ b/cava-examples/UnsignedAdder.v
@@ -17,13 +17,14 @@
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
+From Coq Require Import Vector.
 From Coq Require Import ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
-Require Import Cava.BitVector.
+Require Import Cava.BitArithmetic.
 Require Import FullAdder.
 
 Local Open Scope list_scope.
@@ -82,11 +83,13 @@ Proof. reflexivity. Qed.
 
 Definition adder8Top :=
   setModuleName "adder8" ;;
-  a <- inputVectorTo0 8 "a" ;;
-  b <- inputVectorTo0 8 "b" ;;
+  av <- inputVectorTo0 8 "a" ;;
+  bv <- inputVectorTo0 8 "b" ;;
+  let a := Vector.to_list av in
+  let b := Vector.to_list bv in
   cin <- inputBit "cin" ;;
   '(sum, cout) <- unsignedAdder cin (combine a b) ;;
-  outputVectorTo0 sum "sum" ;;
+  outputVectorTo0 (length sum) (Vector.of_list sum) "sum" ;;
   outputBit "cout" cout.
 
 Definition adder8Netlist := makeNetlist adder8Top.

--- a/cava-examples/UnsignedAdderNat.v
+++ b/cava-examples/UnsignedAdderNat.v
@@ -25,11 +25,12 @@ Scheme Equality for list.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.
+Require Import Cava.Cava.
+Require Import Cava.BitArithmetic.
 Require Import FullAdder.
 Require Import FullAdderNat.
 Require Import UnsignedAdder.
-Require Import BitVector.
+
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.

--- a/cava/.gitignore
+++ b/cava/.gitignore
@@ -31,8 +31,9 @@ Monad.hs
 Netlist.hs
 Netlist0.hs
 State.hs
-BitVector.hs
 PeanoNat.hs
+BitArithmetic.hs
+Bvector.hs
 ExamplesSV
 nand2.sv
 nand2.vcd
@@ -62,3 +63,10 @@ loopedNAND.vvp
 loopedNandArrow.sv
 loopedNandArrow.vcd
 loopedNandArrow.vvp
+Fin.hs
+Plus.hs
+Vector.hs
+VectorDef.hs
+adder4.sv
+adder4.vcd
+adder4.vvp

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -14,11 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-(* Bit-vector operations for Cava.
-*)
+(* Bit-vector arithmetic operations for Cava. *)
 
 From Coq Require Import Bool.Bool. 
 From Coq Require Import Lists.List.
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
 Require Import Nat Arith.
 Require Import Omega.
 From Coq Require Import btauto.Btauto.
@@ -87,62 +88,62 @@ Proof. reflexivity. Qed.
 
 Example n2b_2_3 : nat_to_bits 2 3 = [true; true].
 Proof. reflexivity. Qed.
-
-(*
-Lemma twice : forall (n : nat), n + n = 2 * n.
-Proof.
-  lia.
-Qed.
-
-Lemma even_sn : forall (n : nat), even (S n) = odd (S n + 1).
-Proof.
-  intros.
-  induction n.
-  - simpl. reflexivity.
-  - unfold even.
-Abort.
-
-Lemma odd_even : forall (n : nat), odd (n + 1) = even n.
-Proof.
-  intros.
-  induction n.
-  - simpl. reflexivity.
-Abort.
-
-Lemma odd_2n_plus_1 : forall (n : nat), odd (2 * n + 1) = true.
-Proof.
-  intros.
-  induction n.
-  - simpl. reflexivity.
-Abort.
-
-Lemma first_bit: forall (a : bool) (a0 : list bool),
-               nat_to_bits (length (a :: a0)) (bits_to_nat (a :: a0)) =
-               a :: nat_to_bits (length a0) (bits_to_nat a0).
-Proof.
-  intros.
-  destruct a.
-  - simpl. rewrite plus_0_r.
-  - simpl. rewrite plus_0_r. unfold Nat.b2n. unfold odd. unfold negb.
-    destruct a.
-    + simpl. reflexivity.
-    + simpl. reflexivity.
-Abort.
-*)
-
-Lemma bits_to_from_nat : forall (a : list bool),
-                         length a > 0 ->
-                         nat_to_bits (length a) (bits_to_nat a) = a.  
-Proof.
-  intros.
-  induction a.
-  - simpl. reflexivity.
-Abort.
     
+(******************************************************************************)
+(* Functions useful for Vector operations                                     *)
+(******************************************************************************)
+
+Fixpoint bitvec_to_nat {n : nat} (bits : Bvector n) : nat :=
+  match n, bits with
+  | 0, _ => 0
+  | S n', bv => Nat.b2n (Blow n' bv) + 2 * (bitvec_to_nat (Bhigh n' bv))
+  end.
+
+Definition bv3_0 : Bvector 3 := of_list [false; false; false].
+Example bv3_0_ex : bitvec_to_nat bv3_0 = 0.
+Proof. reflexivity. Qed.
+
+Definition bv3_1 : Bvector 3 := of_list [true; false; false].
+Example bv3_1_ex : bitvec_to_nat bv3_1 = 1.
+Proof. reflexivity. Qed.
+
+Definition bv3_2 : Bvector 3 := of_list [false; true; false].
+Example bv3_2_ex : bitvec_to_nat bv3_2 = 2.
+Proof. reflexivity. Qed.
+
+
+Fixpoint nat_to_bitvec (n : nat) (v : nat) : Bvector n :=
+  match n with
+  | 0    => Bnil
+  | S n' => Bcons (testbit v 0) n' (nat_to_bitvec n' (div2 v))
+  end.
+
+Example bv3_0_exrev : nat_to_bitvec 3 0 = bv3_0.
+Proof. reflexivity. Qed.
+
+Example bv3_1_exrev : nat_to_bitvec 3 1 = bv3_1.
+Proof. reflexivity. Qed.
+
+Example bv3_2_exrev : nat_to_bitvec 3 2 = bv3_2.
+Proof. reflexivity. Qed.
+
+(* Vector version of list seq *)
+Fixpoint vec_seq (a b : nat) : Vector.t nat b :=
+  match b with
+  | 0 => Vector.nil nat
+  | S b' => Vector.cons nat a b' (vec_seq (a + 1) b')
+  end.
+
+(* Vector version of replicate *)
+Fixpoint replicate_vec {A : Type} (n : nat) (v : A) : Vector.t A n :=
+  match n with
+  | 0    => Vector.nil A
+  | S n' => Vector.cons A v n' (replicate_vec n' v)
+  end.
 
 (******************************************************************************)
 (* Functions useful for examples and tests                                    *)
 (******************************************************************************)
 
-Definition fromVec := map Nat.b2n.
-Definition toVec := map nat2bool.
+Definition fromVec := List.map Nat.b2n.
+Definition toVec := List.map nat2bool.

--- a/cava/Cava/Examples.v
+++ b/cava/Cava/Examples.v
@@ -33,7 +33,7 @@ Open Scope monad_scope.
 Require Import Cava.Cava.
 Require Import Cava.Combinators.
 Require Import Cava.Netlist.
-Require Import BitVector.
+Require Import Cava.BitArithmetic.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
@@ -112,16 +112,16 @@ Qed.
 
 (* Unsigned addition examples. *)
 
-Definition bv4_0  := nat_to_bits 4  0.
-Definition bv4_1  := nat_to_bits 4  1.
-Definition bv4_2  := nat_to_bits 4  2.
-Definition bv4_3  := nat_to_bits 4  3.
-Definition bv4_15 := nat_to_bits 4 15.
+Definition bv4_0  := nat_to_bitvec 4  0.
+Definition bv4_1  := nat_to_bitvec 4  1.
+Definition bv4_2  := nat_to_bitvec 4  2.
+Definition bv4_3  := nat_to_bitvec 4  3.
+Definition bv4_15 := nat_to_bitvec 4 15.
 
-Definition bv5_0  := nat_to_bits 5  0.
-Definition bv5_3  := nat_to_bits 5  3.
-Definition bv5_16 := nat_to_bits 5 16.
-Definition bv5_30 := nat_to_bits 5 30.
+Definition bv5_0  := nat_to_bitvec 5  0.
+Definition bv5_3  := nat_to_bitvec 5  3.
+Definition bv5_16 := nat_to_bitvec 5 16.
+Definition bv5_30 := nat_to_bitvec 5 30.
 
 (* Check 0 + 0 = 0 *)
 Example add_0_0 : combinational (unsignedAdd bv4_0 bv4_0) = bv5_0.
@@ -142,12 +142,12 @@ Proof. reflexivity. Qed.
 
 (* An adder example. *)
 
-Definition adder4Top : state CavaState (list Z) :=
+Definition adder4Top : state CavaState (Vector.t Z 5) :=
   setModuleName "adder4" ;;
   a <- inputVectorTo0 4 "a" ;;
   b <- inputVectorTo0 4 "b" ;;
   sum <- unsignedAdd a b ;;
-  outputVectorTo0 sum "sum".
+  outputVectorTo0 5 sum "sum".
 
 Definition adder4Netlist := makeNetlist adder4Top.
 Compute (execState nand2Top initState).

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2019 The Project Oak Authors                                   *)
+(* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -18,14 +18,15 @@ From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
 From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import BitVector.
+Require Import BitArithmetic.
 Require Import Cava.
 Require Import Cava.Examples.
 
-Recursive Extraction Library BitVector.
+Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Combinators.
 Recursive Extraction Library Cava.
 Extraction Library Examples.

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -24,6 +24,7 @@ From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import ZArith.
 From Coq Require Import Lists.List.
+From Coq Require Import Vector.
 Import ListNotations.
 
 (******************************************************************************)
@@ -49,11 +50,11 @@ Inductive Primitive :=
   | DelayBit : Z -> Z -> Primitive
   (* Assignment of bit wire *)
   | AssignBit : Z -> Z -> Primitive
-  (* Conversion to/from vectors *)
-  | ToVec : list Z -> Z -> Primitive
-  | FromVec : Z -> list Z -> Primitive
+  (* Mapping to SystemVerilog vectors *)
+  | ToVec : forall n, Vector.t Z n -> Z -> Primitive (* Maps bitvec to SV vec *)
+  | FromVec : forall n, Z -> Vector.t Z n -> Primitive (* Maps SV vec to bitvec *)
   (* Arithmetic operations *)
-  | UnsignedAdd : Z -> Z -> Z -> Primitive (* Z are names of vectors *)
+  | UnsignedAdd : Z -> Z -> Z -> Primitive
   (* Xilinx FPGA architecture specific gates. *)
   | Xorcy : Z -> Z -> Z -> Primitive
   | Muxcy : Z -> Z -> Z -> Z -> Primitive.
@@ -64,8 +65,8 @@ Inductive Primitive :=
 
 Inductive PortType :=
   | BitPort : Z -> PortType
-  | VectorTo0Port : list Z -> PortType
-  | VectorFrom0Port : list Z -> PortType.
+  | VectorTo0Port : forall n, Vector.t Z n -> PortType
+  | VectorFrom0Port : forall n, Vector.t Z n  -> PortType.
 
 Record PortDeclaration : Type := mkPort {
   port_name : string;

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -40,7 +40,7 @@ cabal-version:        >= 1.10
 library
   build-Depends:     base >= 4
   exposed-Modules:   Cava2SystemVerilog
-                     BitVector
+                     BitArithmetic
                      Cava
                      Combinators
                      Datatypes
@@ -51,6 +51,8 @@ library
                      Nat
                      PeanoNat
                      StateMonad
+                     VectorDef
+                     Vector
   other-Modules:     Applicative
                      BinInt
                      BinNat
@@ -70,5 +72,8 @@ library
                      MonadWriter
                      MonadZero
                      Monoid
+                     Bvector
+                     Fin
+                     Plus
 
   default-language:  Haskell2010

--- a/cava/_CoqProject
+++ b/cava/_CoqProject
@@ -7,7 +7,7 @@ Cava/Arrow/Instances/Coq.v
 Cava/Arrow/Instances/Stream.v
 Cava/Arrow/Instances/Netlist.v
 
-Cava/BitVector.v
+Cava/BitArithmetic.v
 Cava/Netlist.v
 Cava/Cava.v
 Cava/Combinators.v


### PR DESCRIPTION
This reworks `unsignedAdder` to use the Vector type which allows us to explicitly encode bit-vector sizes in the type.