### PR TITLE
Support negative edges for clock and reset

### DIFF
--- a/cava/arrow-examples/ArrowAdder.v
+++ b/cava/arrow-examples/ArrowAdder.v
@@ -55,7 +55,7 @@ Definition fullAdder'
 Definition fullAdder Cava := toCava Cava (Closure_conversion fullAdder').
 
 Definition fullAdderInterface
-  := mkCircuitInterface "fullAdder"
+  := mkCombinationalInterface "fullAdder"
      (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
      (Tuple2 (One ("sum", Bit)) (One ("cout", Bit)))
      [].

--- a/cava/arrow-examples/Concatenative/Examples.v
+++ b/cava/arrow-examples/Concatenative/Examples.v
@@ -61,7 +61,7 @@ Section NetlistExamples.
   List.map (@nand Combinational) arrow_nand_tb_inputs.
 
   Definition nand2Interface
-    := mkCircuitInterface "nandArrow"
+    := mkCombinationalInterface "nandArrow"
        (Tuple2 (One ("input1", Bit)) (One ("input2", Bit)))
        (One ("output1", Bit))
        [].
@@ -84,7 +84,7 @@ Section NetlistExamples.
   List.map (@xor Combinational) arrow_xor_tb_inputs.
 
   Definition xorInterface
-    := mkCircuitInterface "xorArrow"
+    := mkCombinationalInterface "xorArrow"
        (Tuple2 (One ("input1", Bit)) (One ("input2", Bit)))
        (One ("output1", Bit))
        [].
@@ -130,6 +130,7 @@ Section NetlistExamples.
 
   Definition feedbackNandInterface
     := mkCircuitInterface "feedbackNandArrow"
+       "clk" PositiveEdge "rst" PositiveEdge
        (One ("input1", Bit))
        (One ("output1", Bit))
        [].

--- a/cava/arrow-examples/Mux2_1.v
+++ b/cava/arrow-examples/Mux2_1.v
@@ -42,7 +42,7 @@ Definition mux2_1 Cava := toCava Cava (Closure_conversion mux2_1').
 Local Open Scope string_scope.
 
 Definition mux2_1_Interface :=
-   mkCircuitInterface "mux2_1"
+   mkCombinationalInterface "mux2_1"
      (Tuple2 (One ("s", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
      (One ("o", Bit))
      [].

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -109,6 +109,10 @@ Inductive ConstExpr : Type :=
 | HexLiteral: nat -> N -> ConstExpr
 | StringLiteral: string -> ConstExpr.
 
+Inductive SignalEdge :=
+| PositiveEdge
+| NegativeEdge.
+
 Inductive Instance : Type :=
   (* I/O port wiring *)
   | WireInputBit:     string -> Signal -> Instance
@@ -162,10 +166,20 @@ Inductive CircuitAttribute :=
 
 Record CircuitInterface : Type := mkCircuitInterface {
   circuitName    : string;
+  clkName        : string;
+  clkEdge        : SignalEdge;
+  rstName        : string;
+  rstEdge        : SignalEdge;
   circuitInputs  : @shape (string * Kind);
   circuitOutputs : @shape (string * Kind);
   attributes : list CircuitAttribute;
 }.
+
+Definition mkCombinationalInterface circuitName circuitInputs circuitOutputs
+                                    attributes :=
+  mkCircuitInterface circuitName "" PositiveEdge
+                                 "" PositiveEdge
+                                 circuitInputs circuitOutputs attributes.
 
 Fixpoint shapeToPortDeclaration (s : @shape (string * Kind)) :
                                 list PortDeclaration :=
@@ -180,24 +194,27 @@ Fixpoint shapeToPortDeclaration (s : @shape (string * Kind)) :
 
 Record CavaState : Type := mkCavaState {
   netNumber : N;
-  isSequential : bool;
+  clockNet : Signal;
+  clockEdge: SignalEdge;
+  resetNet : Signal;
+  resetEdge : SignalEdge;
   module : Module;
 }.
 
 Definition newWire : state CavaState Signal :=
   cs <- get;;
   match cs with
-  | mkCavaState o isSeq m
-      => put (mkCavaState (o+1) isSeq m) ;;
+  | mkCavaState o clk clkEdge rst rstEdge m
+      => put (mkCavaState (o+1) clk clkEdge rst rstEdge m) ;;
          ret (Wire o)
   end.
 
 Definition newWires (width : nat) : state CavaState (list Signal) :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq m =>
+  | mkCavaState o clk clkEdge rst rstEdge m =>
       let outv := map N.of_nat (seq (N.to_nat o) width) in
-      put (mkCavaState (o + N.of_nat width) isSeq m) ;;
+      put (mkCavaState (o + N.of_nat width) clk clkEdge rst rstEdge m) ;;
       ret (map Wire outv)
   end.
 
@@ -206,8 +223,8 @@ Definition newWiresBitVec (sizes: list nat) : state CavaState (@denoteBitVecWith
   let wireCount := (bitsInPortShape (One (BitVec sizes)))%N in
   let bv := numberBitVec 0 sizes sizes in
   match cs with
-  | mkCavaState o isSeq m =>
-      put (mkCavaState (o + N.of_nat wireCount) isSeq m) ;;
+  | mkCavaState o clk clkEdge rst rstEdge m =>
+      put (mkCavaState (o + N.of_nat wireCount) clk clkEdge rst rstEdge m) ;;
       ret bv
   end.
 
@@ -225,8 +242,8 @@ Fixpoint newWiresFromShape (s: bundle) : state CavaState (signalTy Signal s) :=
 Definition addInstance (newInst: Instance) : state CavaState unit :=
   cs <- get;;
   match cs with
-  | mkCavaState o isSeq (mkModule name insts inputs outputs)
-    => put (mkCavaState o isSeq (mkModule name (newInst::insts) inputs outputs))
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule name insts inputs outputs)
+    => put (mkCavaState o clk clkEdge rst rstEdge (mkModule name (newInst::insts) inputs outputs))
   end.
 
 Fixpoint addInstances (insts: list Instance) : state CavaState unit :=
@@ -240,8 +257,8 @@ Fixpoint addInstances (insts: list Instance) : state CavaState unit :=
 Definition addSequentialInstance (newInst: Instance) : state CavaState unit :=
   cs <- get;;
   match cs with
-  | mkCavaState o _ (mkModule name insts inputs outputs)
-    => put (mkCavaState o true (mkModule name (newInst::insts) inputs outputs))
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule name insts inputs outputs)
+    => put (mkCavaState o clk clkEdge rst rstEdge (mkModule name (newInst::insts) inputs outputs))
   end.
 
 Fixpoint addSequentialInstances (insts: list Instance) : state CavaState unit :=
@@ -252,11 +269,21 @@ Fixpoint addSequentialInstances (insts: list Instance) : state CavaState unit :=
     addSequentialInstances xs
   end.
 
-Definition addPort (newPort: PortDeclaration) : state CavaState unit :=
+Definition addInputPort (newPort: PortDeclaration) : state CavaState unit :=
+  cs <- get ;;
+  match newPort with
+  | mkPort "" _ => ret tt (* Clock or reset not used *)
+  | _ => match cs with
+         | mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs outputs) =>
+           put (mkCavaState o clk clkEdge rst rstEdge (mkModule n insts (cons newPort inputs) outputs))
+         end
+  end.
+
+Definition addOutputPort (newPort: PortDeclaration) : state CavaState unit :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq (mkModule n insts inputs outputs) =>
-      put (mkCavaState o isSeq (mkModule n insts (cons newPort inputs) outputs))
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs outputs) =>
+      put (mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs (cons newPort outputs)))
   end.
 
 (******************************************************************************)
@@ -266,40 +293,59 @@ Definition addPort (newPort: PortDeclaration) : state CavaState unit :=
 Definition setModuleName (name : string) : state CavaState unit :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq (mkModule _ insts inputs outputs)
-     => put (mkCavaState o isSeq (mkModule name insts inputs outputs))
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule _ insts inputs outputs)
+     => put (mkCavaState o clk clkEdge rst rstEdge (mkModule name insts inputs outputs))
   end.
 
+Definition setClockAndReset (clk_and_edge: Signal * SignalEdge)
+                            (rst_and_edge: Signal * SignalEdge)
+                            : state CavaState unit :=
+  let (clk, clkEdge) := clk_and_edge in
+  let (rst, rstEdge) := rst_and_edge in
+  cs <- get ;;
+  match cs with
+  | mkCavaState o _ _ _ _ m
+     => put (mkCavaState o clk clkEdge rst rstEdge m)
+  end.
+
+Definition getClockAndReset : state CavaState ((Signal * SignalEdge) *
+                                               (Signal * SignalEdge)) :=
+  cs <- get ;;
+  match cs with
+  | mkCavaState _ clk clkEdge rst rstEdge _ =>
+     ret ((clk, clkEdge), (rst, rstEdge))
+  end.                                       
+
 Definition inputBit (name : string) : state CavaState Signal :=
-  addPort (mkPort name Bit) ;;
+  addInputPort (mkPort name Bit) ;;
   ret (NamedWire name).
 
 Definition inputVectorTo0 (sizes : list nat) (name : string) : state CavaState (@denoteBitVecWith nat Signal sizes) :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs outputs)
      => let newPort := mkPort name (BitVec sizes) in
-        addPort newPort ;;
+        addInputPort newPort ;;
         ret (smashBitVec name sizes sizes [])
   end.
 
 Definition outputBit (name : string) (i : Signal) : state CavaState Signal :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs outputs)
      => let newPort := mkPort name Bit in
         let insts' := WireOutputBit name i :: insts in
-        put (mkCavaState o isSeq (mkModule n insts' inputs (newPort :: outputs))) ;;
+        put (mkCavaState o clk clkEdge rst rstEdge (mkModule n insts' inputs (newPort :: outputs))) ;;
         ret i
   end.
 
 Definition outputVectorTo0 (sizes : list nat) (v : @denoteBitVecWith nat Signal sizes) (name : string) : state CavaState unit :=
   cs <- get ;;
   match cs with
-  | mkCavaState o isSeq (mkModule n insts inputs outputs)
+  | mkCavaState o clk clkEdge rst rstEdge (mkModule n insts inputs outputs)
      => let newPort := mkPort name (BitVec sizes) in
         let insts' := WireOutputBitVec sizes name v :: insts in
-        put (mkCavaState o isSeq (mkModule n insts' inputs (newPort :: outputs))) ;;
+        put (mkCavaState o clk clkEdge rst rstEdge (mkModule n insts' inputs (newPort :: outputs))) ;;
         ret tt
   end.
 
@@ -312,7 +358,8 @@ Definition outputVectorTo0 (sizes : list nat) (v : @denoteBitVecWith nat Signal 
 *)
 
 Definition initStateFrom (startAt : N) : CavaState
-  := mkCavaState startAt false (mkModule "noname" [] [] []).
+  := mkCavaState startAt UndefinedSignal PositiveEdge UndefinedSignal PositiveEdge
+                 (mkModule "noname" [] [] []).
 
 Definition initState : CavaState
   := initStateFrom 0.
@@ -351,6 +398,9 @@ Definition wireUpCircuit (intf : CircuitInterface)
 
                          : state CavaState unit  :=
   setModuleName (circuitName intf) ;;
+  setClockAndReset (NamedWire (clkName intf), clkEdge intf) (NamedWire (rstName intf), rstEdge intf) ;;
+  addInputPort (mkPort (clkName intf) Bit) ;;
+  addInputPort (mkPort (rstName intf) Bit) ;;
   i <- instantiateInputPorts (circuitInputs intf) ;;
   o <- circuit i ;;
   mapShapeM_ instantiateOutputPort (zipShapes (circuitOutputs intf) (toSignal o)).

--- a/cava/cava/Cava/Signal.v
+++ b/cava/cava/Cava/Signal.v
@@ -18,6 +18,7 @@ From Coq Require Import Ascii String.
 From Coq Require Import ZArith.
 
 Inductive Signal : Type :=
+  | UndefinedSignal : Signal
   | Gnd: Signal
   | Vcc: Signal
   | Wire: N -> Signal

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -80,7 +80,7 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name nrInputs bitSize
-  := mkCircuitInterface name
+  := mkCombinationalInterface name
      (One ("inputs", BitVec [nrInputs; bitSize]))
      (One ("sum", BitVec [bitSize + Nat.log2_up nrInputs]))
      [].

--- a/cava/monad-examples/FullAdder.v
+++ b/cava/monad-examples/FullAdder.v
@@ -46,7 +46,7 @@ Definition halfAdder {m t} `{Cava m t} '(a, b) :=
   ret (partial_sum, carry).
 
 Definition halfAdderInterface
-  := mkCircuitInterface "halfadder"
+  := mkCombinationalInterface "halfadder"
      (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
      (Tuple2 (One ("partial_sum", Bit)) (One ("carry", Bit)))
      [].
@@ -73,7 +73,7 @@ Definition fullAdder {m t} `{Cava m t} '(cin, (a, b)) :=
   ret (abcl, cout).
 
 Definition fullAdderInterface
-  := mkCircuitInterface "fullAdder"
+  := mkCombinationalInterface "fullAdder"
      (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
      (Tuple2 (One ("sum", Bit)) (One ("carry", Bit)))
      [].

--- a/cava/monad-examples/Multiplexers.v
+++ b/cava/monad-examples/Multiplexers.v
@@ -51,7 +51,7 @@ Example m4: combinational (mux2_1 (true, (true, false))) = false.
 Proof. reflexivity. Qed.
 
 Definition mux2_1_Interface
-  := mkCircuitInterface "mux2_1"
+  := mkCombinationalInterface "mux2_1"
      (Tuple2 (One ("sel", Bit)) (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))))
      (One ("o", Bit))
      [].
@@ -64,12 +64,12 @@ Definition mux2_1_tb_inputs :=
    (true, (false, true));
     (true, (true, false))].
 
-Definition mux2_1_tb_xpected_outputs
+Definition mux2_1_tb_expected_outputs
   := map (fun i => combinational (mux2_1 i)) mux2_1_tb_inputs.
 
 Definition mux2_1_tb
   := testBench "mux2_1_tb" mux2_1_Interface
-     mux2_1_tb_inputs mux2_1_tb_xpected_outputs.
+     mux2_1_tb_inputs mux2_1_tb_expected_outputs.
 
 Definition muxBus {m bit} `{Cava m bit} '(sel, i) : m (list bit) :=
   o <- indexArray i sel ;;
@@ -94,7 +94,7 @@ Example m8: combinational (muxBus ([true; true], v)) = v3.
 Proof. reflexivity. Qed.
 
 Definition muxBus4_8Interface
-  := mkCircuitInterface "muxBus4_8"
+  := mkCombinationalInterface "muxBus4_8"
      (Tuple2 (One ("sel", BitVec [2])) (One ("i", BitVec [4; 8])))
      (One ("o", BitVec [8]))
      [].

--- a/cava/monad-examples/NandGate.v
+++ b/cava/monad-examples/NandGate.v
@@ -38,7 +38,7 @@ Local Open Scope string_scope.
    description. *)
 
 Definition nand2Interface
-  := mkCircuitInterface "nand2"
+  := mkCombinationalInterface "nand2"
      (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
      (One ("c", Bit))
      [].
@@ -102,11 +102,13 @@ Definition pipelinedNAND {m t} `{Cava m t}
 
 Definition pipelinedNANDInterface
   := mkCircuitInterface "pipelinedNAND"
+     "clk" PositiveEdge "rst" PositiveEdge
      (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
      (One ("c", Bit))
      [].
 
-Definition pipelinedNANDNetlist := makeNetlist pipelinedNANDInterface pipelinedNAND.
+Definition pipelinedNANDNetlist :=
+  makeNetlist pipelinedNANDInterface pipelinedNAND.
 
 Definition pipelinedNAND_tb_inputs
   := [(false, false);
@@ -119,7 +121,6 @@ Definition pipelinedNAND_tb_inputs
 
 Definition pipelinedNAND_tb_expected_outputs
   := [false; true; false; false; false; true; false].
-
 
 Definition pipelinedNAND_tb
   := testBench "pipelinedNAND_tb" pipelinedNANDInterface
@@ -134,6 +135,7 @@ Definition loopedNAND {m bit} `{Cava m bit}
 
 Definition loopedNANDInterface
   := mkCircuitInterface "loopedNAND"
+     "clk" PositiveEdge "rst" PositiveEdge
      (One ("a", Bit))
      (One ("b", Bit))
      [].

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -70,7 +70,7 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder4Interface
-  := mkCircuitInterface "adder4"
+  := mkCombinationalInterface "adder4"
      (Tuple2 (One ("a", BitVec [4])) (One ("b", BitVec [4])))
      (One ("sum", BitVec [5]))
      [].
@@ -93,7 +93,7 @@ Definition adder4_tb
 (******************************************************************************)
 
 Definition adder8_3inputInterface
-  := mkCircuitInterface "adder8_3input"
+  := mkCombinationalInterface "adder8_3input"
      (Tuple2 (One ("a", BitVec [8])) (Tuple2 (One ("b", BitVec [8])) (One ("c", BitVec [8]))))
      (One ("sum", BitVec [10]))
      [].

--- a/cava/monad-examples/xilinx/NandLUT.v
+++ b/cava/monad-examples/xilinx/NandLUT.v
@@ -39,7 +39,7 @@ Definition lutNAND {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
   ret z.
 
 Definition lutNANDInterface
-  := mkCircuitInterface "lutNAND"
+  := mkCombinationalInterface "lutNAND"
      (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
      (One ("c", Bit))
      [].

--- a/cava/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/cava/monad-examples/xilinx/XilinxAdderExamples.v
@@ -37,7 +37,6 @@ Local Open Scope string_scope.
 (* A few tests to check the unsigned adder.        *)
 (****************************************************************************)
 
-
 Definition v0   := [0;0;0;0;0;0;0;0].
 Definition v1   := [1;0;0;0;0;0;0;0].
 Definition v2   := [0;1;0;0;0;0;0;0].
@@ -82,7 +81,7 @@ Proof. reflexivity. Qed.
 (****************************************************************************)
 
 Definition adder8Interface
-  := mkCircuitInterface "adder8"
+  := mkCombinationalInterface "adder8"
      (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", BitVec [8])) (One ("b", BitVec [8]))))
      (Tuple2 (One ("sum", BitVec [8])) (One ("cout", Bit)))
      [].

--- a/cava/monad-examples/xilinx/XilinxAdderTree.v
+++ b/cava/monad-examples/xilinx/XilinxAdderTree.v
@@ -84,7 +84,7 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name degree bitSize
-  := mkCircuitInterface name
+  := mkCombinationalInterface name
      (One ("inputs", BitVec [2^(degree + 1); bitSize]))
      (One ("sum", BitVec [bitSize + degree + 1]))
      [].

--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -22,6 +22,7 @@ Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Monad.Cava.
 Require Import Cava.Netlist.
+Require Import Cava.Types.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
@@ -36,7 +37,7 @@ Definition lut1_inv {m bit} `{Cava m bit} (i: bit) : m bit :=
   ret o.
 
 Definition lut1_inv_Interface
-  := mkCircuitInterface "lut1_inv" (One ("a", Bit)) (One ("b", Bit)) [].
+  := mkCombinationalInterface "lut1_inv" (One ("a", Bit)) (One ("b", Bit)) [].
 
 Definition lut1_inv_netlist := makeNetlist lut1_inv_Interface lut1_inv.
 
@@ -58,7 +59,7 @@ Definition lut2_and {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
   ret o.
 
 Definition lut2_and_Interface
-  := mkCircuitInterface "lut2_and"
+  := mkCombinationalInterface "lut2_and"
      (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
      (One ("c", Bit))
      [].
@@ -86,7 +87,7 @@ Definition lut3_mux {m bit} `{Cava m bit}
   ret o.
 
 Definition lut3_mux_Interface
-  := mkCircuitInterface "lut3_mux"
+  := mkCombinationalInterface "lut3_mux"
      (Tuple2 (One ("s", Bit))
              (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))))
      (One ("o", Bit))
@@ -124,7 +125,7 @@ Definition lut4_and {m bit} `{Cava m bit}
    find a better way. Satnam.
 *)
 Definition lut4_and_Interface
-  := mkCircuitInterface "lut4_and"
+  := mkCombinationalInterface "lut4_and"
      (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
                      (One ("i2", Bit)))
              (One ("i3", Bit))
@@ -160,7 +161,7 @@ Definition lut5_and {m bit} `{Cava m bit}
    find a better way. Satnam.
 *)
 Definition lut5_and_Interface
-  := mkCircuitInterface "lut5_and"
+  := mkCombinationalInterface "lut5_and"
      (Tuple2 (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
                      (One ("i2", Bit)))
              (One ("i3", Bit))) (One ("i4", Bit))
@@ -196,7 +197,7 @@ Definition lut6_and {m bit} `{Cava m bit}
    find a better way. Satnam.
 *)
 Definition lut6_and_Interface
-  := mkCircuitInterface "lut6_and"
+  := mkCombinationalInterface "lut6_and"
      (Tuple2 (Tuple2 (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
                      (One ("i2", Bit)))
              (One ("i3", Bit))) (One ("i4", Bit))) (One ("i5", Bit))


### PR DESCRIPTION
Signed-off-by: Satnam Singh <satnam@google.com>

The circuit interface mechanism is tweaked to add information and the names and edge-behaviour of clock and reset inputs.