### PR TITLE
Use library Coq.NArith.Ndigits for nat to bitvector conversion.

### DIFF
--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -59,6 +59,7 @@ library
                      StateMonad
                      VectorDef
                      Vector
+                     ByteVector
   other-Modules:     Applicative
                      BinNat
                      BinPos
@@ -77,5 +78,10 @@ library
                      Monoid
                      Fin
                      Plus
+                     Ascii
+                     Basics
+                     Ndigits
+                     String
+                     Wf
 
   default-language:  Haskell2010

--- a/cava/cava/FixupAscii.hs
+++ b/cava/cava/FixupAscii.hs
@@ -1,4 +1,4 @@
-{- Copyright 2019 The Project Oak Authors
+{- Copyright 2020 The Project Oak Authors
   
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,14 +16,20 @@
 module Main
 where
 
-main :: IO ()
-main
-  = do content <- readFile "Ascii.hs"
-       let contentLines = lines content
-           updatedLines = take 2 contentLines ++
-                          extraImports ++
-                          drop 2 contentLines
-       writeFile "Ascii2.hs" (unlines updatedLines)
+fixup :: String -> String
+fixup content
+  = unlines updatedLines
     where
+    contentLines = lines content
+    updatedLines = take 2 contentLines ++
+                   extraImports ++
+                   drop 2 contentLines
     extraImports = ["import qualified Data.Bits",
                     "import qualified Data.Char"]
+
+main :: IO ()
+main
+  = do asciiContent <- readFile "Ascii.hs"
+       writeFile "Ascii2.hs" (fixup asciiContent)
+       bytevectorContent <- readFile "ByteVector.hs"
+       writeFile "ByteVector2.hs" (fixup bytevectorContent)

--- a/cava/cava/Makefile
+++ b/cava/cava/Makefile
@@ -27,6 +27,7 @@ FixupAscii:	FixupAscii.hs
 haskell:	coq FixupAscii
 		./FixupAscii
 		mv Ascii2.hs Ascii.hs
+		mv ByteVector2.hs ByteVector.hs
 		runhaskell Setup.hs configure --user
 		runhaskell Setup.hs build
 		runhaskell Setup.hs install

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -37,7 +37,7 @@ Require Import FullAdder.
 Lemma halfAdderNat_correct :
   forall (a : nat) (b : nat), a < 2 -> b < 2 ->
   let '(part_sum, carry_out) := combinational (halfAdder (nat2bool a) (nat2bool b)) in
-  bits_to_nat [part_sum; carry_out] = a + b.
+  list_bits_to_nat [part_sum; carry_out] = a + b.
 Proof.
   intro.
   case a, b.
@@ -49,7 +49,7 @@ Qed.
 Lemma fullAdderNat_correct :
   forall (a : nat) (b : nat) (cin : nat), a < 2 -> b < 2 -> cin < 2 ->
   let '(sum, carry_out) := combinational (fullAdder (nat2bool a) (nat2bool b) (nat2bool cin)) in
-  bits_to_nat [sum; carry_out] = a + b + cin.
+  list_bits_to_nat [sum; carry_out] = a + b + cin.
 Proof.
   intros.
   case a, b, cin.

--- a/cava/monad-examples/UnsignedAdderNat.v
+++ b/cava/monad-examples/UnsignedAdderNat.v
@@ -43,8 +43,8 @@ Local Open Scope monad_scope.
 
 
 Lemma addN_bheaviour : forall (ab : list (bool * bool)), 
-                       bits_to_nat (combinational (adder false ab)) =
-                       (bits_to_nat (map fst ab)) + (bits_to_nat (map snd ab)).
+                       list_bits_to_nat (combinational (adder false ab)) =
+                       (list_bits_to_nat (map fst ab)) + (list_bits_to_nat (map snd ab)).
 Proof.
   unfold combinational.
   unfold fst.


### PR DESCRIPTION
Use library Coq.NArith.Ndigits for nat to bitvector conversion.
Also add a contributed proof for the list version of bit-vector conversion functions.
Addresses #51 