### PR TITLE
Proofs about nat to bitvector conversion

### DIFF
--- a/cava/cava/Cava/Arrow/Instances/Coq.v
+++ b/cava/cava/Cava/Arrow/Instances/Coq.v
@@ -63,7 +63,7 @@ Section CoqEval.
       let a := bitvec_to_nat av in
       let b := bitvec_to_nat bv in
       let c := a + b in
-      nat_to_bitvec (max m n + 1) c;
+      nat_to_bitvec_sized (max m n + 1) c;
   }.
 
   Example not_true: not_gate true = false.

--- a/cava/cava/Cava/Arrow/Instances/Stream.v
+++ b/cava/cava/Cava/Arrow/Instances/Stream.v
@@ -69,7 +69,7 @@ Section CoqStreamEval.
       let a := bitvec_to_nat av in
       let b := bitvec_to_nat bv in
       let c := a + b in
-      nat_to_bitvec (max m n + 1) c
+      nat_to_bitvec_sized (max m n + 1) c
     );
   }.
 End CoqStreamEval.

--- a/cava/cava/Cava/BitArithmetic.v
+++ b/cava/cava/Cava/BitArithmetic.v
@@ -95,7 +95,9 @@ Example n2b_2_2 : nat_to_list_bits 2 = [false; true].
 Proof. reflexivity. Qed.
 
 Example n2b_2_3 : nat_to_list_bits 3 = [true; true].
-Proof. reflexivity. Qed.
+Proof. reflexivity. Qed.  
+
+
 
 (* The following proof is from Steve Zdancewic. *)
 Lemma bits_to_nat_app : forall u l, list_bits_to_nat' (u ++ l) = (list_bits_to_nat' u) * (shiftl 1 (length l)) + (list_bits_to_nat' l).
@@ -160,17 +162,20 @@ Proof. reflexivity. Qed.
 Definition bv3_2 : Bvector 3 := [false; true; false]%vector.
 Example bv3_2_ex : bitvec_to_nat bv3_2 = 2.
 Proof. reflexivity. Qed.
-        
-Definition nat_to_bitvec (n : nat) (v : nat) : Bvector n :=
+
+Definition nat_to_bitvec (v : nat) : Bvector (N.size_nat (N.of_nat v)) :=
+  N2Bv (N.of_nat v).
+       
+Definition nat_to_bitvec_sized (n : nat) (v : nat) : Bvector n :=
   N2Bv_sized n (N.of_nat v).
 
-Example bv3_0_exrev : nat_to_bitvec 3 0 = bv3_0.
+Example bv3_0_exrev : nat_to_bitvec_sized 3 0 = bv3_0.
 Proof. reflexivity. Qed.
 
-Example bv3_1_exrev : nat_to_bitvec 3 1 = bv3_1.
+Example bv3_1_exrev : nat_to_bitvec_sized 3 1 = bv3_1.
 Proof. reflexivity. Qed.
 
-Example bv3_2_exrev : nat_to_bitvec 3 2 = bv3_2.
+Example bv3_2_exrev : nat_to_bitvec_sized 3 2 = bv3_2.
 Proof. reflexivity. Qed.    
 
 (* Vector version of list seq *)
@@ -187,8 +192,42 @@ Fixpoint replicate_vec {A : Type} (n : nat) (v : A) : Vector.t A n :=
   | S n' => Vector.cons A v n' (replicate_vec n' v)
   end.
 
-Lemma bvnat: forall n v, bitvec_to_nat (nat_to_bitvec n v) = v.
-Admitted. (* For now. *)
+Lemma bits_of_nat_sized: forall n bv, nat_to_bitvec_sized n (bitvec_to_nat bv) = bv.
+Proof.
+  intros.
+  unfold nat_to_bitvec_sized.
+  unfold bitvec_to_nat.
+  rewrite N2Nat.id.
+  rewrite N2Bv_sized_Bv2N. 
+  reflexivity.
+Qed.
+
+Lemma nat_of_bits: forall v, bitvec_to_nat (nat_to_bitvec v) = v.
+Proof.
+  intros.
+  unfold nat_to_bitvec.
+  unfold bitvec_to_nat.
+  rewrite Bv2N_N2Bv. 
+  rewrite Nat2N.id.
+  reflexivity.
+Qed.
+
+Lemma nat_of_bits_sized: forall (v : nat),
+      bitvec_to_nat (nat_to_bitvec_sized (N.size_nat (N.of_nat v)) v) = v.
+Proof.
+  intros.
+  unfold nat_to_bitvec_sized.
+  unfold bitvec_to_nat.
+  rewrite N2Bv_sized_Nsize.
+  rewrite Bv2N_N2Bv.
+  rewrite Nat2N.id.
+  reflexivity.
+Qed.
+
+
+Lemma nat_of_bits_sized_n: forall n (v : nat),
+      bitvec_to_nat (nat_to_bitvec_sized n v) = v.
+Admitted.
 
 (******************************************************************************)
 (* Functions useful for examples and tests                                    *)

--- a/cava/cava/Cava/Monad/Cava.v
+++ b/cava/cava/Cava/Monad/Cava.v
@@ -298,11 +298,13 @@ Definition muxcyBool (s : bool) (di : bool) (ci : bool) : ident bool :=
        | true => ci
        end).
 
-Definition unsignedAddBool {m n : nat} (av : Bvector m) (bv : Bvector n) : ident (Bvector (max m n + 1)) :=
+Definition unsignedAddBool {m n : nat} (av : Bvector m) (bv : Bvector n) :
+           ident (Bvector (max m n + 1)) :=
   let a := bitvec_to_nat av in
   let b := bitvec_to_nat bv in
   let c := a + b in
-  ret (nat_to_bitvec (max m n + 1) c).
+  let cv := nat_to_bitvec_sized (max m n + 1) c in
+  ret cv.
 
 Definition bufBool (i : bool) : ident bool :=
   ret i.

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -71,7 +71,8 @@ Lemma add3_behaviour : forall aL bL cL (av : Bvector aL) (bv : Bvector bL) (cv :
                        let c := bitvec_to_nat cv in
                        bitvec_to_nat (combinational (adder_3in av bv cv)) = a + b + c.
 Proof.
-  intros. unfold combinational. unfold adder_3in. simpl. rewrite bvnat. rewrite bvnat.
+  intros. unfold combinational. unfold adder_3in. simpl.
+  rewrite nat_of_bits_sized_n. rewrite nat_of_bits_sized_n.
   reflexivity.
 Qed.
 
@@ -101,10 +102,10 @@ Definition adder_fixed_top : state CavaState (Vector.t N 9) :=
 
 Definition adder_fixedNetlist := makeNetlist adder_fixed_top.
 
-Definition v0 := nat_to_bitvec 8  4.
-Definition v1 := nat_to_bitvec 8 17.
-Definition v2 := nat_to_bitvec 8  6.
-Definition v3 := nat_to_bitvec 8  3.
+Definition v0 := nat_to_bitvec_sized 8  4.
+Definition v1 := nat_to_bitvec_sized 8 17.
+Definition v2 := nat_to_bitvec_sized 8  6.
+Definition v3 := nat_to_bitvec_sized 8  3.
 
 Example check_fixed: bitvec_to_nat (combinational (adderFixed v0 v1)) = 21.
 Proof. reflexivity. Qed.

--- a/cava/monad-examples/Examples.v
+++ b/cava/monad-examples/Examples.v
@@ -54,16 +54,16 @@ Proof. reflexivity. Qed.
 
 (* Unsigned addition examples. *)
 
-Definition bv4_0  := nat_to_bitvec 4  0.
-Definition bv4_1  := nat_to_bitvec 4  1.
-Definition bv4_2  := nat_to_bitvec 4  2.
-Definition bv4_3  := nat_to_bitvec 4  3.
-Definition bv4_15 := nat_to_bitvec 4 15.
+Definition bv4_0  := nat_to_bitvec_sized 4  0.
+Definition bv4_1  := nat_to_bitvec_sized 4  1.
+Definition bv4_2  := nat_to_bitvec_sized 4  2.
+Definition bv4_3  := nat_to_bitvec_sized 4  3.
+Definition bv4_15 := nat_to_bitvec_sized 4 15.
 
-Definition bv5_0  := nat_to_bitvec 5  0.
-Definition bv5_3  := nat_to_bitvec 5  3.
-Definition bv5_16 := nat_to_bitvec 5 16.
-Definition bv5_30 := nat_to_bitvec 5 30.
+Definition bv5_0  := nat_to_bitvec_sized 5  0.
+Definition bv5_3  := nat_to_bitvec_sized 5  3.
+Definition bv5_16 := nat_to_bitvec_sized 5 16.
+Definition bv5_30 := nat_to_bitvec_sized 5 30.
 
 (* Check 0 + 0 = 0 *)
 Example add_0_0 : combinational (unsignedAdd bv4_0 bv4_0) = bv5_0.


### PR DESCRIPTION
Addresses #53 
Proofs for:
```coq
Lemma bits_of_nat_sized: forall n bv, nat_to_bitvec_sized n (bitvec_to_nat bv) = bv.
Lemma nat_of_bits: forall v, bitvec_to_nat (nat_to_bitvec v) = v.
Lemma nat_of_bits_sized: forall (v : nat),
      bitvec_to_nat (nat_to_bitvec_sized (N.size_nat (N.of_nat v)) v) = v.
```

Still to think about:
```coq
Lemma nat_of_bits_sized_n: forall n (v : nat),
      bitvec_to_nat (nat_to_bitvec_sized n v) = v.
Admitted.
```