### PR TITLE
Pinmux top level stub

### DIFF
--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -152,6 +152,7 @@ end.
 Reserved Notation "'bit'" (at level 1, no associativity).
 Reserved Notation "'bitvec' n" (at level 1, no associativity).
 Reserved Notation "'bitvec_index' n" (at level 1, no associativity).
+Reserved Notation "'extern'" (at level 1, no associativity).
 
 (* Cava *)
 Class Cava  := {
@@ -160,7 +161,8 @@ Class Cava  := {
   representable : Kind -> object
     where "'bit'" := (representable Bit)
     and   "'bitvec' n" := (representable (BitVec n))
-    and   "'bitvec_index' n" := (bitvec [PeanoNat.Nat.log2_up n]);
+    and   "'bitvec_index' n" := (bitvec [PeanoNat.Nat.log2_up n])
+    and   "'extern'" := (representable (ExternalType ""));
 
   constant : bool -> (unit ~> bit);
   constant_vec (dimensions: list nat) : denoteBitVecWith bool dimensions -> (unit ~> bitvec dimensions);
@@ -191,6 +193,7 @@ Class Cava  := {
     match o with
     | Bit => replicate_object (S n) bit ~> bitvec [S n]
     | BitVec xs => replicate_object (S n) (bitvec xs) ~> bitvec (S n::xs)
+    | ExternalType _ => replicate_object (S n) bit ~> bitvec [S n] (* dummy definition *)
     end;
 }.
 

--- a/cava/cava/Cava/Arrow/Instances/Combinational.v
+++ b/cava/cava/Cava/Arrow/Instances/Combinational.v
@@ -106,6 +106,7 @@ Section CoqEval.
     representable t := match t with
       | Bit => bool
       | BitVec xs => denoteBitVecWith bool xs
+      | ExternalType t => unit
       end;
 
     constant b _ := b;
@@ -166,6 +167,8 @@ Section CoqEval.
         unfold denoteBitVecWith.
         apply nprod_to_list.
         cbv [cat CoqArr CoqCat morphism denoteBitVecWith].
+        apply nprod_to_list.
+      * cbv [cat CoqArr CoqCat morphism].
         apply nprod_to_list.
   Defined.
 

--- a/cava/cava/Cava/Arrow/Instances/Constructive.v
+++ b/cava/cava/Cava/Arrow/Instances/Constructive.v
@@ -129,6 +129,7 @@ Definition denoteKind `{Cava} (k: Kind)
 match k with
 | Bit       => bit
 | BitVec n  => bitvec n
+| ExternalType t => unit
 end.
 
 Fixpoint denoteShape `{Cava} (t: shape)
@@ -313,6 +314,7 @@ Proof.
   rewrite IHn.
   reflexivity.
 Qed.
+
 Lemma Nobj_bit_is_replicate_object_leaf_bitvec: forall n xs, Nobj n (BitVec xs) = @replicate_object ConstructiveArr n (One (BitVec xs)).
 Proof.
   intros.
@@ -325,6 +327,7 @@ Qed.
   representable ty := match ty with
   | Bit => One Bit
   | BitVec xs => One (BitVec xs)
+  | ExternalType t => One (ExternalType t)
   end;
 
   constant b := Constant b;
@@ -359,4 +362,6 @@ Proof.
   exact (BitToVec n).
   rewrite <- Nobj_bit_is_replicate_object_leaf_bitvec.
   exact (BitVecToVec n l).
+  rewrite <- Nobj_bit_is_replicate_object_leaf_bit.
+  exact (BitToVec n).
 Defined.

--- a/cava/cava/Cava/Arrow/Instances/Netlist.v
+++ b/cava/cava/Cava/Arrow/Instances/Netlist.v
@@ -141,6 +141,7 @@ Section NetlistEval.
     representable ty := match ty with
     | Bit => One Bit
     | BitVec xs => One (BitVec xs)
+    | ExternalType t => One (ExternalType t)
     end;
 
     constant b _ := match b with
@@ -250,6 +251,10 @@ Section NetlistEval.
         apply object_as_list in X.
         simpl in *.
         destruct l; exact (ret X).
+      * cbv [cat NetlistArr NetlistCat morphism].
+        intros.
+        apply object_as_list in X.
+        exact (ret X).
   Defined.
 
   Close Scope string_scope.
@@ -259,6 +264,7 @@ Section NetlistEval.
     match port in Kind, x, y return denoteKindWith port C with
     | Bit, x, y => f x y
     | BitVec sz, xs, ys => mapBitVec (fun '(x,y) => f x y) sz sz (zipBitVecs sz sz xs ys)
+    | ExternalType t, x, y => f x y
     end .
 
   Fixpoint linkShapes {A B}

--- a/cava/opentitan/pinmux/Makefile
+++ b/cava/opentitan/pinmux/Makefile
@@ -1,0 +1,29 @@
+#
+# Copyright 2020 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+.PHONY: all coq clean
+
+all:		coq
+
+VERILATOR = verilator +1800-2012ext+sv verilator.vlt
+VLINT = $(VERILATOR) --lint-only
+
+Makefile.coq:	_CoqProject
+		coq_makefile -f _CoqProject -o Makefile.coq
+
+coq:		Makefile.coq
+		$(MAKE) -f Makefile.coq
+

--- a/cava/opentitan/pinmux/Pinmux.v
+++ b/cava/opentitan/pinmux/Pinmux.v
@@ -1,0 +1,63 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Ascii String.
+Local Open Scope string_scope.
+
+From Coq Require Import Lists.List.
+Import ListNotations.
+Local Open Scope list_scope.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+Open Scope monad_scope.
+
+Require Import Cava.Monad.Cava.
+Require Import Cava.Netlist.
+Require Import Cava.Signal.
+Require Import Cava.Types.
+
+Definition NPeriphIn := 32.
+Definition NPeriphOut := 32.
+Definition NMioPads := 32.
+
+Definition pinmuxInterface :=
+  mkCircuitInterface "pinmux"
+     "clk_i" PositiveEdge "rst_ni" NegativeEdge
+     (tuple [One ("tl_i", ExternalType "tlul_pkg::tl_h2d_t");
+             One ("periph_to_mio_i", BitVec [NPeriphOut-1]);
+             One ("periph_to_mio_oe_i", BitVec [NPeriphOut-1]);
+             One ("mio_in_i", BitVec [NMioPads-1])])
+     (tuple [One ("tl_o", ExternalType "tlul_pkg::tl_d2h_t ");
+             One ("mio_to_periph_o", BitVec [NPeriphIn-1]);
+             One ("mio_out_o", BitVec [NMioPads-1]);
+             One ("mio_oe_o", BitVec [NMioPads-1])])
+     [].
+
+Definition pinmux {m bit} `{Cava m bit}
+                  (inputs: string *
+                           list bit *
+                           list bit *
+                           list bit) :
+                  m (string *
+                     list bit *
+                     list bit *
+                     list bit)%type :=
+  let '(tl_i, periph_to_mio_i, periph_to_mio_oe_i, mio_in_i) := inputs in
+  z <- zero ;;
+  ret ("xxx", repeat z NPeriphIn, repeat z NMioPads, repeat z NMioPads).
+
+(* Definition pinmux_netlist := makeNetlist pinmuxInterface pinmux. *)

--- a/cava/opentitan/pinmux/_CoqProject
+++ b/cava/opentitan/pinmux/_CoqProject
@@ -1,0 +1,2 @@
+-R ../../cava/Cava Cava
+Pinmux.v


### PR DESCRIPTION
A first cut at a stub for the top-level pinmux. Several dummy definitions for now to accommodate a new signal value to represent uninterpreted types.