### PR TITLE
Remove Shape constructors from interface specifications.

### DIFF
--- a/cava/arrow-examples/ArrowAdder.v
+++ b/cava/arrow-examples/ArrowAdder.v
@@ -55,9 +55,9 @@ Definition fullAdder'
 Definition fullAdder Cava := toCava Cava (Closure_conversion fullAdder').
 
 Definition fullAdderInterface
-  := mkCombinationalInterface "fullAdder"
-     (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
-     (Tuple2 (One ("sum", Bit)) (One ("cout", Bit)))
+  := combinationalInterface "fullAdder"
+     (mkPort "cin" Bit, (mkPort "a" Bit, mkPort "b" Bit))
+     (mkPort "sum" Bit, mkPort "cout" Bit)
      [].
 
 Definition fullAdder_tb_inputs :=

--- a/cava/arrow-examples/Concatenative/Examples.v
+++ b/cava/arrow-examples/Concatenative/Examples.v
@@ -61,9 +61,9 @@ Section NetlistExamples.
   List.map (@nand Combinational) arrow_nand_tb_inputs.
 
   Definition nand2Interface
-    := mkCombinationalInterface "nandArrow"
-       (Tuple2 (One ("input1", Bit)) (One ("input2", Bit)))
-       (One ("output1", Bit))
+    := combinationalInterface "nandArrow"
+       (mkPort "input1" Bit, mkPort "input2" Bit)
+       (mkPort "output1" Bit)
        [].
 
   Definition nandArrow :=
@@ -84,9 +84,9 @@ Section NetlistExamples.
   List.map (@xor Combinational) arrow_xor_tb_inputs.
 
   Definition xorInterface
-    := mkCombinationalInterface "xorArrow"
-       (Tuple2 (One ("input1", Bit)) (One ("input2", Bit)))
-       (One ("output1", Bit))
+    := combinationalInterface "xorArrow"
+       (mkPort "input1" Bit, mkPort "input2" Bit)
+       (mkPort "output1" Bit)
        [].
 
   Definition xorArrow :=
@@ -129,10 +129,10 @@ Section NetlistExamples.
   ].
 
   Definition feedbackNandInterface
-    := mkCircuitInterface "feedbackNandArrow"
+    := sequentialInterface "feedbackNandArrow"
        "clk" PositiveEdge "rst" PositiveEdge
-       (One ("input1", Bit))
-       (One ("output1", Bit))
+       (mkPort "input1" Bit)
+       (mkPort "output1" Bit)
        [].
 
   Definition feedbackNandArrow :=

--- a/cava/arrow-examples/Mux2_1.v
+++ b/cava/arrow-examples/Mux2_1.v
@@ -42,9 +42,9 @@ Definition mux2_1 Cava := toCava Cava (Closure_conversion mux2_1').
 Local Open Scope string_scope.
 
 Definition mux2_1_Interface :=
-   mkCombinationalInterface "mux2_1"
-     (Tuple2 (One ("s", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
-     (One ("o", Bit))
+   combinationalInterface "mux2_1"
+     (mkPort "s" Bit, (mkPort "a" Bit, mkPort "b" Bit))
+     (mkPort "o" Bit)
      [].
 
 Definition mux2_1_netlist :=

--- a/cava/cava/Cava/Signal.v
+++ b/cava/cava/Cava/Signal.v
@@ -19,6 +19,7 @@ From Coq Require Import ZArith.
 
 Inductive Signal : Type :=
   | UndefinedSignal : Signal
+  | UninterpretedSignal: string -> Signal
   | Gnd: Signal
   | Vcc: Signal
   | Wire: N -> Signal

--- a/cava/cava/Cava/Types.v
+++ b/cava/cava/Cava/Types.v
@@ -111,6 +111,21 @@ Fixpoint withoutRightmostUnit {A} (s: @shape A): shape :=
   | Tuple2 t1 t2 =>  Tuple2 t1 (withoutRightmostUnit t2)
   end.
 
+(* Convert values to shape values *)
+
+Class ToShape {a} t := {
+  toShape: t -> @shape a;
+}.
+
+Instance ShapeOne {A: Type}: ToShape A := {
+   toShape t := One t;
+}.
+
+Instance ToShapePair2 {A t1 t2 : Type} `{@ToShape A t1} `{@ToShape A t2}:
+                     @ToShape A (t1 * t2) := {
+  toShape '(a, b) := @Tuple2 A (toShape a) (toShape b);
+}.
+
 (******************************************************************************)
 (* Values of Kind can occur as the type of signals on a circuit interface *)
 (******************************************************************************)

--- a/cava/cava/Cava2SystemVerilog.hs
+++ b/cava/cava/Cava2SystemVerilog.hs
@@ -425,25 +425,25 @@ generateTestBench testBench
     where
     intf = testBenchInterface testBench
     name = circuitName intf
-    inputPortList = shapeToPortDeclaration (circuitInputs intf)
-    outputPortList = shapeToPortDeclaration (circuitOutputs intf)
+    inputPortList = flattenShape (circuitInputs intf)
+    outputPortList = flattenShape (circuitOutputs intf)
     nrTests = length (testBenchInputs testBench)
 
-declareCircuitPorts :: Coq_shape (String, Kind) -> [String]
+declareCircuitPorts :: Coq_shape PortDeclaration -> [String]
 declareCircuitPorts shape
   = insertCommas (map declareCircuitPort portList)
     where
-    portList :: [PortDeclaration]  = shapeToPortDeclaration shape
+    portList :: [PortDeclaration]  = flattenShape shape
 
 declareCircuitPort :: PortDeclaration -> String
 declareCircuitPort port
   = "  output " ++ declarePort port
 
-declareLocalPorts :: Coq_shape (String, Kind) -> [String]
+declareLocalPorts :: Coq_shape PortDeclaration -> [String]
 declareLocalPorts shape
   = map declareLocalPort portList
     where
-    portList :: [PortDeclaration]  = shapeToPortDeclaration shape
+    portList :: [PortDeclaration] = flattenShape shape
 
 declareLocalPort :: PortDeclaration -> String
 declareLocalPort port

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -80,9 +80,9 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name nrInputs bitSize
-  := mkCombinationalInterface name
-     (One ("inputs", BitVec [nrInputs; bitSize]))
-     (One ("sum", BitVec [bitSize + Nat.log2_up nrInputs]))
+  := combinationalInterface name
+     (mkPort "inputs" (BitVec [nrInputs; bitSize]))
+     (mkPort "sum" (BitVec [bitSize + Nat.log2_up nrInputs]))
      [].
 
 (* Create netlist and test-bench for a 4-input adder tree. *)

--- a/cava/monad-examples/FullAdder.v
+++ b/cava/monad-examples/FullAdder.v
@@ -46,9 +46,9 @@ Definition halfAdder {m t} `{Cava m t} '(a, b) :=
   ret (partial_sum, carry).
 
 Definition halfAdderInterface
-  := mkCombinationalInterface "halfadder"
-     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
-     (Tuple2 (One ("partial_sum", Bit)) (One ("carry", Bit)))
+  := combinationalInterface "halfadder"
+     (mkPort "a" Bit, mkPort "b" Bit)
+     (mkPort "partial_sum" Bit, mkPort "carry" Bit)
      [].
 
 Definition halfAdderNetlist := makeNetlist halfAdderInterface halfAdder.
@@ -61,7 +61,6 @@ Proof.
   auto.
 Qed.
 
-
 (******************************************************************************)
 (* Build a full-adder                                                         *)
 (******************************************************************************)
@@ -73,9 +72,9 @@ Definition fullAdder {m t} `{Cava m t} '(cin, (a, b)) :=
   ret (abcl, cout).
 
 Definition fullAdderInterface
-  := mkCombinationalInterface "fullAdder"
-     (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", Bit)) (One ("b", Bit))))
-     (Tuple2 (One ("sum", Bit)) (One ("carry", Bit)))
+  := combinationalInterface "fullAdder"
+     (mkPort "cin" Bit, (mkPort "a" Bit, mkPort "b" Bit))
+     (mkPort "sum" Bit, mkPort "carry" Bit)
      [].
 
 Definition fullAdderNetlist := makeNetlist fullAdderInterface fullAdder.

--- a/cava/monad-examples/Multiplexers.v
+++ b/cava/monad-examples/Multiplexers.v
@@ -51,9 +51,9 @@ Example m4: combinational (mux2_1 (true, (true, false))) = false.
 Proof. reflexivity. Qed.
 
 Definition mux2_1_Interface
-  := mkCombinationalInterface "mux2_1"
-     (Tuple2 (One ("sel", Bit)) (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))))
-     (One ("o", Bit))
+  := combinationalInterface "mux2_1"
+     (mkPort "sel" Bit, (mkPort "i0" Bit, mkPort "i1" Bit))
+     (mkPort "o" Bit)
      [].
 
 Definition mux2_1Netlist := makeNetlist mux2_1_Interface mux2_1.
@@ -94,9 +94,9 @@ Example m8: combinational (muxBus ([true; true], v)) = v3.
 Proof. reflexivity. Qed.
 
 Definition muxBus4_8Interface
-  := mkCombinationalInterface "muxBus4_8"
-     (Tuple2 (One ("sel", BitVec [2])) (One ("i", BitVec [4; 8])))
-     (One ("o", BitVec [8]))
+  := combinationalInterface "muxBus4_8"
+     (mkPort "sel" (BitVec [2]), mkPort "i" (BitVec [4; 8]))
+     (mkPort "o" (BitVec [8]))
      [].
 
 Definition muxBus4_8Netlist := makeNetlist muxBus4_8Interface muxBus.

--- a/cava/monad-examples/NandGate.v
+++ b/cava/monad-examples/NandGate.v
@@ -34,13 +34,16 @@ Local Open Scope list_scope.
 Local Open Scope monad_scope.
 Local Open Scope string_scope.
 
+Generalizable All Variables.
+
 (* NAND gate example. Fist, let's define an overloaded NAND gate
    description. *)
 
 Definition nand2Interface
-  := mkCombinationalInterface "nand2"
-     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
-     (One ("c", Bit))
+  := combinationalInterface
+     "nand2"
+     (mkPort "a" Bit, mkPort "b" Bit)
+     (mkPort "c" Bit)
      [].
 
 Definition nand2_gate {m t} `{Cava m t} := and2 >=> inv.
@@ -86,10 +89,10 @@ Definition pipelinedNAND {m t} `{Cava m t}
   := nand2_gate >=> delayBit >=> inv >=> delayBit.
 
 Definition pipelinedNANDInterface
-  := mkCircuitInterface "pipelinedNAND"
+  := sequentialInterface "pipelinedNAND"
      "clk" PositiveEdge "rst" PositiveEdge
-     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
-     (One ("c", Bit))
+     (mkPort "a" Bit, mkPort "b" Bit)
+     (mkPort "c"  Bit)
      [].
 
 Definition pipelinedNANDNetlist :=
@@ -119,10 +122,10 @@ Definition loopedNAND {m bit} `{Cava m bit}
   := loopBit (second delayBit >=> nand2 >=> fork2).
 
 Definition loopedNANDInterface
-  := mkCircuitInterface "loopedNAND"
+  := sequentialInterface "loopedNAND"
      "clk" PositiveEdge "rst" PositiveEdge
-     (One ("a", Bit))
-     (One ("b", Bit))
+     (mkPort "a" Bit)
+     (mkPort "b" Bit)
      [].
 
 Definition loopedNANDNetlist := makeNetlist loopedNANDInterface loopedNAND.

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -70,9 +70,9 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder4Interface
-  := mkCombinationalInterface "adder4"
-     (Tuple2 (One ("a", BitVec [4])) (One ("b", BitVec [4])))
-     (One ("sum", BitVec [5]))
+  := combinationalInterface "adder4"
+     (mkPort "a" (BitVec [4]), mkPort "b" (BitVec [4]))
+     (mkPort "sum" (BitVec [5]))
      [].
 
 Definition adder4Netlist
@@ -93,24 +93,24 @@ Definition adder4_tb
 (******************************************************************************)
 
 Definition adder8_3inputInterface
-  := mkCombinationalInterface "adder8_3input"
-     (Tuple2 (One ("a", BitVec [8])) (Tuple2 (One ("b", BitVec [8])) (One ("c", BitVec [8]))))
-     (One ("sum", BitVec [10]))
+  := combinationalInterface "adder8_3input"
+     (mkPort "a" (BitVec [8]), mkPort "b" (BitVec [8]), mkPort "c" (BitVec [8]))
+     (mkPort "sum" (BitVec [10]))
      [].
 
 Definition adder8_3inputNetlist
   := makeNetlist adder8_3inputInterface
-     (fun '(a, (b, c)) => adder_3input a b c).
+     (fun '(a, b, c) => adder_3input a b c).
 
 Local Open Scope N_scope.
 
 Definition adder8_3input_tb_inputs :=
-  map (fun '(x, (y, z)) => (nat_to_list_bits_sized 8 x,
-                            (nat_to_list_bits_sized 8 y, nat_to_list_bits_sized 8 z)))
-  [(17, (23, 95)); (4, (200, 30)); (255, (255, 200))].
+  map (fun '(x, y, z) => (nat_to_list_bits_sized 8 x,
+                          nat_to_list_bits_sized 8 y, nat_to_list_bits_sized 8 z))
+  [(17, 23, 95); (4, 200, 30); (255, 255, 200)].
 
 Definition adder8_3input_tb_expected_outputs :=
-  map (fun '(a, (b, c)) => combinational (adder_3input a b c)) adder8_3input_tb_inputs.
+  map (fun '(a, b, c) => combinational (adder_3input a b c)) adder8_3input_tb_inputs.
 
 Definition adder8_3input_tb :=
   testBench "adder8_3input_tb" adder8_3inputInterface

--- a/cava/monad-examples/xilinx/NandLUT.v
+++ b/cava/monad-examples/xilinx/NandLUT.v
@@ -39,9 +39,9 @@ Definition lutNAND {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
   ret z.
 
 Definition lutNANDInterface
-  := mkCombinationalInterface "lutNAND"
-     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
-     (One ("c", Bit))
+  := combinationalInterface "lutNAND"
+     (mkPort "a"  Bit, mkPort "b" Bit)
+     (mkPort "c" Bit)
      [].
 
 Definition lutNANDNetlist := makeNetlist lutNANDInterface lutNAND.

--- a/cava/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/cava/monad-examples/xilinx/XilinxAdderExamples.v
@@ -81,9 +81,9 @@ Proof. reflexivity. Qed.
 (****************************************************************************)
 
 Definition adder8Interface
-  := mkCombinationalInterface "adder8"
-     (Tuple2 (One ("cin", Bit)) (Tuple2 (One ("a", BitVec [8])) (One ("b", BitVec [8]))))
-     (Tuple2 (One ("sum", BitVec [8])) (One ("cout", Bit)))
+  := combinationalInterface "adder8"
+     (mkPort "cin" Bit, (mkPort "a" (BitVec [8]), mkPort "b" (BitVec [8])))
+     (mkPort "sum" (BitVec [8]), mkPort "cout" Bit)
      [].
 
 Definition adder8Netlist := makeNetlist adder8Interface xilinxAdderWithCarry.

--- a/cava/monad-examples/xilinx/XilinxAdderTree.v
+++ b/cava/monad-examples/xilinx/XilinxAdderTree.v
@@ -84,9 +84,9 @@ Proof. reflexivity. Qed.
 Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name degree bitSize
-  := mkCombinationalInterface name
-     (One ("inputs", BitVec [2^(degree + 1); bitSize]))
-     (One ("sum", BitVec [bitSize + degree + 1]))
+  := combinationalInterface name
+     (mkPort "inputs" (BitVec [2^(degree + 1); bitSize]))
+     (mkPort "sum" (BitVec [bitSize + degree + 1]))
      [].
 
 (* Create netlist and test-bench for a 4-input adder tree. *)

--- a/cava/opentitan/pinmux/Makefile
+++ b/cava/opentitan/pinmux/Makefile
@@ -27,3 +27,5 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+clean:		
+		-@$(MAKE) -f Makefile.coq clean

--- a/cava/opentitan/pinmux/Pinmux.v
+++ b/cava/opentitan/pinmux/Pinmux.v
@@ -35,16 +35,16 @@ Definition NPeriphOut := 32.
 Definition NMioPads := 32.
 
 Definition pinmuxInterface :=
-  mkCircuitInterface "pinmux"
+  sequentialInterface "pinmux"
      "clk_i" PositiveEdge "rst_ni" NegativeEdge
-     (tuple [One ("tl_i", ExternalType "tlul_pkg::tl_h2d_t");
-             One ("periph_to_mio_i", BitVec [NPeriphOut-1]);
-             One ("periph_to_mio_oe_i", BitVec [NPeriphOut-1]);
-             One ("mio_in_i", BitVec [NMioPads-1])])
-     (tuple [One ("tl_o", ExternalType "tlul_pkg::tl_d2h_t ");
-             One ("mio_to_periph_o", BitVec [NPeriphIn-1]);
-             One ("mio_out_o", BitVec [NMioPads-1]);
-             One ("mio_oe_o", BitVec [NMioPads-1])])
+     (mkPort "tl_i" (ExternalType "tlul_pkg::tl_h2d_t"),
+      mkPort "periph_to_mio_i" (BitVec [NPeriphOut-1]),
+      mkPort "periph_to_mio_oe_i" (BitVec [NPeriphOut-1]),
+      mkPort "mio_in_i" (BitVec [NMioPads-1]))
+     (mkPort "tl_o" (ExternalType "tlul_pkg::tl_d2h_t "),
+      mkPort "mio_to_periph_o" (BitVec [NPeriphIn-1]),
+      mkPort "mio_out_o" (BitVec [NMioPads-1]),
+      mkPort "mio_oe_o" (BitVec [NMioPads-1]))
      [].
 
 Definition pinmux {m bit} `{Cava m bit}

--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -37,7 +37,7 @@ Definition lut1_inv {m bit} `{Cava m bit} (i: bit) : m bit :=
   ret o.
 
 Definition lut1_inv_Interface
-  := mkCombinationalInterface "lut1_inv" (One ("a", Bit)) (One ("b", Bit)) [].
+  := combinationalInterface "lut1_inv" (mkPort "a" Bit) (mkPort "b" Bit) [].
 
 Definition lut1_inv_netlist := makeNetlist lut1_inv_Interface lut1_inv.
 
@@ -59,9 +59,9 @@ Definition lut2_and {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
   ret o.
 
 Definition lut2_and_Interface
-  := mkCombinationalInterface "lut2_and"
-     (Tuple2 (One ("a", Bit)) (One ("b", Bit)))
-     (One ("c", Bit))
+  := combinationalInterface "lut2_and"
+     (mkPort "a" Bit, mkPort "b" Bit)
+     (mkPort "c" Bit)
      [].
 
 Definition lut2_and_nelist := makeNetlist lut2_and_Interface lut2_and.
@@ -87,10 +87,9 @@ Definition lut3_mux {m bit} `{Cava m bit}
   ret o.
 
 Definition lut3_mux_Interface
-  := mkCombinationalInterface "lut3_mux"
-     (Tuple2 (One ("s", Bit))
-             (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))))
-     (One ("o", Bit))
+  := combinationalInterface "lut3_mux"
+     (mkPort "s" Bit, (mkPort "i0" Bit, mkPort "i1" Bit))
+     (mkPort "o" Bit)
      [].
 
 Definition lut3_mux_nelist := makeNetlist lut3_mux_Interface lut3_mux.
@@ -121,16 +120,13 @@ Definition lut4_and {m bit} `{Cava m bit}
             andb (andb i0 i1) (andb i2 i3)) i ;;
   ret o.
 
-(* The left-associative nesting we need to use here is mad. We need to
-   find a better way. Satnam.
-*)
 Definition lut4_and_Interface
-  := mkCombinationalInterface "lut4_and"
-     (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
-                     (One ("i2", Bit)))
-             (One ("i3", Bit))
-     )
-     (One ("o", Bit))
+  := combinationalInterface "lut4_and"
+     (mkPort "i0" Bit,
+      mkPort "i1" Bit,
+      mkPort "i2" Bit,
+      mkPort "i3" Bit)
+     (mkPort "o" Bit)
      [].
 
 Definition lut4_and_nelist := makeNetlist lut4_and_Interface lut4_and.
@@ -157,16 +153,14 @@ Definition lut5_and {m bit} `{Cava m bit}
             andb (andb (andb i0 i1) (andb i2 i3)) i4) i ;;
   ret o.
 
-(* The left-associative nesting we need to use here is mad. We need to
-   find a better way. Satnam.
-*)
 Definition lut5_and_Interface
-  := mkCombinationalInterface "lut5_and"
-     (Tuple2 (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
-                     (One ("i2", Bit)))
-             (One ("i3", Bit))) (One ("i4", Bit))
-     )
-     (One ("o", Bit))
+  := combinationalInterface "lut5_and"
+     (mkPort "i0" Bit,
+      mkPort "i1" Bit,
+      mkPort "i2" Bit,
+      mkPort "i3" Bit,
+      mkPort "i4" Bit)
+     (mkPort "o" Bit)
      [].
 
 Definition lut5_and_nelist := makeNetlist lut5_and_Interface lut5_and.
@@ -197,12 +191,14 @@ Definition lut6_and {m bit} `{Cava m bit}
    find a better way. Satnam.
 *)
 Definition lut6_and_Interface
-  := mkCombinationalInterface "lut6_and"
-     (Tuple2 (Tuple2 (Tuple2 (Tuple2 (Tuple2 (One ("i0", Bit)) (One ("i1", Bit))) 
-                     (One ("i2", Bit)))
-             (One ("i3", Bit))) (One ("i4", Bit))) (One ("i5", Bit))
-     )
-     (One ("o", Bit))
+  := combinationalInterface "lut6_and"
+     (mkPort "i0" Bit,
+      mkPort "i1" Bit,
+      mkPort "i2" Bit,
+      mkPort "i3" Bit,
+      mkPort "i4" Bit,
+      mkPort "i5" Bit)
+     (mkPort "o" Bit)
      [].
 
 Definition lut6_and_nelist := makeNetlist lut6_and_Interface lut6_and.


### PR DESCRIPTION
Several changes:

* The `Shape` constructors don't need to be used in circuit interfaces, leading to much clearer interface descriptions. Several typeclasses that are no longer needed are deleted in the PR.
* The port specifications are now directly in terms of the `PortDeclaration` type e.g. `mkPort "wombat" Bit`.
* A stub definition for the pinmux has been started.
