### PR TITLE
Convert to using N instead of Z for net indexes and counting

### DIFF
--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -80,7 +80,7 @@ Definition makeNetlist {t} (circuit : state CavaState t) : CavaState
 (* Netlist implementations for the Cava class.                                *)
 (******************************************************************************)
 
-Definition invNet (i : Z) : state CavaState Z :=
+Definition invNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -88,7 +88,7 @@ Definition invNet (i : Z) : state CavaState Z :=
          ret o
   end.
 
-Definition andNet (i : Z * Z) : state CavaState Z :=
+Definition andNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -96,7 +96,7 @@ Definition andNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition nandNet (i : Z * Z) : state CavaState Z :=
+Definition nandNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -104,7 +104,7 @@ Definition nandNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition orNet (i : Z * Z) : state CavaState Z :=
+Definition orNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -112,7 +112,7 @@ Definition orNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition norNet (i : Z * Z) : state CavaState Z :=
+Definition norNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -120,7 +120,7 @@ Definition norNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition xorNet (i : Z * Z) : state CavaState Z :=
+Definition xorNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -129,7 +129,7 @@ Definition xorNet (i : Z * Z) : state CavaState Z :=
   end.
 
 
-Definition xorcyNet (i : Z * Z) : state CavaState Z :=
+Definition xorcyNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -137,7 +137,7 @@ Definition xorcyNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition xnorNet (i : Z * Z) : state CavaState Z :=
+Definition xnorNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -145,7 +145,7 @@ Definition xnorNet (i : Z * Z) : state CavaState Z :=
          ret o
   end.
 
-Definition bufNet (i : Z) : state CavaState Z :=
+Definition bufNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -153,7 +153,7 @@ Definition bufNet (i : Z) : state CavaState Z :=
          ret o
   end.
 
-Definition muxcyNet (s : Z)  (di : Z) (ci : Z) : state CavaState Z :=
+Definition muxcyNet (s : N)  (di : N) (ci : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -161,18 +161,18 @@ Definition muxcyNet (s : Z)  (di : Z) (ci : Z) : state CavaState Z :=
          ret o
   end.  
 
-Definition unsignedAddNet {m n : nat} (av : Vector.t Z m) (bv : Vector.t Z n) : state CavaState (Vector.t Z (max m n + 1)) :=
+Definition unsignedAddNet {m n : nat} (av : Vector.t N m) (bv : Vector.t N n) : state CavaState (Vector.t N (max m n + 1)) :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
       => let l := max m n + 1 in
-         let outv := Vector.map Z.of_nat (vec_seq (Z.to_nat o) (max m n + 1)) in
+         let outv := Vector.map N.of_nat (vec_seq (N.to_nat o) (max m n + 1)) in
          let adder := [ToVec m av v; ToVec n bv (v + 1); UnsignedAdd v (v + 1) (v + 2); FromVec l (v + 2) outv] in
-         put (mkCavaState (o + (Z.of_nat l)) v isSeq (mkModule name (adder ++ insts) inputs outputs )) ;;
+         put (mkCavaState (o + (N.of_nat l)) v isSeq (mkModule name (adder ++ insts) inputs outputs )) ;;
          ret outv
   end.
 
-Definition delayBitNet (i : Z) : state CavaState Z :=
+Definition delayBitNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -180,7 +180,7 @@ Definition delayBitNet (i : Z) : state CavaState Z :=
          ret o
   end.
 
-Definition loopBitNet (A B : Type) (f : (A * Z)%type -> state CavaState (B * Z)%type) (a : A) : state CavaState B :=
+Definition loopBitNet (A B : Type) (f : (A * N)%type -> state CavaState (B * N)%type) (a : A) : state CavaState B :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule name insts inputs outputs)
@@ -199,9 +199,9 @@ Definition loopBitNet (A B : Type) (f : (A * Z)%type -> state CavaState (B * Z)%
 (* any top-level pins or other module-level data                              *)
 (******************************************************************************)
 
-Instance CavaNet : Cava (state CavaState) Z :=
-  { zero := ret 0%Z;
-    one := ret 1%Z;
+Instance CavaNet : Cava (state CavaState) N :=
+  { zero := ret 0%N;
+    one := ret 1%N;
     delayBit := delayBitNet;
     loopBit a b := loopBitNet a b;
     inv := invNet;
@@ -228,17 +228,17 @@ Definition setModuleName (name : string) : state CavaState unit :=
      => put (mkCavaState o v isSeq (mkModule name insts inputs outputs))
   end.
 
-Definition inputVectorTo0 (size : nat) (name : string) : state CavaState (Vector.t Z size) :=
+Definition inputVectorTo0 (size : nat) (name : string) : state CavaState (Vector.t N size) :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule n insts inputs outputs)
-     => let netNumbers := Vector.map Z.of_nat (vec_seq (Z.abs_nat o) size) in
+     => let netNumbers := Vector.map N.of_nat (vec_seq (N.to_nat o) size) in
         let newPort := mkPort name (VectorTo0Port size netNumbers) in
-        put (mkCavaState (o + (Z.of_nat size)) v isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
+        put (mkCavaState (o + (N.of_nat size)) v isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
         ret netNumbers
   end.
 
-Definition inputBit (name : string) : state CavaState Z :=
+Definition inputBit (name : string) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule n insts inputs outputs)
@@ -247,7 +247,7 @@ Definition inputBit (name : string) : state CavaState Z :=
         ret o
   end.
 
-Definition outputBit (name : string) (i : Z) : state CavaState Z :=
+Definition outputBit (name : string) (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o v isSeq (mkModule n insts inputs outputs)
@@ -256,7 +256,7 @@ Definition outputBit (name : string) (i : Z) : state CavaState Z :=
         ret i
   end.
 
-Definition outputVectorTo0 (size : nat) (v : Vector.t Z size) (name : string) : state CavaState (Vector.t Z size) :=
+Definition outputVectorTo0 (size : nat) (v : Vector.t N size) (name : string) : state CavaState (Vector.t N size) :=
   cs <- get ;;
   match cs with
   | mkCavaState o vecs isSeq (mkModule n insts inputs outputs)

--- a/cava/Cava/Examples.v
+++ b/cava/Cava/Examples.v
@@ -23,7 +23,7 @@ Require Import Program.Basics.
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
-From Coq Require Import ZArith.
+From Coq Require Import NArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
@@ -52,7 +52,7 @@ Proof. reflexivity. Qed.
 Example and_11 : combinational (and2 (true, true)) = true.
 Proof. reflexivity. Qed.
 
-Eval cbv in (execState (inv (2%Z)) (initStateFrom 3)).
+Eval cbv in (execState (inv (2%N)) (initStateFrom 3)).
 
 (* NAND gate example. Fist, let's define an overloaded NAND gate
    description. *)
@@ -74,9 +74,9 @@ Proof. reflexivity. Qed.
 
 (* Generate a circuit graph representation for the NAND gate using the
    netlist interpretatin. *)
-Eval cbv in (execState (nand2_gate (2%Z, 3%Z)) (initStateFrom 4)).
+Eval cbv in (execState (nand2_gate (2%N, 3%N)) (initStateFrom 4)).
 
-Definition nand2Top : state CavaState Z :=
+Definition nand2Top : state CavaState N :=
   setModuleName "nand2" ;;
   a <- inputBit "a" ;;
   b <- inputBit "b" ;;
@@ -142,7 +142,7 @@ Proof. reflexivity. Qed.
 
 (* An adder example. *)
 
-Definition adder4Top : state CavaState (Vector.t Z 5) :=
+Definition adder4Top : state CavaState (Vector.t N 5) :=
   setModuleName "adder4" ;;
   a <- inputVectorTo0 4 "a" ;;
   b <- inputVectorTo0 4 "b" ;;
@@ -157,7 +157,7 @@ Compute (execState nand2Top initState).
 
 Definition loopedNAND {m bit} `{Cava m bit}  := loopBit (second delayBit >=> nand2 >=> fork2).
 
-Definition loopedNANDTop : state CavaState Z :=
+Definition loopedNANDTop : state CavaState N :=
   setModuleName "loopedNAND" ;;
   a <- inputBit "a" ;;
   b <- loopedNAND a ;;

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2019 The Project Oak Authors                                   *)
+(* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -38,35 +38,35 @@ Import ListNotations.
 
 Inductive Primitive :=
   (* SystemVerilog primitive gates. *)
-  | Not  : Z -> Z -> Primitive
-  | And  : list Z -> Z -> Primitive
-  | Nand : list Z -> Z -> Primitive
-  | Or   : list Z -> Z -> Primitive
-  | Nor  : list Z -> Z -> Primitive
-  | Xor  : list Z -> Z -> Primitive
-  | Xnor : list Z -> Z -> Primitive
-  | Buf  : Z -> Z -> Primitive
+  | Not  : N -> N -> Primitive
+  | And  : list N -> N -> Primitive
+  | Nand : list N -> N -> Primitive
+  | Or   : list N -> N -> Primitive
+  | Nor  : list N -> N -> Primitive
+  | Xor  : list N -> N -> Primitive
+  | Xnor : list N -> N -> Primitive
+  | Buf  : N -> N -> Primitive
   (* A Cava unit delay bit component. *)
-  | DelayBit : Z -> Z -> Primitive
+  | DelayBit : N -> N -> Primitive
   (* Assignment of bit wire *)
-  | AssignBit : Z -> Z -> Primitive
+  | AssignBit : N -> N -> Primitive
   (* Mapping to SystemVerilog vectors *)
-  | ToVec : forall n, Vector.t Z n -> Z -> Primitive (* Maps bitvec to SV vec *)
-  | FromVec : forall n, Z -> Vector.t Z n -> Primitive (* Maps SV vec to bitvec *)
+  | ToVec : forall n, Vector.t N n -> N -> Primitive (* Maps bitvec to SV vec *)
+  | FromVec : forall n, N -> Vector.t N n -> Primitive (* Maps SV vec to bitvec *)
   (* Arithmetic operations *)
-  | UnsignedAdd : Z -> Z -> Z -> Primitive
+  | UnsignedAdd : N -> N -> N -> Primitive
   (* Xilinx FPGA architecture specific gates. *)
-  | Xorcy : Z -> Z -> Z -> Primitive
-  | Muxcy : Z -> Z -> Z -> Z -> Primitive.
+  | Xorcy : N -> N -> N -> Primitive
+  | Muxcy : N -> N -> N -> N -> Primitive.
 
 (******************************************************************************)
 (* Data structures to represent circuit graph/netlist state                   *)
 (******************************************************************************)
 
 Inductive PortType :=
-  | BitPort : Z -> PortType
-  | VectorTo0Port : forall n, Vector.t Z n -> PortType
-  | VectorFrom0Port : forall n, Vector.t Z n  -> PortType.
+  | BitPort : N -> PortType
+  | VectorTo0Port : forall n, Vector.t N n -> PortType
+  | VectorFrom0Port : forall n, Vector.t N n  -> PortType.
 
 Record PortDeclaration : Type := mkPort {
   port_name : string;
@@ -83,8 +83,8 @@ Record Module : Type := mkModule {
 }.
 
 Record CavaState : Type := mkCavaState {
-  netNumber : Z;
-  vecNumber : Z;
+  netNumber : N;
+  vecNumber : N;
   isSequential : bool;
   module : Module;
 }.
@@ -97,7 +97,7 @@ Record CavaState : Type := mkCavaState {
    constant signal 1. We start numbering from 2 for the user nets.
 *)
 
-Definition initStateFrom (startAt : Z) : CavaState
+Definition initStateFrom (startAt : N) : CavaState
   := mkCavaState startAt 0 false (mkModule "" [] [] []).
 
 Definition initState : CavaState

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -40,6 +40,7 @@ cabal-version:        >= 1.10
 library
   build-Depends:     base >= 4
   exposed-Modules:   Cava2SystemVerilog
+                     BinNums
                      BitArithmetic
                      Cava
                      Combinators
@@ -54,9 +55,7 @@ library
                      VectorDef
                      Vector
   other-Modules:     Applicative
-                     BinInt
                      BinNat
-                     BinNums
                      BinPos
                      Bool
                      Decimal


### PR DESCRIPTION
`N` can't be extracted the way `Z` can (i.e. by silently converting to `Prelude.Integer`) so it is left as-is i.e. as `BinNum.N` which is then unpacked in the Haskell side.
Addresses issue #30 