### PR TITLE
Add a _CoqProject to use for vscoq for Visual Studio Code

### DIFF
--- a/cava/Makefile
+++ b/cava/Makefile
@@ -19,12 +19,14 @@
 all:
 	cd cava && $(MAKE) && \
 	cd ../monad-examples && $(MAKE) && \
-	cd ../arrow-examples && $(MAKE) && \
+	cd xilinx && $(MAKE) coq && \
+	cd ../../arrow-examples && $(MAKE) && \
 	cd ..
 
 clean:
 	cd cava && $(MAKE) clean && \
 	cd ../monad-examples && $(MAKE) clean && \
-	cd ../arrow-examples && $(MAKE) clean && \
+	cd xilinx && $(MAKE) clean && \
+	cd ../../arrow-examples && $(MAKE) clean && \
 	cd ..
 	rm -rf .DS_Store

--- a/cava/_CoqProject
+++ b/cava/_CoqProject
@@ -1,0 +1,6 @@
+# This top-level _CoqProject exists to make it easier to navigate
+# the Cava source and examples using the vscoq plug-in for vscode.
+-R cava/Cava Cava
+-Q monad-examples MonadExamples
+-Q monad-examples/xilinx XilinxExamples
+-Q arrow-examples ArrowExamples

--- a/cava/arrow-examples/ArrowExamples.v
+++ b/cava/arrow-examples/ArrowExamples.v
@@ -16,9 +16,9 @@ Require Import Cava.Arrow.Instances.Coq.
 Require Import Cava.Arrow.Instances.Netlist.
 Require Import Cava.Arrow.Instances.Stream.
 
-Require Import Nand.
-Require Import Xor.
-Require Import FeedbackNand.
+Require Import ArrowExamples.Nand.
+Require Import ArrowExamples.Xor.
+Require Import ArrowExamples.FeedbackNand.
 
 Local Open Scope string_scope.
 

--- a/cava/arrow-examples/FeedbackNand.v
+++ b/cava/arrow-examples/FeedbackNand.v
@@ -1,6 +1,6 @@
 Require Import Cava.Arrow.Arrow.
 
-Require Import Nand.
+Require Import ArrowExamples.Nand.
 
 (* nand previous output and current input, output delayed 1 cycle *)
 Definition feedbackNand

--- a/cava/arrow-examples/Xor.v
+++ b/cava/arrow-examples/Xor.v
@@ -1,6 +1,6 @@
 Require Import Cava.Arrow.Arrow.
 
-Require Import Nand.
+Require Import ArrowExamples.Nand.
 
 (* An implementation of an XOR gate made out of the NAND circuit
    defined above. *)

--- a/cava/arrow-examples/_CoqProject
+++ b/cava/arrow-examples/_CoqProject
@@ -1,7 +1,7 @@
 -R ../cava/Cava Cava
--R . Lib
+-R . ArrowExamples
 ArrowExamples.v
 Nand.v
 Xor.v
 FeedbackNand.v
-Extraction.v
+ArrowExtraction.v

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -35,7 +35,7 @@ Local Open Scope monad_scope.
 
 Require Import Cava.Monad.Cava.
 Require Import Cava.BitArithmetic.
-Require Import FullAdder.
+Require Import MonadExamples.FullAdder.
 
 Open Scope N_scope.
 

--- a/cava/monad-examples/MonadExtraction.v
+++ b/cava/monad-examples/MonadExtraction.v
@@ -14,6 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Examples.
+Require Import NandGate.
+Require Import FullAdder.
+Require Import UnsignedAdderExamples.
+Require Import AdderTree.
 From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
@@ -22,12 +27,8 @@ From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import Nand.
-Require Import Xor.
-Require Import FeedbackNand.
-Require Import ArrowExamples.
-
-Extraction Library Nand.
-Extraction Library Xor.
-Extraction Library FeedbackNand.
-Extraction Library ArrowExamples.
+Extraction Library Examples.
+Extraction Library NandGate.
+Extraction Library FullAdder.
+Extraction Library UnsignedAdderExamples.
+Extraction Library AdderTree.

--- a/cava/monad-examples/_CoqProject
+++ b/cava/monad-examples/_CoqProject
@@ -1,9 +1,9 @@
 -R ../cava/Cava Cava
--R . Lib
+-R . MonadExamples
 Examples.v
 NandGate.v
 FullAdder.v
 FullAdderNat.v
 UnsignedAdderExamples.v
 AdderTree.v
-Extraction.v
+MonadExtraction.v

--- a/cava/monad-examples/xilinx/XilinxExtraction.v
+++ b/cava/monad-examples/xilinx/XilinxExtraction.v
@@ -14,6 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import XilinxAdderExamples.
+Require Import XilinxAdderTree.
 From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
@@ -22,12 +24,5 @@ From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import Nand.
-Require Import Xor.
-Require Import FeedbackNand.
-Require Import ArrowExamples.
-
-Extraction Library Nand.
-Extraction Library Xor.
-Extraction Library FeedbackNand.
-Extraction Library ArrowExamples.
+Extraction Library XilinxAdderExamples.
+Extraction Library XilinxAdderTree.

--- a/cava/monad-examples/xilinx/_CoqProject
+++ b/cava/monad-examples/xilinx/_CoqProject
@@ -1,5 +1,5 @@
 -R ../../cava/Cava Cava
--R . Lib
+-R . XilinxExamples
 XilinxAdderExamples.v
 XilinxAdderTree.v
-Extraction.v
+XilinxExtraction.v


### PR DESCRIPTION
@blaxill as part of this change I put the examples (including the arrow examples) into their own libraries with a name other than the default `Lib`.
Now we can start Visual Studio code from the top level caca directory and the `_CoqProject` there makes all the cava source and the library source available in Visual Studio code.