### PR TITLE
Switch from nat to N for values convertible to bit-vectors

### DIFF
--- a/cava/cava/Cava/BitArithmetic.v
+++ b/cava/cava/Cava/BitArithmetic.v
@@ -60,31 +60,31 @@ Fixpoint list_bits_to_nat' (bits : list bool) : nat :=
 Definition nat_to_list_bits' (n : nat) : list bool :=
   fold_shift_nat [] (fun x b l => l++[b]) n.
 
-Definition nat_to_list_bits (n : nat) : list bool :=
-  to_list (N2Bv (N.of_nat n)).
+Definition nat_to_list_bits (n : N) : list bool :=
+  to_list (N2Bv n).
 
-Definition nat_to_list_bits_sized (size : nat) (n : nat) : list bool :=
-  to_list (N2Bv_sized size (N.of_nat n)).
+Definition nat_to_list_bits_sized (size : nat) (n : N) : list bool :=
+  to_list (N2Bv_sized size n).
 
-Definition list_bits_to_nat (bv : list bool) : nat :=
-  N.to_nat (Bv2N (of_list bv)).
+Definition list_bits_to_nat (bv : list bool) : N :=
+  Bv2N (of_list bv).
 
-Example b2n_empty : list_bits_to_nat [] = 0.
+Example b2n_empty : list_bits_to_nat [] = 0%N.
 Proof. reflexivity. Qed.
 
-Example b2n_0 : list_bits_to_nat [false] = 0.
+Example b2n_0 : list_bits_to_nat [false] = 0%N.
 Proof. reflexivity. Qed.
 
-Example b2n_1 : list_bits_to_nat [true] = 1.
+Example b2n_1 : list_bits_to_nat [true] = 1%N.
 Proof. reflexivity. Qed.
 
-Example b2n_10 : list_bits_to_nat [false; true] = 2.
+Example b2n_10 : list_bits_to_nat [false; true] = 2%N.
 Proof. reflexivity. Qed.
 
-Example b2n_01 : list_bits_to_nat [true; false] = 1.
+Example b2n_01 : list_bits_to_nat [true; false] = 1%N.
 Proof. reflexivity. Qed.
 
-Example b2n_11 : list_bits_to_nat [true; true] = 3.
+Example b2n_11 : list_bits_to_nat [true; true] = 3%N.
 Proof. reflexivity. Qed.
 
 Example n2b_0_1 : nat_to_list_bits 0 = [].
@@ -99,8 +99,7 @@ Proof. reflexivity. Qed.
 Example n2b_2_3 : nat_to_list_bits 3 = [true; true].
 Proof. reflexivity. Qed.  
 
-
-Lemma nat_of_list_bits_sized: forall (size v : nat),
+Lemma nat_of_list_bits_sized: forall (size :  nat) (v : N),
       list_bits_to_nat (nat_to_list_bits_sized size v) = v.
 Admitted.
 
@@ -241,6 +240,12 @@ Definition nat2bool (n : nat) : bool :=
   match n with
   | 0 => false
   | _ => true
+  end.
+
+Definition n2bool (n : N) : bool :=
+  match n with
+  | 0%N => false
+  | _   => true
   end.
 
 Definition fromVec := List.map Nat.b2n.

--- a/cava/cava/Cava/Monad/Cava.v
+++ b/cava/cava/Cava/Monad/Cava.v
@@ -299,17 +299,17 @@ Definition muxcyBool (s : bool) (di : bool) (ci : bool) : ident bool :=
        | true => ci
        end).
 
-(* Unsigned addition is defined to be the addition of the two unsigned
-   input vectors followed by a modulus determinted by the size of the
-   result vector.
-*)
+Local Open Scope N_scope.
+
 Definition unsignedAddBool (sumSize : nat)
                            (a : list bool) (b : list bool) :
                            ident (list bool) :=
   let a := list_bits_to_nat a in
-  let b := list_bits_to_nat b in
-  let sum := (a + b) mod 2^sumSize in
+  let b : N := list_bits_to_nat b in
+  let sum := (a + b) mod 2^(N.of_nat sumSize) in
   ret (nat_to_list_bits_sized sumSize sum).
+
+Local Open Scope N_scope.
 
 Definition bufBool (i : bool) : ident bool :=
   ret i.

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -14,6 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+From Coq Require Import ZArith.
+From Coq Require Import ZArith.BinInt.
+From Coq Require Import PArith.BinPos.
+From Coq Require Import Numbers.NatInt.NZPow.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 Open Scope monad_scope.
@@ -27,7 +31,6 @@ Require Import Nat Arith Lia.
 
 From Coq Require Import Lists.List.
 Import ListNotations.
-Local Open Scope list_scope.
 
 (******************************************************************************)
 (* A three input adder.                                                       *)
@@ -40,11 +43,13 @@ Definition adder_3input {m bit} `{Cava m bit} (sumSize : nat)
   sum <- unsignedAdd sumSize a_plus_b c ;;
   ret sum.
 
+Open Scope N_scope.
+
 Lemma mod_plus_mod: forall a b c n, n > 0 ->
                     ((a + b) mod n + c) mod n = (a + b + c) mod n.
 Proof.
   intros.
-  rewrite Nat.add_mod_idemp_l.
+  rewrite N.add_mod_idemp_l.
   - reflexivity.
   - lia.
 Qed.
@@ -53,11 +58,9 @@ Lemma two_p_gt_0: forall n, 2^n > 0.
 Proof.
   intros.
   induction n.
-  - simpl. lia.
-  - rewrite Nat.pow_succ_r.
-    + lia.
-    + lia.
-Qed.
+  - reflexivity.
+(* Ugh, what is the N equivalent of Nat.pow_succ_r ? *)
+Admitted.
 
 Lemma add3_behaviour : forall (sumSize : nat)
                        (av : list bool)
@@ -67,7 +70,7 @@ Lemma add3_behaviour : forall (sumSize : nat)
                        let b := list_bits_to_nat bv in
                        let c := list_bits_to_nat cv in
                        list_bits_to_nat (combinational (adder_3input sumSize av bv cv))
-                         = (a + b + c) mod 2^sumSize.
+                         = (a + b + c) mod 2^(N.of_nat sumSize).
 Proof.
   intros. unfold combinational. unfold adder_3input. simpl.
   do 2 rewrite nat_of_list_bits_sized.

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -42,9 +42,13 @@ Definition v1 := nat_to_list_bits_sized 8 17.
 Definition v2 := nat_to_list_bits_sized 8  6.
 Definition v3 := nat_to_list_bits_sized 8  3.
 
+Local Open Scope nat_scope.
+
 Definition halve {A} (l : list A) : list A * list A :=
   let mid := (length l) / 2 in
   (firstn mid l, skipn mid l).
+
+Local Close Scope nat_scope.
 
 Fixpoint adderTree {m bit} `{Cava m bit} (n s : nat) (v: list (list bit)) : m (list bit) :=
   match n with

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -18,6 +18,8 @@
    separate because they are not used for extraction to SystemVerilog.
 *)
 
+From Coq Require Import ZArith.
+From Coq Require Import ZArith.BinInt.
 From Coq Require Import Bool.Bool. 
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
@@ -35,10 +37,11 @@ Require Import Cava.Monad.Cava.
 Require Import Cava.BitArithmetic.
 Require Import FullAdder.
 
+Open Scope N_scope.
 
 Lemma halfAdderNat_correct :
-  forall (a : nat) (b : nat), a < 2 -> b < 2 ->
-  let '(part_sum, carry_out) := combinational (halfAdder (nat2bool a) (nat2bool b)) in
+  forall (a : N) (b : N), a < 2 -> b < 2 ->
+  let '(part_sum, carry_out) := combinational (halfAdder (n2bool a) (n2bool b)) in
   list_bits_to_nat [part_sum; carry_out] = a + b.
 Proof.
   intros.
@@ -49,8 +52,8 @@ Admitted.
 
   
 Lemma fullAdderNat_correct :
-  forall (a : nat) (b : nat) (cin : nat), a < 2 -> b < 2 -> cin < 2 ->
-  let '(sum, carry_out) := combinational (fullAdder (nat2bool a) (nat2bool b) (nat2bool cin)) in
+  forall (a : N) (b : N) (cin : N), a < 2 -> b < 2 -> cin < 2 ->
+  let '(sum, carry_out) := combinational (fullAdder (n2bool a) (n2bool b) (n2bool cin)) in
   list_bits_to_nat [sum; carry_out] = a + b + cin.
 Proof.
   intros.


### PR DESCRIPTION
As we process lager numbers it is going to be much more efficient to represent them in a binary way using `N` rather than `nat`. I can't immediately work out how to re-do one of the proofs with `N` instead of `nat` for the rule `Nat.pow_succ_r` so admitting for now.