### PR TITLE
Create tests and LUT1 INV and LUT2 AND

### DIFF
--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -1,0 +1,76 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Ascii String.
+From Coq Require Import Lists.List.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+
+Require Import Cava.Monad.Cava.
+Require Import Cava.Netlist.
+
+Local Open Scope list_scope.
+Local Open Scope monad_scope.
+Local Open Scope string_scope.
+
+(****************************************************************************)
+(* LUT1 config test                                                         *)
+(****************************************************************************)
+
+Definition lut1_inv {m bit} `{Cava m bit} (i: bit) : m bit :=
+  o <- lut1 negb i ;;
+  ret o.
+
+Definition lut1_inv_Interface
+  := mkCircuitInterface "lut1_inv" (One ("a", Bit)) (One ("b", Bit)) [].
+
+Definition lut1_inv_netlist := makeNetlist lut1_inv_Interface lut1_inv.
+
+Definition lut1_inv_tb_inputs := [false; true].
+
+Definition lut1_inv_tb_expected_outputs : list bool :=
+  map (fun i => combinational (lut1_inv i)) lut1_inv_tb_inputs.
+
+Definition lut1_inv_tb :=
+  testBench "lut1_inv_tb" lut1_inv_Interface
+  lut1_inv_tb_inputs lut1_inv_tb_expected_outputs.
+
+(****************************************************************************)
+(* LUT2 config test                                                         *)
+(****************************************************************************)
+
+Definition lut2_and {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
+  o <- lut2 andb i0i1 ;;
+  ret o.
+
+Definition lut2_and_Interface
+  := mkCircuitInterface "lut2_and"
+     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
+     (One ("c", Bit))
+     [].
+
+Definition lut2_and_nelist := makeNetlist lut2_and_Interface lut2_and.
+
+Definition lut2_and_tb_inputs : list (bool * bool) :=
+ [(false, false); (false, true); (true, false); (true, true)].       
+
+ Definition lut2_and_tb_expected_outputs : list bool :=
+  map (fun i => combinational (lut2_and i)) lut2_and_tb_inputs.
+
+Definition lut2_and_tb :=
+  testBench "lut2_and_tb" lut2_and_Interface
+  lut2_and_tb_inputs lut2_and_tb_expected_outputs.

--- a/cava/tests/xilinx/Makefile
+++ b/cava/tests/xilinx/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright 2020 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# To simulate Xilinx specific SystemVerilog netlists the environment
+# variable XILINX should point to the root of the Xilinx software
+# tools installation directory e.g.
+#    ...../vivado/2018.3 
+
+.PHONY: all coq clean
+
+all:		coq lut1_inv_tb.vcd lut2_and_tb.vcd
+
+Makefile.coq:	_CoqProject
+		coq_makefile -f _CoqProject -o Makefile.coq
+
+coq:		Makefile.coq
+		$(MAKE) -f Makefile.coq
+
+VivadoTestsSV:	VivadoTestsSV.hs
+		ghc -O2 --make $^
+
+lut1_inv_tb.sv:	coq VivadoTestsSV
+		./VivadoTestsSV
+
+lut1_inv_tb.vcd:	lut1_inv.sv lut1_inv_tb.sv lut1_inv_tb.tcl
+			vivado -mode tcl -source lut1_inv_tb.tcl
+			mv lut1_inv/lut1_inv.sim/sim_1/behav/xsim/lut1_inv_tb.vcd .
+
+clean:
+	-@$(MAKE) -f Makefile.coq clean
+	git clean -xfd
+	rm -rf obj_dir

--- a/cava/tests/xilinx/VivadoExtraction.v
+++ b/cava/tests/xilinx/VivadoExtraction.v
@@ -1,0 +1,26 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Extraction.
+From Coq Require Import extraction.ExtrHaskellZInteger.
+From Coq Require Import extraction.ExtrHaskellString.
+From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellNatInteger.
+
+Extraction Language Haskell.
+
+Require Import LUTTests.
+Extraction Library LUTTests.

--- a/cava/tests/xilinx/VivadoTestsSV.hs
+++ b/cava/tests/xilinx/VivadoTestsSV.hs
@@ -1,0 +1,28 @@
+{- Copyright 2020 The Project Oak Authors
+  
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-}
+
+
+module Main where
+
+import Cava2SystemVerilog
+import LUTTests
+
+main :: IO ()
+main = do writeSystemVerilog lut1_inv_netlist
+          writeTestBench lut1_inv_tb
+          writeSystemVerilog lut2_and_nelist
+          writeTestBench lut2_and_tb
+
+

--- a/cava/tests/xilinx/_CoqProject
+++ b/cava/tests/xilinx/_CoqProject
@@ -1,0 +1,4 @@
+-R ../../cava/Cava Cava
+-R . VivadoTests
+LUTTests.v
+VivadoExtraction.v

--- a/cava/tests/xilinx/lutNAND_tb.tcl
+++ b/cava/tests/xilinx/lutNAND_tb.tcl
@@ -1,0 +1,33 @@
+#
+# Copyright 2020 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Vivado tcl script to synthesize, implement and generate write_bitstream
+# for the add8.sv example for EDIF extraction
+#
+set outputDir ./vivado_genfiles/output
+create_project -force lutNAND lutNAND -part xc7A200tsbg484-1
+add_files -fileset sim_1 -norecurse lutNAND_tb.sv lutNAND.sv 
+set_property top lutNAND_tb  [get_filesets sim_1]
+import_files -force -norecurse
+launch_simulation
+open_vcd lutNAND_tb.vcd
+log_vcd *
+log_vcd [ get_objects *]
+add_force {/lutNAND_tb/clk} {0 0ns} {1 50ns} -repeat_every 100ns
+run 400ns
+flush_vcd
+close_vcd
+exit


### PR DESCRIPTION
This moves the LUT tests form `monad-examples/xilinx` to `tests/xilinx` and also tests INV and AND2 individually. Tests are run with the Xilinx xsim simulator. The testbench generator now produces a tcl script for driving the simulation and producing a VCD waveform. Right now we can't run these tests in CI until we can work out a way of running SystemVerilog simulations in our CI framework that work with the UNISIM library.

```console
xvlog -sv lut1_inv.sv lut1_inv_tb.sv
INFO: [VRFC 10-2263] Analyzing SystemVerilog file "/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut1_inv.sv" into library work
INFO: [VRFC 10-311] analyzing module lut1_inv
INFO: [VRFC 10-2263] Analyzing SystemVerilog file "/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut1_inv_tb.sv" into library work
INFO: [VRFC 10-311] analyzing module lut1_inv_tb
xelab --debug typical -L unisims_ver work.lut1_inv_tb -s lut1_inv_tb_sim
Vivado Simulator 2018.3
Copyright 1986-1999, 2001-2018 Xilinx, Inc. All Rights Reserved.
Running: /usr/local/google/home/satnam/vivado/2018.3/bin/unwrapped/lnx64.o/xelab --debug typical -L unisims_ver work.lut1_inv_tb -s lut1_inv_tb_sim
Multi-threading is on. Using 10 slave threads.
Starting static elaboration
WARNING: [VRFC 10-696] first argument of $fatal is invalid, expecting 0, 1 or 2 [/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut1_inv_tb.sv:37]
Completed static elaboration
INFO: [XSIM 43-4329] Assuming default value 1 for the first arguement of $fatal at Line 37, File /usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut1_inv_tb.sv
Starting simulation data flow analysis
Completed simulation data flow analysis
Time Resolution for simulation is 1ps
Compiling module unisims_ver.x_lut1_mux2
Compiling module unisims_ver.LUT1
Compiling module work.lut1_inv
Compiling module work.lut1_inv_tb
Built simulation snapshot lut1_inv_tb_sim
xsim --tclbatch lut1_inv_tb.tcl lut1_inv_tb_sim

****** xsim v2018.3 (64-bit)
  **** SW Build 2405991 on Thu Dec  6 23:36:41 MST 2018
  **** IP Build 2404404 on Fri Dec  7 01:43:56 MST 2018
    ** Copyright 1986-2018 Xilinx, Inc. All Rights Reserved.

source xsim.dir/lut1_inv_tb_sim/xsim_script.tcl
# xsim {lut1_inv_tb_sim} -autoloadwcfg -tclbatch {lut1_inv_tb.tcl}
Vivado Simulator 2018.3
Time resolution is 1 ps
source lut1_inv_tb.tcl
## open_vcd lut1_inv_tb.vcd
## log_vcd *
INFO: HDL object /lut1_inv_tb/a_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut1_inv_tb/b_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## log_vcd [ get_objects * ]
INFO: HDL object /lut1_inv_tb/a_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut1_inv_tb/b_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## add_force {/lut1_inv_tb/clk} {0 0ns} {1 50ns} -repeat_every 100ns
## run 200ns
               50000: tick = 0, a = 0, b = 1
              150000: tick = 1, a = 1, b = 0
PASSED
## flush_vcd
## close_vcd
## exit
INFO: [Common 17-206] Exiting xsim at Thu May  7 12:14:59 2020...
xvlog -sv lut2_and.sv lut2_and_tb.sv
INFO: [VRFC 10-2263] Analyzing SystemVerilog file "/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut2_and.sv" into library work
INFO: [VRFC 10-311] analyzing module lut2_and
INFO: [VRFC 10-2263] Analyzing SystemVerilog file "/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut2_and_tb.sv" into library work
INFO: [VRFC 10-311] analyzing module lut2_and_tb
xelab --debug typical -L unisims_ver work.lut2_and_tb -s lut2_and_tb_sim
Vivado Simulator 2018.3
Copyright 1986-1999, 2001-2018 Xilinx, Inc. All Rights Reserved.
Running: /usr/local/google/home/satnam/vivado/2018.3/bin/unwrapped/lnx64.o/xelab --debug typical -L unisims_ver work.lut2_and_tb -s lut2_and_tb_sim
Multi-threading is on. Using 10 slave threads.
Starting static elaboration
WARNING: [VRFC 10-696] first argument of $fatal is invalid, expecting 0, 1 or 2 [/usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut2_and_tb.sv:49]
Completed static elaboration
INFO: [XSIM 43-4329] Assuming default value 1 for the first arguement of $fatal at Line 49, File /usr/local/google/home/satnam/oak-hardware/cava/tests/xilinx/lut2_and_tb.sv
Starting simulation data flow analysis
Completed simulation data flow analysis
Time Resolution for simulation is 1ps
Compiling module unisims_ver.x_lut2_mux4
Compiling module unisims_ver.LUT2
Compiling module work.lut2_and
Compiling module work.lut2_and_tb
Built simulation snapshot lut2_and_tb_sim
xsim --tclbatch lut2_and_tb.tcl lut2_and_tb_sim

****** xsim v2018.3 (64-bit)
  **** SW Build 2405991 on Thu Dec  6 23:36:41 MST 2018
  **** IP Build 2404404 on Fri Dec  7 01:43:56 MST 2018
    ** Copyright 1986-2018 Xilinx, Inc. All Rights Reserved.

source xsim.dir/lut2_and_tb_sim/xsim_script.tcl
# xsim {lut2_and_tb_sim} -autoloadwcfg -tclbatch {lut2_and_tb.tcl}
Vivado Simulator 2018.3
Time resolution is 1 ps
source lut2_and_tb.tcl
## open_vcd lut2_and_tb.vcd
## log_vcd *
INFO: HDL object /lut2_and_tb/a_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut2_and_tb/b_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut2_and_tb/c_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## log_vcd [ get_objects * ]
INFO: HDL object /lut2_and_tb/a_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut2_and_tb/b_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut2_and_tb/c_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## add_force {/lut2_and_tb/clk} {0 0ns} {1 50ns} -repeat_every 100ns
## run 400ns
               50000: tick = 0, a = 0, b = 0, c = 0
              150000: tick = 1, a = 0, b = 1, c = 0
              250000: tick = 2, a = 1, b = 0, c = 0
              350000: tick = 3, a = 1, b = 1, c = 1
PASSED
## flush_vcd
## close_vcd
## exit
INFO: [Common 17-206] Exiting xsim at Thu May  7 12:15:29 2020...
```
