### PR TITLE
Add comment to auto-generated Haskell files

### DIFF
--- a/cava/cava/.gitignore
+++ b/cava/cava/.gitignore
@@ -17,7 +17,7 @@ Makefile.coq
 *.hs
 !Cava2SystemVerilog.hs
 !ExamplesSV.hs
-!FixupAscii.hs
+!FixupHaskell.hs
 !Setup.hs
 
 # Binaries

--- a/cava/cava/Cava/Extraction.v
+++ b/cava/cava/Cava/Extraction.v
@@ -21,6 +21,8 @@ From Coq Require Import ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
+Set Extraction KeepSingleton.
+Set Extraction File Comment "Auto-generated from Cava/Coq. Please do not hand edit.".
 
 Require Import Cava.BitArithmetic.
 Require Import Cava.Monad.Cava.

--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -66,10 +66,10 @@ library
                      VectorDef
                      Vector
                      XilinxAdder
-                     ByteVector
   other-Modules:     Applicative
                      BinPos
                      Bool
+                     ByteVector
                      Decimal
                      Functor
                      Specif

--- a/cava/cava/FixupHaskell.hs
+++ b/cava/cava/FixupHaskell.hs
@@ -21,9 +21,9 @@ fixup content
   = unlines updatedLines
     where
     contentLines = lines content
-    updatedLines = take 2 contentLines ++
+    updatedLines = take 3 contentLines ++
                    extraImports ++
-                   drop 2 contentLines
+                   drop 3 contentLines
     extraImports = ["import qualified Data.Bits",
                     "import qualified Data.Char"]
 

--- a/cava/cava/Makefile
+++ b/cava/cava/Makefile
@@ -21,11 +21,11 @@ all:		coq haskell
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
-FixupAscii:	FixupAscii.hs
-		ghc --make FixupAscii.hs
+FixupHaskell:	FixupHaskell.hs
+		ghc --make $^
 
-haskell:	coq FixupAscii
-		./FixupAscii
+haskell:	coq FixupHaskell
+		./FixupHaskell
 		mv Ascii2.hs Ascii.hs
 		mv ByteVector2.hs ByteVector.hs
 		runhaskell Setup.hs configure --user


### PR DESCRIPTION
This changes the extraction technique to add a comment to Haskell files to indicated they have been auto-generated (so don't hand edit).