### PR TITLE
Update Arrow/Instances/Netlist.v for the new netlist types

### DIFF
--- a/cava/arrow-examples/ArrowExamplesSV.hs
+++ b/cava/arrow-examples/ArrowExamplesSV.hs
@@ -1,11 +1,11 @@
 {- Copyright 2020 The Project Oak Authors
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,5 +20,6 @@ import Cava2SystemVerilog
 import ArrowExamples
 
 main :: IO ()
-main = do writeSystemVerilog xorArrow
-          writeSystemVerilog loopedNandArrow
+main = do writeSystemVerilog nandArrow
+          writeSystemVerilog xorArrow
+          writeSystemVerilog feedbackNandArrow

--- a/cava/arrow-examples/Extraction.v
+++ b/cava/arrow-examples/Extraction.v
@@ -23,4 +23,7 @@ From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
+Extraction Library Nand.
+Extraction Library Xor.
+Extraction Library FeedbackNand.
 Extraction Library ArrowExamples.

--- a/cava/arrow-examples/FeedbackNand.v
+++ b/cava/arrow-examples/FeedbackNand.v
@@ -1,0 +1,10 @@
+Require Import Cava.Arrow.Arrow.
+
+Require Import Nand.
+
+(* nand previous output and current input, output delayed 1 cycle *)
+Definition feedbackNand
+  {Cava: CavaDelay}
+  {ArrowLoop: @ArrowLoop (@cava_delay_arr Cava)}
+  : bit ~> bit :=
+  loopl (nand >>> delay_gate >>> copy).

--- a/cava/arrow-examples/Makefile
+++ b/cava/arrow-examples/Makefile
@@ -32,16 +32,17 @@ ArrowExamplesSV:	ArrowExamplesSV.hs
 
 xorArrow.sv:	coq ArrowExamplesSV
 		./ArrowExamplesSV
+		$(VLINT) nandArrow.sv
 		$(VLINT) xorArrow.sv
-		$(VLINT) loopedNandArrow.sv
+		$(VLINT) feedbackNandArrow.sv
 
 %.vcd:		%.sv testbench/%_tb.sv
 		iverilog -g2012 -o $*.vvp $^
 		./$*.vvp
 
-.PRECIOUS:	xorArrow.sv loopedNandArrow.sv
+.PRECIOUS:	xorArrow.sv feedbackNandArrow.sv
 
-auto_vcds:	xorArrow.vcd loopedNandArrow.vcd
+auto_vcds:	xorArrow.vcd feedbackNandArrow.vcd
 
 clean:
 		-@$(MAKE) -f Makefile.coq clean

--- a/cava/arrow-examples/Nand.v
+++ b/cava/arrow-examples/Nand.v
@@ -1,0 +1,6 @@
+Require Import Cava.Arrow.Arrow.
+
+(* Implement a NAND circuit by composing an AND gate and INV gate. *)
+Definition nand
+  `{Cava}
+  := and_gate >>> not_gate.

--- a/cava/arrow-examples/Xor.v
+++ b/cava/arrow-examples/Xor.v
@@ -1,0 +1,15 @@
+Require Import Cava.Arrow.Arrow.
+
+Require Import Nand.
+
+(* An implementation of an XOR gate made out of the NAND circuit
+   defined above. *)
+Definition xor
+  `{Cava}
+  : (bit**bit) ~> bit :=
+  copy
+  >>> first (nand >>> copy)                    (* ((nand,nand),(x,y)) *)
+  >>> assoc                                    (* (nand,(nand,(x,y))) *)
+  >>> second (unassoc >>> first nand >>> swap) (* (nand,(y, x_nand)) *)
+  >>> unassoc >>> first nand                   (* (y_nand,x_nand) *)
+  >>> nand.

--- a/cava/arrow-examples/_CoqProject
+++ b/cava/arrow-examples/_CoqProject
@@ -1,4 +1,7 @@
 -R ../cava/Cava Cava
 -R . Lib
 ArrowExamples.v
+Nand.v
+Xor.v
+FeedbackNand.v
 Extraction.v

--- a/cava/arrow-examples/testbench/feedbackNandArrow_tb.sv
+++ b/cava/arrow-examples/testbench/feedbackNandArrow_tb.sv
@@ -13,21 +13,21 @@
 // limitations under the License.
 //
 
-module loopedNandArrow_test;
-  
+module feedbackNandArrow_test;
+
   timeunit 1ns; timeprecision 1ns;
 
   logic clk, rst, a, b;
-  
-  loopedNandArrow lloopedNandArrow_inst  (.clk(clk),
+
+  feedbackNandArrow lfeedbackNandArrow_inst  (.clk(clk),
                                           .rst(rst),
                                           .input1(a),
                                           .output1(b)
   );
 
-  initial begin 
-    clk = 1'b1; 
-  end 
+  initial begin
+    clk = 1'b1;
+  end
 
   // Clock generation.
   always #5 clk = ~clk;
@@ -67,10 +67,10 @@ module loopedNandArrow_test;
     @(posedge clk);
     $finish;
   end
-  
+
   initial
   begin
-    $dumpfile("loopedNandArrow.vcd");
+    $dumpfile("feedbackNandArrow.vcd");
     $dumpvars;
   end
 

--- a/cava/cava/Cava/Monad/Cava.v
+++ b/cava/cava/Cava/Monad/Cava.v
@@ -231,31 +231,6 @@ Definition inputBit (name : string) : state CavaState N :=
         ret o
   end.
 
-(* The duplicated i and l parametere are a temporary work-around to allow
-   well-founded recursion to be recoginized.
-   TODO(satnam): Rewrite with an appropriate well-foundedness proof.
-*)
-Fixpoint numberBitVec (offset : N) (i : list nat) (l : list nat) : @bitVecTy nat N l :=
-  match l, i return @bitVecTy nat N l with 
-  | [], _         => 0%N
-  | [x], [_]      => map N.of_nat (seq (N.to_nat offset) x)
-  | x::xs, p::ps  => let z := N.of_nat (fold_left (fun x y => x * y) xs 1) in
-                     map (fun w => numberBitVec (offset+w*z) ps xs) (map N.of_nat (seq 0 x))
-  | _, _          => []
-  end.
-
- Fixpoint numberPort (i : N) (inputs : @shape portType) : signalTy N inputs :=
-  match inputs return signalTy N inputs with
-  | Empty => tt
-  | One typ =>
-      match typ return portTypeTy N typ with
-      | Bit => i
-      | BitVec xs => numberBitVec i xs xs
-      end
-  | Tuple2 t1 t2 => let t1Size := bitsInPortShape t1 in
-                    (numberPort i t1,  numberPort (i + N.of_nat t1Size) t2)
-  end.
-
 Definition inputVectorTo0 (sizes : list nat) (name : string) : state CavaState (@bitVecTy nat N sizes) :=
   cs <- get ;;
   match cs with


### PR DESCRIPTION
This updates arrows for the new netlist types and adds a few functions port functions.

I also moved your existing `numberBitVec` `numberPort` functions into Netlist.v so they can be used for arrows too. I added a `flattenBitVec` function as I was having trouble getting the classes to resolve when the value I had was not concrete/was dependent on a sub call, but that might have been a limitation in my Coq understanding. 

~~There is one issue left, the inputs/outputs aren't connected (see below), I couldn't see how to connect them up with mkModule now- @satnam6502 do I need to use the new CircuitInterface for this? thanks~~ I think I know what to do, working on this now

~~~
module xorArrow(
  input logic input1,
  input logic input2,
  output logic output1
  );

  timeunit 1ns; timeprecision 1ns;

  logic[11:0] net;

  // Constant nets
  assign net[0] = 1'b0;
  assign net[1] = 1'b1;
  // Populate vectors.

  not inst_1 (net[11],net[10]);
  and inst_2 (net[10],net[9],net[7]);
  not inst_3 (net[9],net[8]);
  and inst_4 (net[8],net[5],net[3]);
  not inst_5 (net[7],net[6]);
  and inst_6 (net[6],net[5],net[2]);
  not inst_7 (net[5],net[4]);
  and inst_8 (net[4],net[2],net[3]);

endmodule
~~~