### PR TITLE
Implement and test LUT4

### DIFF
--- a/cava/cava/Cava2SystemVerilog.hs
+++ b/cava/cava/Cava2SystemVerilog.hs
@@ -263,6 +263,14 @@ generateInstance inst@(Netlist.BindPrimitive _ _
      ++ showArgs args ++ ";"
      where
      args = maybe (error "Primitive did not have extractable arguments!") id $ Netlist.instanceArgs inst
+generateInstance inst@(Netlist.BindPrimitive _ _
+                 (Netlist.Lut4 config) _ _) instNr
+   = "  LUT4 #(.INIT(16'h" ++
+     showHex (fromN config) "" ++ ")) lut4_" ++ show instNr ++ " "
+     ++ showArgs args ++ ";"
+     where
+     args = maybe (error "Primitive did not have extractable arguments!") id $ Netlist.instanceArgs inst
+
 generateInstance (Netlist.BindPrimitive _ _ (Netlist.UnsignedAdd _ _ _) ab s) _
    = "" -- Generated instead during vector generation
 generateInstance inst@(Netlist.BindPrimitive i o prim _ _) instNr

--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -107,4 +107,40 @@ Definition lut3_mux_tb_inputs : list (bool * (bool * bool)) :=
 
 Definition lut3_mux_tb :=
   testBench "lut3_mux_tb" lut3_mux_Interface
-  lut3_mux_tb_inputs lut3_mux_tb_expected_outputs.  
+  lut3_mux_tb_inputs lut3_mux_tb_expected_outputs.
+
+(****************************************************************************)
+(* LUT4 config test                                                         *)
+(****************************************************************************)
+
+Definition lut4_and {m bit} `{Cava m bit}
+           (i : bit * bit * bit * bit) : m bit :=
+  let '(i0, i1, i2, i3) := i in
+  o <- lut4 (fun i0 i1 i2 i3 =>
+            andb (andb i0 i1) (andb i2 i3)) i ;;
+  ret o.
+
+(* The left-associative nesting we need to use here is mad. We need to
+   find a better way. Satnam.
+*)
+Definition lut4_and_Interface
+  := mkCircuitInterface "lut4_and"
+     (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
+                     (One ("i2", Bit)))
+             (One ("i3", Bit))
+     )
+     (One ("o", Bit))
+     [].
+
+Definition lut4_and_nelist := makeNetlist lut4_and_Interface lut4_and.
+
+Definition lut4_and_tb_inputs : list (bool * bool * bool * bool) :=
+ [(false, false, false, false);
+  (true, true, true, true)].
+
+Definition lut4_and_tb_expected_outputs : list bool :=
+  map (fun i => combinational (lut4_and i)) lut4_and_tb_inputs.
+
+Definition lut4_and_tb :=
+  testBench "lut4_and_tb" lut4_and_Interface
+  lut4_and_tb_inputs lut4_and_tb_expected_outputs.

--- a/cava/tests/xilinx/Makefile
+++ b/cava/tests/xilinx/Makefile
@@ -21,7 +21,7 @@
 
 .PHONY: all coq clean
 
-SV = lut1_inv.sv lut2_and.sv lut3_mux.sv
+SV = lut1_inv.sv lut2_and.sv lut3_mux.sv lut4_and.sv
 
 BENCHES = $(SV:.sv=_tb.sv)
 VCDS = $(SV:.sv=_tb.vcd)

--- a/cava/tests/xilinx/VivadoTestsSV.hs
+++ b/cava/tests/xilinx/VivadoTestsSV.hs
@@ -26,5 +26,7 @@ main = do writeSystemVerilog lut1_inv_netlist
           writeTestBench lut2_and_tb
           writeSystemVerilog lut3_mux_nelist
           writeTestBench lut3_mux_tb
+          writeSystemVerilog lut4_and_nelist
+          writeTestBench lut4_and_tb
 
 


### PR DESCRIPTION
Added LUT4 to netlist data-type and monad API for Cava and produced a small test to check against config LSB/MSB errors.

```console
xsim --tclbatch lut4_and_tb.tcl lut4_and_tb_sim

****** xsim v2018.3 (64-bit)
  **** SW Build 2405991 on Thu Dec  6 23:36:41 MST 2018
  **** IP Build 2404404 on Fri Dec  7 01:43:56 MST 2018
    ** Copyright 1986-2018 Xilinx, Inc. All Rights Reserved.

source xsim.dir/lut4_and_tb_sim/xsim_script.tcl
# xsim {lut4_and_tb_sim} -autoloadwcfg -tclbatch {lut4_and_tb.tcl}
Vivado Simulator 2018.3
Time resolution is 1 ps
source lut4_and_tb.tcl
## open_vcd lut4_and_tb.vcd
## log_vcd *
INFO: HDL object /lut4_and_tb/i0_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i1_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i2_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i3_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/o_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## log_vcd [ get_objects * ]
INFO: HDL object /lut4_and_tb/i0_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i1_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i2_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/i3_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
INFO: HDL object /lut4_and_tb/o_vectors is an unpacked array. VCD does not support unpacked array type according to IEEE LRM 1800-2009, section21.7.5.
## add_force {/lut4_and_tb/clk} {0 0ns} {1 50ns} -repeat_every 100ns
## run 200ns
               50000: tick = 0, i0 = 0, i1 = 0, i2 = 0, i3 = 0, o = 0
              150000: tick = 1, i0 = 1, i1 = 1, i2 = 1, i3 = 1, o = 1
PASSED
## flush_vcd
## close_vcd
## exit
INFO: [Common 17-206] Exiting xsim at Thu May  7 20:57:49 2020...
```