### PR TITLE
Add Arrow notation

### DIFF
--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -4,7 +4,7 @@ From Coq Require Import Bool.Bool.
 From Cava Require Import Netlist.
 
 Reserved Infix "~>" (at level 90, right associativity).
-Reserved Infix "**" (at level 40, left associativity).
+Reserved Infix "**" (at level 30, right associativity).
 Reserved Infix ">>>" (at level 90, right associativity).
 
 (* more flexible than a haskell style category,
@@ -66,7 +66,7 @@ Bind Scope arrow_scope with Arrow.
 Delimit Scope arrow_scope with Arrow.
 
 Notation "x ** y" := (product x y)
-  (at level 40, left associativity) : arrow_scope.
+  (at level 30, right associativity) : arrow_scope.
 
 Open Scope arrow_scope.
 

--- a/cava/cava/_CoqProject
+++ b/cava/cava/_CoqProject
@@ -11,5 +11,6 @@ Cava/Arrow/Arrow.v
 Cava/Arrow/Instances/Coq.v
 Cava/Arrow/Instances/Stream.v
 Cava/Arrow/Instances/Netlist.v
+Cava/Arrow/Syntax.v
 
 Cava/Extraction.v


### PR DESCRIPTION
This adds arrow notation. It is still missing a key part of the compilation to generalized arrows which I am continuing to work on.

Some of the syntax will simplify further when the compilation pass is done. Items here built as `kappa` types are left as `kappa` types and require separate notation, but they directly reduce to an arrow in future and not require separate notation.