### PR TITLE
Make adder semantics assume bit-growth implicitly

### DIFF
--- a/cava/cava/Cava/Monad/Cava.v
+++ b/cava/cava/Cava/Monad/Cava.v
@@ -66,7 +66,7 @@ Class Cava m bit `{Monad m} := {
   xorcy : bit * bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
   muxcy : bit -> bit -> bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
   (* Synthesizable arithmetic operations. *)
-  unsignedAdd : nat -> list bit -> list bit -> m (list bit);
+  unsignedAdd : list bit -> list bit -> m (list bit);
 }.
 
 (******************************************************************************)
@@ -161,9 +161,9 @@ Definition muxcyNet (s : N)  (di : N) (ci : N) : state CavaState N :=
          ret o
   end.
 
-Definition unsignedAddNet (sumSize : nat)
-                          (a : list N) (b : list N) :
+Definition unsignedAddNet (a : list N) (b : list N) :
                           state CavaState (list N) :=
+  let sumSize := max (length a) (length b) + 1 in
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
@@ -299,17 +299,13 @@ Definition muxcyBool (s : bool) (di : bool) (ci : bool) : ident bool :=
        | true => ci
        end).
 
-Local Open Scope N_scope.
-
-Definition unsignedAddBool (sumSize : nat)
-                           (a : list bool) (b : list bool) :
+Definition unsignedAddBool (av : list bool) (bv : list bool) :
                            ident (list bool) :=
-  let a := list_bits_to_nat a in
-  let b : N := list_bits_to_nat b in
-  let sum := (a + b) mod 2^(N.of_nat sumSize) in
+  let a := list_bits_to_nat av in
+  let b := list_bits_to_nat bv in
+  let sumSize := max (length av) (length bv) + 1 in
+  let sum := (a + b)%N in
   ret (nat_to_list_bits_sized sumSize sum).
-
-Local Open Scope N_scope.
 
 Definition bufBool (i : bool) : ident bool :=
   ret i.
@@ -389,8 +385,7 @@ Definition muxcyBoolList (s : list bool) (di : list bool) (ci : list bool) : ide
    we model sequential circuits.
    TODO(satnam): Replace with actual definition when sequential circuit semantics are clearer.
 *)
-Definition unsignedAddBoolList (sumSize : nat)
-                               (a : list (list bool)) (b : list (list bool)) :
+Definition unsignedAddBoolList (a : list (list bool)) (b : list (list bool)) :
                                ident (list (list bool)) :=
   ret ([]).
 

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -36,31 +36,18 @@ Import ListNotations.
 (* A three input adder.                                                       *)
 (******************************************************************************)
 
-Definition adder_3input {m bit} `{Cava m bit} (sumSize : nat)
+Definition adder_3input {m bit} `{Cava m bit}
                         (a : list bit) (b : list bit) (c : list bit)
                         : m (list bit) :=
-  a_plus_b <- unsignedAdd sumSize a b ;;
-  sum <- unsignedAdd sumSize a_plus_b c ;;
+  a_plus_b <- unsignedAdd a b ;;
+  sum <- unsignedAdd a_plus_b c ;;
   ret sum.
 
 Open Scope N_scope.
 
-Lemma mod_plus_mod: forall a b c n, n > 0 ->
-                    ((a + b) mod n + c) mod n = (a + b + c) mod n.
-Proof.
-  intros.
-  rewrite N.add_mod_idemp_l.
-  - reflexivity.
-  - lia.
-Qed.
-
-Lemma two_p_gt_0: forall n, 2^n > 0.
-Proof.
-  intros.
-  induction n.
-  - reflexivity.
-(* Ugh, what is the N equivalent of Nat.pow_succ_r ? *)
-Admitted.
+(******************************************************************************)
+(* A proof that the three-input adder does indeed add three numbers correctly *)
+(******************************************************************************)
 
 Lemma add3_behaviour : forall (sumSize : nat)
                        (av : list bool)
@@ -69,14 +56,12 @@ Lemma add3_behaviour : forall (sumSize : nat)
                        let a := list_bits_to_nat av in
                        let b := list_bits_to_nat bv in
                        let c := list_bits_to_nat cv in
-                       list_bits_to_nat (combinational (adder_3input sumSize av bv cv))
-                         = (a + b + c) mod 2^(N.of_nat sumSize).
+                       list_bits_to_nat (combinational (adder_3input av bv cv))
+                         = a + b + c.
 Proof.
   intros. unfold combinational. unfold adder_3input. simpl.
   do 2 rewrite nat_of_list_bits_sized.
   fold a b c.
-  rewrite mod_plus_mod.
-  - reflexivity.
-  - apply two_p_gt_0.
+  reflexivity.
 Qed.
 

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -50,33 +50,33 @@ Definition halve {A} (l : list A) : list A * list A :=
 
 Local Close Scope nat_scope.
 
-Fixpoint adderTree {m bit} `{Cava m bit} (n s : nat) (v: list (list bit)) : m (list bit) :=
+Fixpoint adderTree {m bit} `{Cava m bit} (n : nat) (v: list (list bit)) : m (list bit) :=
   match n with
   | O => match v with
-         | [a; b] => unsignedAdd s a b
+         | [a; b] => unsignedAdd a b
          | _ => ret [] (* Error case *)
          end
   | S n' => let '(vL, vH) := halve v in
-            aS <- adderTree n' s vL ;;
-            bS <- adderTree n' s vH ;;
-            sum <- unsignedAdd s aS bS ;;
+            aS <- adderTree n' vL ;;
+            bS <- adderTree n' vH ;;
+            sum <- unsignedAdd aS bS ;;
             ret sum
   end.
  
-(* An adder tree with 2 inputs each of 8 bits in size. *)
+(* An adder tree with 2 inputs. *)
 
 Definition adderTree2_8 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
-  := adderTree 0 8 v.
+  := adderTree 0 v.
 
 Definition v0_v1 := [v0; v1].
 Definition v0_plus_v1 : list bool := combinational (adderTree2_8 v0_v1).
 Example sum_vo_v1 : list_bits_to_nat v0_plus_v1 = 21.
 Proof. reflexivity. Qed.
 
-(* An adder tree with 4 inputs each of 8 bits in size. *)
+(* An adder tree with 4 inputs. *)
 
 Definition adderTree4_8 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
-  := adderTree 1 8 v.
+  := adderTree 1 v.
 
 Definition v0_v1_v2_v3 := [v0; v1; v2; v3].
 Definition adderTree4_8_v0_v1_v2_v3 : list bool := combinational (adderTree4_8 v0_v1_v2_v3).
@@ -90,7 +90,7 @@ Definition adder_tree4_8_top : state CavaState (list N) :=
   c <- inputVectorTo0 8 "c" ;;
   d <- inputVectorTo0 8 "d" ;;
   sum <- adderTree4_8 [a; b; c; d] ;;
-  outputVectorTo0 8 sum "sum".
+  outputVectorTo0 (length sum) sum "sum".
 
 Definition adder_tree4_8Netlist := makeNetlist adder_tree4_8_top.
 

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -47,47 +47,20 @@ Definition bv5_16 := nat_to_list_bits_sized 5 16.
 Definition bv5_30 := nat_to_list_bits_sized 5 30.
 
 (* Check 0 + 0 = 0 *)
-Example add5_0_0 : combinational (unsignedAdd 5 bv4_0 bv4_0) = bv5_0.
+Example add5_0_0 : combinational (unsignedAdd bv4_0 bv4_0) = bv5_0.
 Proof. reflexivity. Qed.
 
 (* Check 1 + 2 = 3 *)
-Example add5_1_2 : combinational (unsignedAdd 5 bv4_1 bv4_2) = bv5_3.
+Example add5_1_2 : combinational (unsignedAdd bv4_1 bv4_2) = bv5_3.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 16 *)
-Example add5_15_1 : combinational (unsignedAdd 5 bv4_15 bv4_1) = bv5_16.
-Proof. reflexivity. Qed.
-
-(* Check 15 + 1 = 16 for 4-bit result *)
-Example add4_15_1 : combinational (unsignedAdd 4 bv4_15 bv4_1)
-                  = nat_to_list_bits_sized 4 0.
+Example add5_15_1 : combinational (unsignedAdd bv4_15 bv4_1) = bv5_16.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 15 = 30 *)
-Example add5_15_15 : combinational (unsignedAdd 5 bv4_15 bv4_15) = bv5_30.
+Example add5_15_15 : combinational (unsignedAdd bv4_15 bv4_15) = bv5_30.
 Proof. reflexivity. Qed.
-
-(* Check 15 + 15 = 14 for 4-bit result *)
-Example add4_15_15 : combinational (unsignedAdd 4 bv4_15 bv4_15)
-                   = nat_to_list_bits_sized 4 14.
-Proof. reflexivity. Qed.
-
-(* Check 15 + 15 = 6 for 3-bit result *)
-Example add3_15_15 : combinational (unsignedAdd 3 bv4_15 bv4_15)
-                   = nat_to_list_bits_sized 3 6.
-Proof. reflexivity. Qed.
-
-(* Check 15 + 15 = 2 for 2-bit result *)
-Example add2_15_15 : combinational (unsignedAdd 2 bv4_15 bv4_15)
-                   = nat_to_list_bits_sized 2 2.
-Proof. reflexivity. Qed.
-
-(* Check 15 + 15 = 0 for 1-bit result *)
-Example add1_15_15 : combinational (unsignedAdd 1 bv4_15 bv4_15)
-                   = nat_to_list_bits_sized 1 0.
-Proof. reflexivity. Qed.
-
-(* An adder example. *)
 
 (******************************************************************************)
 (* Generate a 4-bit unsigned adder with 5-bit output.                         *)
@@ -97,7 +70,7 @@ Definition adder4Top : state CavaState (list N) :=
   setModuleName "adder4" ;;
   a <- inputVectorTo0 4 "a" ;;
   b <- inputVectorTo0 4 "b" ;;
-  sum <- unsignedAdd 5 a b ;;
+  sum <- unsignedAdd a b ;;
   outputVectorTo0 5 sum "sum".
 
 Definition adder4Netlist := makeNetlist adder4Top.
@@ -111,7 +84,7 @@ Definition adder8_3inputTop : state CavaState (list N) :=
   a <- inputVectorTo0 8 "a" ;;
   b <- inputVectorTo0 8 "b" ;;
   c <- inputVectorTo0 8 "c" ;;
-  sum <- adder_3input 10 a b c ;;
+  sum <- adder_3input a b c ;;
   outputVectorTo0 10 sum "sum".
 
 Definition adder8_3inputNetlist := makeNetlist adder8_3inputTop.

--- a/cava/monad-examples/testbench/adder_tree4_8_tb.sv
+++ b/cava/monad-examples/testbench/adder_tree4_8_tb.sv
@@ -30,7 +30,7 @@ module adder_tree4_8_tb(
          '{ 8'd15, 8'd3, 8'd200, 8'd7 }
        };
 
-  logic[7:0] expected_output[2] = '{ 8'd29, 8'd225 };     
+  logic[9:0] expected_output[2] = '{ 8'd29, 8'd225 };     
 
   int unsigned i = 0;
 


### PR DESCRIPTION
This simplifies semantic and proofs, and I think we should explicitly separate out the process of `mod`-ing values to shave off bits.