### PR TITLE
Add LUTs and multidimensional indexing to Arrows

### DIFF
--- a/cava/arrow-examples/SyntaxExamples.v
+++ b/cava/arrow-examples/SyntaxExamples.v
@@ -25,7 +25,7 @@ Definition xilinxFullAdder
      let b = snd' ab in
      let part_sum = !xor_gate a b in
      let sum      = !xorcy part_sum cin in
-     let cout     = !muxcy part_sum cin a in
+     let cout     = !muxcy part_sum (cin, a) in
      (sum, cout)
   ]>.
 

--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -170,7 +170,7 @@ Class Cava  := {
   buf_gate:  bit        ** unit ~> bit;
 
   xorcy:     bit ** bit ** unit ~> bit;
-  muxcy:     bit ** bit ** bit ** unit ~> bit;
+  muxcy:     bit ** (bit ** bit) ** unit ~> bit;
   
   unsigned_add a b c: bitvec [a] ** bitvec [b] ** unit ~> bitvec [c];
 

--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -138,6 +138,11 @@ Class ArrowLoop (A: Arrow) := {
   loopl {x y z} : (z**x ~> z**y) -> (x ~> y);
 }.
 
+(*
+replicate_object returns an object in the argument format expect by Kappa Calculus.
+That is, the object is repeated n times, as a right nested tuple, with the rightmost
+tuple element set to the unit type.
+*)
 Fixpoint replicate_object `{Arrow} (n: nat) (o: object) :=
 match n with 
 | O => unit

--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -1,8 +1,7 @@
-From Coq Require Import Setoid Classes.Morphisms Lists.List.
+From Coq Require Import Setoid Classes.Morphisms Lists.List NaryFunctions String.
 Import ListNotations.
 
 From Cava Require Import Types.
-
 
 Reserved Infix "~>" (at level 90, no associativity).
 Reserved Infix "~[ C ]~>" (at level 90, no associativity).
@@ -139,12 +138,24 @@ Class ArrowLoop (A: Arrow) := {
   loopl {x y z} : (z**x ~> z**y) -> (x ~> y);
 }.
 
+Fixpoint replicate_object `{Arrow} (n: nat) (o: object) :=
+match n with 
+| O => unit
+| S n' => o ** replicate_object n' o 
+end.
+
+Reserved Notation "'bit'" (at level 1, no associativity).
+Reserved Notation "'bitvec' n" (at level 1, no associativity).
+Reserved Notation "'bitvec_index' n" (at level 1, no associativity).
+
 (* Cava *)
 Class Cava  := {
   cava_arrow :> Arrow;
 
-  bit : object;
-  bitvec : list nat -> object;
+  representable : Kind -> object
+    where "'bit'" := (representable Bit)
+    and   "'bitvec' n" := (representable (BitVec n))
+    and   "'bitvec_index' n" := (bitvec [PeanoNat.Nat.log2_up n]);
 
   constant : bool -> (unit ~> bit);
   constant_vec (dimensions: list nat) : denoteBitVecWith bool dimensions -> (unit ~> bitvec dimensions);
@@ -160,11 +171,35 @@ Class Cava  := {
 
   xorcy:     bit ** bit ** unit ~> bit;
   muxcy:     bit ** bit ** bit ** unit ~> bit;
+  
+  unsigned_add a b c: bitvec [a] ** bitvec [b] ** unit ~> bitvec [c];
 
-  unsigned_add a b s: bitvec [a] ** bitvec [b] ** unit ~> bitvec [s];
+  lut n: (bool^^n --> bool) -> (replicate_object n bit) ~> bit;
+
+  degenerate_bitvec xs := match xs with | [] => bit | _ => bitvec xs end;
+
+  index_array n xs
+    : bitvec (n::xs) ** bitvec_index n ** unit 
+    ~> degenerate_bitvec xs;
+
+  to_vec n o:
+    match o with
+    | Bit => replicate_object (S n) bit ~> bitvec [S n]
+    | BitVec xs => replicate_object (S n) (bitvec xs) ~> bitvec (S n::xs)
+    end;
 }.
 
 Coercion cava_arrow: Cava >-> Arrow.
+
+Declare Scope cava_scope.
+Bind Scope cava_scope with Cava.
+Delimit Scope cava_scope with cava.
+
+Notation "'bit'" := (representable Bit)(at level 1, no associativity) : cava_scope.
+Notation "'bitvec' n" := (representable (BitVec n)) (at level 1, no associativity) : cava_scope.
+Notation "'bitvec_index' n" := (bitvec [PeanoNat.Nat.log2_up n])%cava(at level 1, no associativity) : cava_scope.
+
+Open Scope cava_scope.
 
 Definition cava_cat (_: Cava): Category := _.
 Definition cava_obj (cava: Cava): Type := @object (@cava_cat cava).
@@ -213,5 +248,3 @@ Proof.
   setoid_rewrite H.
   reflexivity.
 Qed.
-
-

--- a/cava/cava/Cava/Arrow/Instances/Combinational.v
+++ b/cava/cava/Cava/Arrow/Instances/Combinational.v
@@ -121,7 +121,7 @@ Section CoqEval.
     buf_gate '(x, tt) := x;
 
     xorcy '(x, (y, tt)) := xorb x y;
-    muxcy '(i,(t,(e,tt))) := if i then t else e;
+    muxcy '(i,((t,e),tt)) := if i then t else e;
 
     unsigned_add m n s '(av, (bv, tt)) :=
       let a := list_bits_to_nat av in

--- a/cava/cava/Cava/Arrow/Instances/Constructive.v
+++ b/cava/cava/Cava/Arrow/Instances/Constructive.v
@@ -36,19 +36,19 @@ Inductive structure: bundle -> bundle -> Type :=
 | Constant:    bool -> structure Empty (One Bit)
 | ConstantVec: forall n,  denoteBitVecWith bool n -> structure Empty ((One (BitVec n)))
 
-| NotGate:     structure (Tuple2 (One Bit) Empty) (One Bit)
-| AndGate:     structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| NandGate:    structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| OrGate:      structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| NorGate:     structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| XorGate:     structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| XnorGate:    structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| BufGate:     structure (Tuple2 (One Bit) Empty) (One Bit)
+| NotGate:     structure << One Bit>> (One Bit)
+| AndGate:     structure << One Bit, One Bit >> (One Bit)
+| NandGate:    structure << One Bit, One Bit >> (One Bit)
+| OrGate:      structure << One Bit, One Bit >> (One Bit)
+| NorGate:     structure << One Bit, One Bit >> (One Bit)
+| XorGate:     structure << One Bit, One Bit >> (One Bit)
+| XnorGate:    structure << One Bit, One Bit >> (One Bit)
+| BufGate:     structure << One Bit >> (One Bit)
 
-| Xorcy:       structure (Tuple2 (One Bit) (Tuple2 (One Bit) Empty)) (One Bit)
-| Muxcy:       structure (Tuple2 (One Bit) (Tuple2 (One Bit) (Tuple2 (One Bit) Empty))) (One Bit)
+| Xorcy:       structure << One Bit, One Bit >> (One Bit)
+| Muxcy:       structure << One Bit, Tuple2 (One Bit) (One Bit) >> (One Bit)
 
-| UnsignedAdd: forall a b s, structure (Tuple2 ((One (BitVec [a]))) (Tuple2 ((One (BitVec [b]))) Empty)) ((One (BitVec [s])))
+| UnsignedAdd: forall a b s, structure << One (BitVec [a]),  One (BitVec [b]) >> (One (BitVec [s]))
 
 | Lut: forall n (f: bool^^n --> bool), structure (Nobj n Bit) (One Bit)
 

--- a/cava/cava/Cava/Arrow/Instances/Netlist.v
+++ b/cava/cava/Cava/Arrow/Instances/Netlist.v
@@ -198,7 +198,7 @@ Section NetlistEval.
       addInstance (Component "XORCY" [] [("O", o); ("CI", i0); ("LI", i1)]) ;;
       ret o;
 
-    muxcy '(s,(ci,(di, tt))) :=
+    muxcy '(s,((ci, di), tt)) :=
       o <- newWire ;;
       addInstance ( Component "MUXCY" [] [("O", o); ("S", s); ("CI", ci); ("DI", di)]) ;;
       ret o;

--- a/cava/cava/Cava/Arrow/Instances/Netlist.v
+++ b/cava/cava/Cava/Arrow/Instances/Netlist.v
@@ -1,10 +1,13 @@
 From Coq Require Import Program.Tactics.
 From Coq Require Import Bool.Bool.
-(* From Coq Require Import Bool.Bvector. *)
 From Coq Require Import Vector.
 From Coq Require Import Lists.List.
 From Coq Require Import Strings.String.
 From Coq Require Import ZArith.
+From Coq Require Import Numbers.DecimalString.
+From Coq Require Import Bool.Bvector.
+
+Import NilZero.
 
 Import ListNotations.
 
@@ -108,11 +111,37 @@ Section NetlistEval.
     simpl; auto.
   Defined.
 
-  Instance NetlistCava : Cava := {
+  Fixpoint object_as_list n:
+    forall x, signalTy Signal (replicate_object n (One x)) -> list (signalTy Signal (One x)).
+  Proof.
+    intros.
+
+    induction n.
+    simpl in *.
+    exact ([]).
+
+    simpl in *.
+    refine (fst X :: _).
+    apply (IHn (snd X)).
+  Defined.
+
+  Fixpoint bv_to_nprod n (v: Bvector n): NaryFunctions.nprod bool n.
+  Proof.
+    unfold Bvector in *.
+    destruct n.
+    exact tt.
+    refine (pair _ _ ).
+    exact (Vector.hd v).
+    exact (bv_to_nprod n (Vector.tl v)).
+  Defined.
+
+  #[refine] Instance NetlistCava : Cava := {
     cava_arrow := NetlistArr;
 
-    bit := One Bit;
-    bitvec n := One (BitVec n);
+    representable ty := match ty with
+    | Bit => One Bit
+    | BitVec xs => One (BitVec xs)
+    end;
 
     constant b _ := match b with
       | true => ret Vcc
@@ -178,7 +207,50 @@ Section NetlistEval.
       sum <- newWires s ;;
       addInstance (UnsignedAdd x y sum) ;;
       ret sum;
+
+    lut n f is :=
+      let seq := seq 0 (2^n) in
+      let f' := NaryFunctions.nuncurry bool bool n f in 
+      let powers := map
+        (fun p => let bv := Ndigits.N2Bv_sized n (N.of_nat p) in
+                  2^(N.of_nat p) * N.b2n (f' (bv_to_nprod n bv))
+        )%N
+        seq in
+      let config := fold_left N.add powers 0%N in
+      let component_name := ("LUT" ++ string_of_uint (Nat.to_uint n))%string in
+      let is_as_list := object_as_list n _ is in
+      let inputs := map 
+        (fun '(i, n) => ("I" ++ string_of_uint (Nat.to_uint i), n))%string 
+        (combine seq is_as_list) in
+      o <- newWire ;;
+      let component := 
+        Component
+        component_name [("INIT", HexLiteral (2^n) config)]
+        (("O", o) :: inputs) in
+      addInstance component;;
+      ret o;
+    
+    index_array x xs '(array, (index, _)) := 
+      o <- newWiresBitVec xs;;
+      addInstance (IndexAlt x xs array index o) ;;
+      ret _; 
+      
+    to_vec n o := _;
   }.
+  Proof.
+    - destruct xs; simpl in *; exact (o). 
+    - intros.
+      destruct o. 
+      * cbv [cat NetlistArr NetlistCat morphism].
+        intros.
+        apply object_as_list in X.
+        exact (ret X).
+      * cbv [cat NetlistArr NetlistCat morphism].
+        intros.
+        apply object_as_list in X.
+        simpl in *.
+        destruct l; exact (ret X).
+  Defined.
 
   Close Scope string_scope.
 

--- a/cava/cava/Cava/Arrow/Kappa/Syntax.v
+++ b/cava/cava/Cava/Arrow/Kappa/Syntax.v
@@ -94,7 +94,7 @@ Definition xilinxFullAdder
      let b = snd' ab in
      let part_sum = !xor_gate a b in
      let sum      = !xorcy part_sum cin in
-     let cout     = !muxcy part_sum cin a in
+     let cout     = !muxcy part_sum (cin, a) in
      (sum, cout)
   ]>.
 

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -135,6 +135,11 @@ Inductive Instance : Type :=
   (* Multiplexors *)
   | IndexBitArray: list Signal -> list Signal -> Signal -> Instance
   | IndexArray: list (list Signal) -> list Signal -> list Signal -> Instance
+  | IndexAlt: forall sz szs,
+      @denoteBitVecWith nat Signal (sz::szs) ->
+      list Signal ->
+      @denoteBitVecWith nat Signal szs
+      -> Instance
   | Component: string -> list (string * ConstExpr) -> list (string * Signal) ->
                Instance.
 

--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -51,11 +51,13 @@ library
                      Combinational
                      Constructive
                      Datatypes
+                     DecimalString
                      IdentityMonad
                      Kappa
                      List
                      Logic
                      Monad
+                     NaryFunctions
                      Netlist
                      Netlist0
                      Nat

--- a/cava/cava/FixupHaskell.hs
+++ b/cava/cava/FixupHaskell.hs
@@ -33,3 +33,5 @@ main
        writeFile "Ascii2.hs" (fixup asciiContent)
        bytevectorContent <- readFile "ByteVector.hs"
        writeFile "ByteVector2.hs" (fixup bytevectorContent)
+       decimalStringContent <- readFile "DecimalString.hs"
+       writeFile "DecimalString2.hs" (fixup decimalStringContent)

--- a/cava/cava/Makefile
+++ b/cava/cava/Makefile
@@ -28,6 +28,7 @@ haskell:	coq FixupHaskell
 		./FixupHaskell
 		mv Ascii2.hs Ascii.hs
 		mv ByteVector2.hs ByteVector.hs
+		mv DecimalString2.hs DecimalString.hs
 		runhaskell Setup.hs configure --user
 		runhaskell Setup.hs build
 		runhaskell Setup.hs install


### PR DESCRIPTION
Currently this generates a dummy Netlist instance `IndexAlt`. After switching Netlist `list`s back to vectors an indexing function will be created and this netlist constructor can be removed.