### PR TITLE
Add port names to component instantiations

### DIFF
--- a/cava/cava/Cava/Monad/Cava.v
+++ b/cava/cava/Cava/Monad/Cava.v
@@ -42,6 +42,7 @@ Generalizable All Variables.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
+Local Open Scope string_scope.
 
 (* The Cava class represents circuit graphs with Coq-level inputs and
    outputs, but does not represent the IO ports of circuits. This allows
@@ -144,7 +145,9 @@ Definition lut1Net (f : bool -> bool) (i : N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut1 config i o) insts) inputs outputs )) ;;
+      => let component := Component "LUT1" [("INIT", HexLiteral 2 config)]
+                          [("O", o); ("I0", i)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -157,7 +160,9 @@ Definition lut2Net (f : bool -> bool -> bool) (i : N * N) : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut2 config i0 i1 o) insts) inputs outputs )) ;;
+      => let component := Component "LUT2" [("INIT", HexLiteral 4 config)]
+                          [("O", o); ("I0", i0); ("I1", i1)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -176,7 +181,9 @@ Definition lut3Net (f : bool -> bool -> bool -> bool) (i : N * N * N) :
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut3 config i0 i1 i2 o) insts) inputs outputs )) ;;
+      => let component := Component "LUT3" [("INIT", HexLiteral 8 config)]
+                          [("O", o); ("I0", i0); ("I1", i1); ("I2", i2)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -196,7 +203,9 @@ Definition lut4Net (f : bool -> bool -> bool -> bool -> bool)
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut4 config i0 i1 i2 i3 o) insts) inputs outputs )) ;;
+      => let component := Component "LUT4" [("INIT", HexLiteral 16 config)]
+                          [("O", o); ("I0", i0); ("I1", i1); ("I2", i2); ("I3", i3)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -216,7 +225,9 @@ Definition lut5Net (f : bool -> bool -> bool -> bool -> bool -> bool)
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut5 config i0 i1 i2 i3 i4 o) insts) inputs outputs )) ;;
+      => let component := Component "LUT5" [("INIT", HexLiteral 32 config)]
+                          [("O", o); ("I0", i0); ("I1", i1); ("I2", i2); ("I3", i3); ("I4", i4)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
@@ -236,19 +247,13 @@ Definition lut6Net (f : bool -> bool -> bool -> bool -> bool -> bool -> bool)
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Lut6 config i0 i1 i2 i3 i4 i5 o) insts) inputs outputs )) ;;
+      => let component := Component "LUT6" [("INIT", HexLiteral 64 config)]
+                          [("O", o); ("I0", i0); ("I1", i1); ("I2", i2); ("I3", i3); ("I4", i4); ("I5", i5)] in
+        put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 
 Local Close Scope N_scope.
-
-Definition xorcyNet (i : N * N) : state CavaState N :=
-  cs <- get ;;
-  match cs with
-  | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Xorcy (fst i) (snd i) o) insts) inputs outputs )) ;;
-         ret o
-  end.
 
 Definition xnorNet (i : N * N) : state CavaState N :=
   cs <- get ;;
@@ -266,11 +271,21 @@ Definition bufNet (i : N) : state CavaState N :=
          ret o
   end.
 
+Definition xorcyNet (i : N * N) : state CavaState N :=
+  cs <- get ;;
+  match cs with
+  | mkCavaState o isSeq (mkModule name insts inputs outputs)
+      => let component := Component "XORCY" [] [("O", o); ("CI", fst i); ("LI", snd i)] in 
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
+         ret o
+  end.
+
 Definition muxcyNet (s : N) (ci : N) (di : N)  : state CavaState N :=
   cs <- get ;;
   match cs with
   | mkCavaState o isSeq (mkModule name insts inputs outputs)
-      => put (mkCavaState (o+1) isSeq (mkModule name (cons (Muxcy s ci di o) insts) inputs outputs )) ;;
+      => let component := Component "MUXCY" [] [("O", o); ("S", s); ("CI", ci); ("DI", di)] in
+         put (mkCavaState (o+1) isSeq (mkModule name (cons component insts) inputs outputs )) ;;
          ret o
   end.
 

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -256,10 +256,14 @@ Instance FlattenList {a} `{Flatten a} : Flatten (list a) := {
 (* PrimitiveInstance elements                                                 *)
 (******************************************************************************)
 
-(* The primitive elements that can be instantiated in Cava. Some are generic
+(* The primitive elements that can be instantiated in Cava. These are generic
    SystemVerilog gates that can be used with synthesis and back-end tools to
-   map to any architecture, while others are specific to Xilinx FPGAs.
+   map to any architecture.
 *)
+
+Inductive ConstExpr : Type :=
+| HexLiteral: nat -> N -> ConstExpr
+| StringLiteral: string -> ConstExpr.
 
 Inductive Instance : Type :=
   (* I/O port wiring *)
@@ -287,15 +291,8 @@ Inductive Instance : Type :=
   (* Multiplexors *)    
   | IndexBitArray: list N -> list N -> N -> Instance
   | IndexArray: list (list N) -> list N -> list N -> Instance
-  (* Xilinx FPGA architecture specific gates. *)
-  | Lut1:      N -> N -> N -> Instance
-  | Lut2:      N -> N -> N -> N -> Instance
-  | Lut3:      N -> N -> N -> N -> N -> Instance
-  | Lut4:      N -> N -> N -> N -> N -> N -> Instance
-  | Lut5:      N -> N -> N -> N -> N -> N -> N -> Instance
-  | Lut6:      N -> N -> N -> N -> N -> N -> N -> N -> Instance                
-  | Xorcy:     N -> N -> N -> Instance
-  | Muxcy:     N -> N -> N -> N -> Instance.
+  | Component: string -> list (string * ConstExpr) -> list (string * N) ->
+               Instance.
 
 (******************************************************************************)
 (* Data structures to represent circuit graph/netlist state                   *)

--- a/cava/tests/xilinx/Makefile
+++ b/cava/tests/xilinx/Makefile
@@ -28,7 +28,7 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
-all:		coq $(VCDS)
+all:		coq lut1_inv.sv $(VCDS)
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt -y $(XILINX)/data/verilog/src/xeclib
 VLINT = $(VERILATOR) --lint-only
@@ -61,4 +61,5 @@ lut1_inv.sv:	coq VivadoTestsSV
 clean:
 	-@$(MAKE) -f Makefile.coq clean
 	git clean -Xfd
+	rm -rf *.sv *.tcl *.cpp *.vcd VivadoTestsSV LUTTests.hs
 	rm -rf obj_dir

--- a/cava/tests/xilinx/verilator.vlt
+++ b/cava/tests/xilinx/verilator.vlt
@@ -1,3 +1,2 @@
 `verilator_config
 lint_off -rule UNOPTFLAT
-lint_off -rule BLKANDNBLK


### PR DESCRIPTION
Signed-off-by: Satnam Singh <satnam@google.com>

Now all component instantiations (except for primitive gates) have the port name used in the instantiation. The Xilinx gates have been removed as explicit enteries in `Netlist` and instead there is now a generic `Component` constructor for building SystemVerilog instantiations.