### PR TITLE
Add support for multi-dimensional input bit-vectors

### DIFF
--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -88,26 +88,23 @@ Local Open Scope nat_scope.
 
 Definition adder_tree4_8Interface
   := mkCircuitInterface "adder_tree4_8"
-     (Tuple2 (Tuple2 (One ("a", BitVec [8])) (One ("b", BitVec [8])))
-             (Tuple2 (One ("c", BitVec [8])) (One ("d", BitVec [8]))))
+     (One ("inputs", BitVec [4; 8]))
      (One ("sum", BitVec [11]))
      [].
 
 Definition adder_tree4_8Netlist
-  := makeNetlist adder_tree4_8Interface
-    (fun '((a, b), (c, d)) => adderTree4 [a; b; c; d]).
+  := makeNetlist adder_tree4_8Interface adderTree4.
+
+Compute combinational (adderTree4 [v0; v1; v2; v3]).
 
 Local Open Scope N_scope.
 
 Definition adder_tree4_8_tb_inputs
-  := map (fun '((a, b), (c, d)) =>
-      ((nat_to_list_bits_sized 8 a, nat_to_list_bits_sized 8 b),
-       (nat_to_list_bits_sized 8 c, nat_to_list_bits_sized 8 d)))
-     [((17, 42), (23, 95)); ((4, 13), (200, 30)); ((255, 74), (255, 200))].
+  := map (fun i => map (nat_to_list_bits_sized 8) i)
+     [[17; 42; 23; 95]; [4; 13; 200; 30]; [255; 74; 255; 200]].
 
 Definition adder_tree4_8_tb_expected_outputs
-  := map (fun '((a, b), (c, d)) => combinational (adderTree4 [a; b; c; d]))
-     adder_tree4_8_tb_inputs.
+  := map (fun i => combinational (adderTree4 i)) adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "adder_tree4_8_tb" adder_tree4_8Interface


### PR DESCRIPTION
This adds support for multi-dimensional bit-vectors used as the *inputs* to circuits to be used for circuit netlist generation and for test-bench generation. Support for multi-dimensional output bit-vectors will follow in the separate PR.
Partly addresses #77 