### PR TITLE
Enable Arrows with the updated Netlist

### DIFF
--- a/cava/Makefile
+++ b/cava/Makefile
@@ -18,9 +18,9 @@
 
 all:
 	cd cava && $(MAKE) clean all && \
-	cd ../monad-examples && $(MAKE) clean all 
-#	cd ../arrow-examples && $(MAKE) clean all && \
-#	cd ..
+	cd ../monad-examples && $(MAKE) clean all && \
+	cd ../arrow-examples && $(MAKE) clean all && \
+	cd ..
 
 clean:
 	cd cava && $(MAKE) clean && \

--- a/cava/arrow-examples/ArrowExamples.v
+++ b/cava/arrow-examples/ArrowExamples.v
@@ -155,10 +155,10 @@ Section NetlistExamples.
     "xorArrow"
     (@xor NetlistCava)
     (fun '(l,r) =>
-      [ mkPort "input1" Bit l
-      ; mkPort "input2" Bit r
+      [ mkPort "input1" (One Bit) l
+      ; mkPort "input2" (One Bit) r
       ])
-    (fun o => [mkPort "output1" Bit o]).
+    (fun o => [mkPort "output1" (One Bit) o]).
   (* Compute the circuit netlist for the XOR made up of NANDs made up of ANDs and INVs *)
   Eval compute in xorArrowNetlist.
   (* For extraction *)
@@ -169,8 +169,8 @@ Section NetlistExamples.
   Definition loopedNandArrowNetlist := arrowToHDLModule
     "loopedNandArrow"
     (@loopedNand NetlistCavaDelay NetlistLoop)
-    (fun i => [ mkPort "input1" Bit i])
-    (fun o => [mkPort "output1" Bit o]).
+    (fun i => [ mkPort "input1" (One Bit) i])
+    (fun o => [mkPort "output1" (One Bit) o]).
   Eval compute in loopedNandArrowNetlist.
   Definition loopedNandArrow :=
     let '(nl, count) := loopedNandArrowNetlist

--- a/cava/cava/Cava/Arrow/Instances/Coq.v
+++ b/cava/cava/Cava/Arrow/Instances/Coq.v
@@ -11,7 +11,10 @@ From Coq Require Import ZArith.
 Require Import Cava.BitArithmetic.
 Require Import Cava.Arrow.Arrow.
 
-(* Arrow as function evaluation, no delay elements or loops *)
+(******************************************************************************)
+(* Evaluation as function evaluation, no delay elements or loops              *)
+(******************************************************************************)
+
 Section CoqEval.
   Instance CoqCat : Category := {
     object := Type;

--- a/cava/cava/Cava/Extraction.v
+++ b/cava/cava/Cava/Extraction.v
@@ -31,9 +31,9 @@ Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Cava.
 Recursive Extraction Library Combinators.
 
-(* Require Import Cava.Arrow.Arrow. *)
-(* Require Import Cava.Arrow.Instances.Netlist. *)
-(* Recursive Extraction Library Arrow. *)
+Require Import Cava.Arrow.Arrow.
+Require Import Cava.Arrow.Instances.Netlist.
+Recursive Extraction Library Arrow.
 
 Recursive Extraction Library Netlist.
 Recursive Extraction Library UnsignedAdders.

--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -40,7 +40,7 @@ cabal-version:        >= 1.10
 library
   build-Depends:     base >= 4, mtl >= 2
   exposed-Modules:   Cava2SystemVerilog
-                     -- Arrow
+                     Arrow
                      BinNums
                      BitArithmetic
                      Bvector
@@ -52,7 +52,7 @@ library
                      Logic
                      Monad
                      Netlist
-                     -- Netlist0
+                     Netlist0
                      Nat
                      PeanoNat
                      StateMonad

--- a/cava/cava/_CoqProject
+++ b/cava/cava/_CoqProject
@@ -6,10 +6,10 @@ Cava/Monad/Cava.v
 Cava/Monad/Combinators.v
 Cava/Monad/UnsignedAdders.v
 
-# Cava/Arrow.v
-# Cava/Arrow/Arrow.v
-# Cava/Arrow/Instances/Coq.v
-# Cava/Arrow/Instances/Stream.v
-# Cava/Arrow/Instances/Netlist.v
+Cava/Arrow.v
+Cava/Arrow/Arrow.v
+Cava/Arrow/Instances/Coq.v
+Cava/Arrow/Instances/Stream.v
+Cava/Arrow/Instances/Netlist.v
 
 Cava/Extraction.v


### PR DESCRIPTION
The Netlist Arrow instance is currently restricted to one dimensional bitvectors, and use some intermediate types that will be removed in the future.