### PR TITLE
Add circuit interface mechansim

### DIFF
--- a/cava/arrow-examples/ArrowExamples.v
+++ b/cava/arrow-examples/ArrowExamples.v
@@ -155,10 +155,10 @@ Section NetlistExamples.
     "xorArrow"
     (@xor NetlistCava)
     (fun '(l,r) =>
-      [ mkPort "input1" (One Bit) l
-      ; mkPort "input2" (One Bit) r
+      [ mkPort "input1" (One Bit)
+      ; mkPort "input2" (One Bit)
       ])
-    (fun o => [mkPort "output1" (One Bit) o]).
+    (fun o => [mkPort "output1" (One Bit)]).
   (* Compute the circuit netlist for the XOR made up of NANDs made up of ANDs and INVs *)
   Eval compute in xorArrowNetlist.
   (* For extraction *)
@@ -169,8 +169,8 @@ Section NetlistExamples.
   Definition loopedNandArrowNetlist := arrowToHDLModule
     "loopedNandArrow"
     (@loopedNand NetlistCavaDelay NetlistLoop)
-    (fun i => [ mkPort "input1" (One Bit) i])
-    (fun o => [mkPort "output1" (One Bit) o]).
+    (fun i => [ mkPort "input1" (One Bit)])
+    (fun o => [mkPort "output1" (One Bit)]).
   Eval compute in loopedNandArrowNetlist.
   Definition loopedNandArrow :=
     let '(nl, count) := loopedNandArrowNetlist

--- a/cava/cava/Cava/Arrow/Instances/Netlist.v
+++ b/cava/cava/Cava/Arrow/Instances/Netlist.v
@@ -243,6 +243,6 @@ Section NetlistEval.
   Eval cbv in arrowToHDLModule
     "not"
     not_gate
-    (fun i => [mkPort "input1" (One Bit) i])
-    (fun o => [mkPort "output1" (One Bit) o]).
+    (fun i => [mkPort "input1" (One Bit)])
+    (fun o => [mkPort "output1" (One Bit)]).
 End NetlistEval.

--- a/cava/cava/Cava/Monad/Combinators.v
+++ b/cava/cava/Cava/Monad/Combinators.v
@@ -121,16 +121,21 @@ Fixpoint below `{Monad m} {A B C D E F G}
 
 *)
 
-Fixpoint col `{Monad m} {A B C}
-             (circuit : A * B -> m (C * A)%type) (a : A) (b : list B) :
-             m (list C * A)%type :=
+Fixpoint col' `{Monad m} {A B C}
+              (circuit : A * B -> m (C * A)%type) (a : A) (b : list B) :
+              m (list C * A)%type :=
   match b with
   | [] => ret ([], a)
-  | b0::br => c_cs_e <- below circuit (fun ab => col circuit (fst ab) (snd ab)) (a, (b0, br)) ;;
+  | b0::br => c_cs_e <- below circuit (fun ab => col' circuit (fst ab) (snd ab)) (a, (b0, br)) ;;
               let (c_cs, e) := c_cs_e : (C * list C) * A in
               let (c, cs) := c_cs : C * list C in
               ret (c::cs, e)
   end.
+
+Definition col `{Monad m} {A B C}
+                (circuit : A * B -> m (C * A)%type) (ab : A * list B) :
+                m (list C * A)%type :=
+  col' circuit (fst ab) (snd ab).
 
 Definition fork2 `{Mondad_m : Monad m} {A} (a:A) := ret (a, a).
 

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -43,6 +43,7 @@ Definition v2 := nat_to_list_bits_sized 8  6.
 Definition v3 := nat_to_list_bits_sized 8  3.
 
 Local Open Scope nat_scope.
+Local Open Scope string_scope.
 
 Definition halve {A} (l : list A) : list A * list A :=
   let mid := (length l) / 2 in
@@ -65,33 +66,36 @@ Fixpoint adderTree {m bit} `{Cava m bit} (n : nat) (v: list (list bit)) : m (lis
  
 (* An adder tree with 2 inputs. *)
 
-Definition adderTree2_8 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
+Definition adderTree2 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
   := adderTree 0 v.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : list bool := combinational (adderTree2_8 v0_v1).
+Definition v0_plus_v1 : list bool := combinational (adderTree2 v0_v1).
 Example sum_vo_v1 : list_bits_to_nat v0_plus_v1 = 21.
 Proof. reflexivity. Qed.
 
 (* An adder tree with 4 inputs. *)
 
-Definition adderTree4_8 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
+Definition adderTree4 {m bit} `{Cava m bit} (v : list (list bit)) : m (list bit)
   := adderTree 1 v.
 
 Definition v0_v1_v2_v3 := [v0; v1; v2; v3].
-Definition adderTree4_8_v0_v1_v2_v3 : list bool := combinational (adderTree4_8 v0_v1_v2_v3).
-Example sum_v0_v1_v2_v3 : list_bits_to_nat (combinational (adderTree4_8 v0_v1_v2_v3)) = 30.
+Definition adderTree4_v0_v1_v2_v3 : list bool := combinational (adderTree4 v0_v1_v2_v3).
+Example sum_v0_v1_v2_v3 : list_bits_to_nat (combinational (adderTree4 v0_v1_v2_v3)) = 30.
 Proof. reflexivity. Qed.
 
-Definition adder_tree4_8_top : state CavaState (list N) :=
-  setModuleName "adder_tree4_8" ;;
-  a <- inputVectorTo0 8 "a" ;;
-  b <- inputVectorTo0 8 "b" ;;
-  c <- inputVectorTo0 8 "c" ;;
-  d <- inputVectorTo0 8 "d" ;;
-  sum <- adderTree4_8 [a; b; c; d] ;;
-  outputVectorTo0 (length sum) sum "sum".
+Local Open Scope nat_scope.
 
-Definition adder_tree4_8Netlist := makeNetlist adder_tree4_8_top.
+Definition adder_tree4_8Interface
+  := mkCircuitInterface "adder_tree4_8"
+     (Tuple2 (Tuple2 (One ("a", BitVec [8])) (One ("b", BitVec [8])))
+             (Tuple2 (One ("c", BitVec [8])) (One ("d", BitVec [8]))))
+     (One ("sum", BitVec [11]))
+     [].
+
+Definition adder_tree4_8Netlist
+  := makeNetlist adder_tree4_8Interface
+    (fun '(a, b, (c, d)) => adderTree4 [a; b; c; d]).
+
 
 

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -41,7 +41,7 @@ Open Scope N_scope.
 
 Lemma halfAdderNat_correct :
   forall (a : N) (b : N), a < 2 -> b < 2 ->
-  let '(part_sum, carry_out) := combinational (halfAdder (n2bool a) (n2bool b)) in
+  let '(part_sum, carry_out) := combinational (halfAdder (n2bool a, n2bool b)) in
   list_bits_to_nat [part_sum; carry_out] = a + b.
 Proof.
   intros.
@@ -53,7 +53,7 @@ Admitted.
   
 Lemma fullAdderNat_correct :
   forall (a : N) (b : N) (cin : N), a < 2 -> b < 2 -> cin < 2 ->
-  let '(sum, carry_out) := combinational (fullAdder (n2bool a) (n2bool b) (n2bool cin)) in
+  let '(sum, carry_out) := combinational (fullAdder (n2bool a, n2bool b, n2bool cin)) in
   list_bits_to_nat [sum; carry_out] = a + b + cin.
 Proof.
   intros.

--- a/cava/monad-examples/NandGate.v
+++ b/cava/monad-examples/NandGate.v
@@ -14,11 +14,6 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-(* A codification of the Lava embedded DSL develope for Haskell into
-   Coq for the specification, implementaiton and formal verification of
-   circuits. Experimental work, very much in flux, as Satnam learns Coq!
-*)
-
 Require Import Program.Basics.
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
@@ -31,23 +26,24 @@ Export MonadNotation.
 Open Scope monad_scope.
 
 Require Import Cava.Monad.Cava.
+Require Import Cava.Netlist.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
+Local Open Scope string_scope.
 
 (* NAND gate example. Fist, let's define an overloaded NAND gate
    description. *)
 
+Definition nand2Interface
+  := mkCircuitInterface "nand2"
+     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
+     (One ("c", Bit))
+     [].
+
 Definition nand2_gate {m t} `{Cava m t} := and2 >=> inv.
 
-Definition nand2Top :=
-  setModuleName "nand2" ;;
-  a <- inputBit "a" ;;
-  b <- inputBit "b" ;;
-  c <- nand2_gate (a, b) ;;
-  outputBit "c" c.
-
-Definition nand2Netlist := makeNetlist nand2Top.
+Definition nand2Netlist := makeNetlist nand2Interface nand2.
 
 (* A proof that the NAND gate implementation is correct. *)
 Lemma nand2_behaviour : forall (a : bool) (b : bool),
@@ -100,11 +96,10 @@ Definition nand_tb : list ((bool * bool) * bool) :=
 Definition pipelinedNAND {m t} `{Cava m t}
   := nand2_gate >=> delayBit >=> inv >=> delayBit.
 
-Definition pipelinedNANDTop :=
-  setModuleName "pipelinedNAND" ;;
-  a <- inputBit "a" ;;
-  b <- inputBit "b" ;;
-  c <- pipelinedNAND (a, b) ;;
-  outputBit "c" c.
+Definition pipelinedNANDInterface
+  := mkCircuitInterface "pipelinedNAND"
+     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
+     (One ("c", Bit))
+     [].
 
-Definition pipelinedNANDNetlist := makeNetlist pipelinedNANDTop.
+Definition pipelinedNANDNetlist := makeNetlist pipelinedNANDInterface pipelinedNAND.

--- a/cava/monad-examples/UnsignedAdderNat.v
+++ b/cava/monad-examples/UnsignedAdderNat.v
@@ -44,9 +44,9 @@ Local Open Scope monad_scope.
 (****************************************************************************)
 
 
-Lemma addN_bheaviour : forall (ab : list (bool * bool)), 
-                       list_bits_to_nat (combinational (adder false ab)) =
-                       (list_bits_to_nat (map fst ab)) + (list_bits_to_nat (map snd ab)).
+Lemma addN_bheaviour : forall (a b : list bool),
+                       list_bits_to_nat (combinational (adder (false, (a, b)))) =
+                       (list_bits_to_nat a) + (list_bits_to_nat b).
 Proof.
   unfold combinational.
   unfold fst.


### PR DESCRIPTION
This PR is a first attempt at adding a mechanism for describing circuit interfaces which will allow us to do things like automate the generation of test benches. Several things are not right with the current approach but it is a step forward from the current ad hoc port wiring process.

The `singalTy` function does not seem to work for tuples of tuples, as described in the `Cava.v` files. Currently the adder tree example uses a workaround for this.

This PR no longer associates port net numbers with the port declarations . Instead, the association between port names and internal nets is made using four wiring components. This means the arrow examples don't generate working SystemVerilog now because I was not able to adjust the arrow code to use to new components. If this is too much of a hassle then we can try to add back the port numbers to the port declarations (but right now I feel that information does not belong there: a port specification is independent of how the net numbers are generated for the ports).

The syntax for specifying circuit interface types is far from ideal but after doing a few examples I suspect we can come up with some way of making it more rational.

The use of the `Flatten` type class means that circuits that are to be mapped to a netlist can only have one input and the input type is a combination of bits, bit-vectors or tuples of these types but no other types.