### PR TITLE
A three input adder

### DIFF
--- a/cava-examples/.gitignore
+++ b/cava-examples/.gitignore
@@ -18,3 +18,6 @@ Nat.hs
 PeanoNat.hs
 Specif.hs
 fulladder.sv
+AdderTree.hs
+adder8_3in.sv
+adder8_3in.vcd

--- a/cava-examples/AdderTree.v
+++ b/cava-examples/AdderTree.v
@@ -1,0 +1,61 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+(* A codification of the Lava embedded DSL develope for Haskell into
+   Coq for the specification, implementaiton and formal verification of
+   circuits. Experimental work, very much in flux, as Satnam learns Coq!
+*)
+
+Require Import Program.Basics.
+From Coq Require Import Bool.Bool.
+From Coq Require Import Ascii String.
+From Coq Require Import Lists.List.
+From Coq Require Import NArith.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+Open Scope monad_scope.
+
+Require Import Cava.Cava.
+Require Import Cava.Combinators.
+Require Import Cava.Netlist.
+Require Import Cava.BitArithmetic.
+
+Local Open Scope list_scope.
+Local Open Scope monad_scope.
+
+
+Definition adder_3in {m bit} `{Cava m bit} {aL bL cL : nat}
+                     (a : (Vector.t bit aL))
+                     (b : (Vector.t bit bL))
+                     (c : (Vector.t bit cL))
+                     : m (Vector.t bit (max (max aL bL + 1) cL + 1)) :=
+  a_plus_b <- unsignedAdd a b ;;
+  sum <- unsignedAdd a_plus_b c ;;
+  ret sum.
+
+
+Definition adder8_3inTop : state CavaState (Vector.t N 10) :=
+  setModuleName "adder8_3in" ;;
+  a <- inputVectorTo0 8 "a" ;;
+  b <- inputVectorTo0 8 "b" ;;
+  c <- inputVectorTo0 8 "c" ;;
+  sum <- adder_3in a b c ;;
+  outputVectorTo0 10 sum "sum".
+
+Definition adder8_3inNetlist := makeNetlist adder8_3inTop.
+  

--- a/cava-examples/ExamplesExtraction.v
+++ b/cava-examples/ExamplesExtraction.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2019 The Project Oak Authors                                   *)
+(* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -17,6 +17,7 @@
 Require Import NandGate.
 Require Import FullAdder.
 Require Import UnsignedAdder.
+Require Import AdderTree.
 From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
@@ -28,3 +29,4 @@ Extraction Language Haskell.
 Extraction Library NandGate.
 Extraction Library FullAdder.
 Extraction Library UnsignedAdder.
+Extraction Library AdderTree.

--- a/cava-examples/ExamplesSV.hs
+++ b/cava-examples/ExamplesSV.hs
@@ -21,10 +21,12 @@ import Cava2SystemVerilog
 import NandGate
 import FullAdder
 import UnsignedAdder
+import AdderTree
 
 main :: IO ()
 main = do writeSystemVerilog nand2Netlist
           writeSystemVerilog fullAdderNetlist
           writeSystemVerilog fullAdderFCNetlist
           writeSystemVerilog adder8Netlist
+          writeSystemVerilog adder8_3inNetlist
           writeSystemVerilog pipelinedNANDNetlist

--- a/cava-examples/Makefile
+++ b/cava-examples/Makefile
@@ -35,6 +35,10 @@ ExamplesSV:	ExamplesSV.hs
 
 nand2.sv:	compile ExamplesSV
 		./ExamplesSV
+		verilator --lint-only verilator.vlt nand2.sv
+		verilator --lint-only verilator.vlt fulladder.sv
+		verilator --lint-only verilator.vlt pipelinedNAND.sv
+		verilator --lint-only verilator.vlt adder8_3in.sv
 
 nand2.vcd:	nand2.sv nand2_tb.sv
 		iverilog -g2012 -o nand2.vvp nand2.sv nand2_tb.sv
@@ -53,6 +57,12 @@ adder8.vcd:	adder8.sv adder8_tb.sv
 		xvlog -sv adder8.sv adder8_tb.sv
 		xelab --debug typical -L unisims_ver work.adder_test -s adder8_sim
 		xsim --R adder8_sim
+
+adder8_3in.sv:	nand2.sv
+
+adder8_3in.vcd:	adder8_3in.sv adder8_3in_tb.sv
+		iverilog -g2012 -o adder8_3in.vvp adder8_3in.sv adder8_3in_tb.sv
+		./adder8_3in.vvp
 
 pipelinedNAND.sv:	nand2.sv
 

--- a/cava-examples/_CoqProject
+++ b/cava-examples/_CoqProject
@@ -5,4 +5,5 @@ FullAdder.v
 FullAdderNat.v
 UnsignedAdder.v
 UnsignedAdderNat.v
+AdderTree.v
 ExamplesExtraction.v

--- a/cava-examples/adder8_3in_tb.sv
+++ b/cava-examples/adder8_3in_tb.sv
@@ -1,0 +1,47 @@
+//
+// Copyright 2020 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module adder8_3in_test;
+  
+  timeunit 1ns; timeprecision 1ns;
+
+  logic cin, cout;
+  logic [7:0] a, b, c;
+  logic [9:0] sum;
+  
+  adder8_3in adder8__3in_inst  (.*);
+ 
+  initial $monitor($time, " a = %0d, b = %0d, c = %0d, sum = %0d", a, b, c, sum);
+
+  initial begin
+    assign a   = 8'd4;
+    assign b   = 8'd5;
+    assign c   = 8'd11;
+    #10
+    assign a   = 8'd15;
+    assign b   = 8'd3;
+    assign c   = 8'd200;
+    #10
+    $finish;
+  end
+  
+  initial
+  begin
+    $dumpfile("adder8_3in.vcd");
+    $dumpvars;
+  end
+
+endmodule

--- a/cava-examples/verilator.vlt
+++ b/cava-examples/verilator.vlt
@@ -1,0 +1,4 @@
+`verilator_config
+lint_off -rule UNOPTFLAT
+lint_off -rule BLKANDNBLK
+lint_off -rule WIDTH


### PR DESCRIPTION
This example checks that a three input adder of variable lengths works. Added verilator lint waiver to permit automatic extension of vectors for addition, added a small testbench and checked via Xilinx Vivado synthesis that this can be implemented (it can). Addressing #35 