### PR TITLE
Move SystemVerilog fresh vector name generation out of Coq and into H…

### DIFF
--- a/cava/Cava/Arrow/ArrowExamples.v
+++ b/cava/Cava/Arrow/ArrowExamples.v
@@ -160,7 +160,7 @@ Section NetlistExamples.
   (* For extraction *)
   Definition xorArrow :=
     let '(nl, count) := xorArrowNetlist
-    in mkCavaState count 0 false nl.
+    in mkCavaState count false nl.
 
   Definition loopedNandArrowNetlist := arrowToHDLModule
     "loopedNandArrow"
@@ -170,5 +170,5 @@ Section NetlistExamples.
   Eval compute in loopedNandArrowNetlist.
   Definition loopedNandArrow :=
     let '(nl, count) := loopedNandArrowNetlist
-    in mkCavaState count 0 true nl.
+    in mkCavaState count true nl.
 End NetlistExamples.

--- a/cava/Cava/Cava.v
+++ b/cava/Cava/Cava.v
@@ -83,48 +83,48 @@ Definition makeNetlist {t} (circuit : state CavaState t) : CavaState
 Definition invNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Not i o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Not i o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition andNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (And [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (And [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition nandNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Nand [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Nand [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition orNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Or [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Or [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition norNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Nor [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Nor [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition xorNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Xor [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Xor [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -132,64 +132,63 @@ Definition xorNet (i : N * N) : state CavaState N :=
 Definition xorcyNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Xorcy (fst i) (snd i) o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Xorcy (fst i) (snd i) o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition xnorNet (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Xnor [fst i; snd i] o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Xnor [fst i; snd i] o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition bufNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Buf i o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Buf i o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition muxcyNet (s : N)  (di : N) (ci : N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name (cons (Muxcy s di ci o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Muxcy s di ci o) insts) inputs outputs )) ;;
          ret o
   end.  
 
 Definition unsignedAddNet {m n : nat} (av : Vector.t N m) (bv : Vector.t N n) : state CavaState (Vector.t N (max m n + 1)) :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
       => let l := max m n + 1 in
          let outv := Vector.map N.of_nat (vec_seq (N.to_nat o) (max m n + 1)) in
-         let adder := [ToVec m av v; ToVec n bv (v + 1); UnsignedAdd v (v + 1) (v + 2); FromVec l (v + 2) outv] in
-         put (mkCavaState (o + (N.of_nat l)) v isSeq (mkModule name (adder ++ insts) inputs outputs )) ;;
+         put (mkCavaState (o + (N.of_nat l)) isSeq (mkModule name (cons (UnsignedAdd m n av bv outv) insts) inputs outputs )) ;;
          ret outv
   end.
 
 Definition delayBitNet (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v true (mkModule name (cons (DelayBit i o) insts) inputs outputs )) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) true (mkModule name (cons (DelayBit i o) insts) inputs outputs )) ;;
          ret o
   end.
 
 Definition loopBitNet (A B : Type) (f : (A * N)%type -> state CavaState (B * N)%type) (a : A) : state CavaState B :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) v isSeq (mkModule name insts inputs outputs)) ;;
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => put (mkCavaState (o+1) isSeq (mkModule name insts inputs outputs)) ;;
          '(b, cOut) <- f (a, o) ;;
           cs2 <- get ;;
           match cs2 with
-          | mkCavaState o2 v2 isSeq (mkModule name insts inputs outputs)
-              => put (mkCavaState (o2+1) v2 isSeq (mkModule name (cons (AssignBit o cOut) insts) inputs outputs)) ;;
+          | mkCavaState o2 isSeq (mkModule name insts inputs outputs)
+              => put (mkCavaState (o2+1) isSeq (mkModule name (cons (AssignBit o cOut) insts) inputs outputs)) ;;
                  ret b
           end
   end.
@@ -224,44 +223,44 @@ Instance CavaNet : Cava (state CavaState) N :=
 Definition setModuleName (name : string) : state CavaState unit :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule _ insts inputs outputs)
-     => put (mkCavaState o v isSeq (mkModule name insts inputs outputs))
+  | mkCavaState o isSeq (mkModule _ insts inputs outputs)
+     => put (mkCavaState o isSeq (mkModule name insts inputs outputs))
   end.
 
 Definition inputVectorTo0 (size : nat) (name : string) : state CavaState (Vector.t N size) :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o isSeq (mkModule n insts inputs outputs)
      => let netNumbers := Vector.map N.of_nat (vec_seq (N.to_nat o) size) in
         let newPort := mkPort name (VectorTo0Port size netNumbers) in
-        put (mkCavaState (o + (N.of_nat size)) v isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
+        put (mkCavaState (o + (N.of_nat size)) isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
         ret netNumbers
   end.
 
 Definition inputBit (name : string) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o isSeq (mkModule n insts inputs outputs)
      => let newPort := mkPort name (BitPort o) in
-        put (mkCavaState (o+1) v isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
+        put (mkCavaState (o+1) isSeq (mkModule n insts (cons newPort inputs) outputs)) ;;
         ret o
   end.
 
 Definition outputBit (name : string) (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
-  | mkCavaState o v isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o isSeq (mkModule n insts inputs outputs)
      => let newPort := mkPort name (BitPort i) in
-        put (mkCavaState o v isSeq (mkModule n insts inputs (cons newPort outputs))) ;;
+        put (mkCavaState o isSeq (mkModule n insts inputs (cons newPort outputs))) ;;
         ret i
   end.
 
 Definition outputVectorTo0 (size : nat) (v : Vector.t N size) (name : string) : state CavaState (Vector.t N size) :=
   cs <- get ;;
   match cs with
-  | mkCavaState o vecs isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o isSeq (mkModule n insts inputs outputs)
      => let newPort := mkPort name (VectorTo0Port size v) in
-        put (mkCavaState o vecs isSeq (mkModule n insts inputs (cons newPort outputs))) ;;
+        put (mkCavaState o isSeq (mkModule n insts inputs (cons newPort outputs))) ;;
         ret v
   end.
 

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -50,11 +50,9 @@ Inductive Primitive :=
   | DelayBit : N -> N -> Primitive
   (* Assignment of bit wire *)
   | AssignBit : N -> N -> Primitive
-  (* Mapping to SystemVerilog vectors *)
-  | ToVec : forall n, Vector.t N n -> N -> Primitive (* Maps bitvec to SV vec *)
-  | FromVec : forall n, N -> Vector.t N n -> Primitive (* Maps SV vec to bitvec *)
   (* Arithmetic operations *)
-  | UnsignedAdd : N -> N -> N -> Primitive
+  | UnsignedAdd : forall m n, Vector.t N m -> Vector.t N n ->
+                              Vector.t N (max m n + 1) -> Primitive
   (* Xilinx FPGA architecture specific gates. *)
   | Xorcy : N -> N -> N -> Primitive
   | Muxcy : N -> N -> N -> N -> Primitive.
@@ -84,7 +82,6 @@ Record Module : Type := mkModule {
 
 Record CavaState : Type := mkCavaState {
   netNumber : N;
-  vecNumber : N;
   isSequential : bool;
   module : Module;
 }.
@@ -98,7 +95,7 @@ Record CavaState : Type := mkCavaState {
 *)
 
 Definition initStateFrom (startAt : N) : CavaState
-  := mkCavaState startAt 0 false (mkModule "" [] [] []).
+  := mkCavaState startAt false (mkModule "" [] [] []).
 
 Definition initState : CavaState
   := initStateFrom 2.

--- a/cava/Cava2HDL.cabal
+++ b/cava/Cava2HDL.cabal
@@ -38,7 +38,7 @@ stability:           Experimental
 cabal-version:        >= 1.10
 
 library
-  build-Depends:     base >= 4
+  build-Depends:     base >= 4, mtl >= 2
   exposed-Modules:   Cava2SystemVerilog
                      BinNums
                      BitArithmetic


### PR DESCRIPTION
…askell

Address #32 

Now the Coq side just has to know about Coq `Vector`s and the mapping to and from SystemVerilog vectors is done purely on the Haskell side.