### PR TITLE
Refactor modules for Cava monad kernel

### DIFF
--- a/cava/cava/Cava/Cava.v
+++ b/cava/cava/Cava/Cava.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2019 The Project Oak Authors                                   *)
+(* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -14,21 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-(* Experiments with the primitives that form the core of Cava. *)
 
-Require Import Cava.Monad.CavaMonad.
-Require Import ExtLib.Structures.Monads.
+(* A codification of the Lava embedded DSL develope for Haskell into
+   Coq for the specification, implementaiton and formal verification of circuits.
+*)
 
-(* Experiments with the primitive Cava gates. *)
-
-Example inv_false : combinational (inv false) = true.
-Proof. reflexivity. Qed.
-
-Example inv_true  : combinational (inv true) = false.
-Proof. reflexivity. Qed.
-
-Example and_00 : combinational (and2 (false, false)) = false.
-Proof. reflexivity. Qed.
-
-Example and_11 : combinational (and2 (true, true)) = true.
-Proof. reflexivity. Qed.
+Require Export Cava.BitArithmetic.
+Require Export Cava.Netlist.
+Require Export Cava.Types.

--- a/cava/cava/Cava/Extraction.v
+++ b/cava/cava/Cava/Extraction.v
@@ -25,15 +25,22 @@ Set Extraction KeepSingleton.
 Set Extraction File Comment "Auto-generated from Cava/Coq. Please do not hand edit.".
 
 Require Import Cava.BitArithmetic.
+Require Import Cava.Cava.
 Require Import Cava.Signal.
-Require Import Cava.Monad.Cava.
+Require Import Cava.Monad.CavaMonad.
+Require Import Cava.Monad.CombinationalMonad.
+Require Import Cava.Monad.CavaClass.
 Require Import Cava.Monad.Combinators.
+Require Import Cava.Monad.NetlistGeneration.
 Require Import Cava.Monad.UnsignedAdders.
 Require Import Cava.Monad.XilinxAdder.
 
 Recursive Extraction Library BitArithmetic.
 Recursive Extraction Library Cava.
+Recursive Extraction Library CavaMonad.
+Recursive Extraction Library CombinationalMonad.
 Recursive Extraction Library Combinators.
+Recursive Extraction Library NetlistGeneration.
 
 Require Import Cava.Arrow.Arrow.
 Require Import Cava.Arrow.Kappa.Kappa.

--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -1,0 +1,55 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import ExtLib.Structures.Monads.
+
+(* The Cava class represents circuit graphs with Coq-level inputs and
+   outputs, but does not represent the IO ports of circuits. This allows
+   us to define both circuit netlist interpretations for the Cava class
+   as well as behavioural interpretations for attributing semantics. *)
+Class Cava m bit `{Monad m} := {
+  (* Constant values. *)
+  zero : m bit; (* This component always returns the value 0. *)
+  one : m bit; (* This component always returns the value 1. *)
+  delayBit : bit -> m bit; (* Cava bit-level unit delay. *)
+  loopBit : forall {A B : Type}, ((A * bit)%type -> m (B * bit)%type) -> A -> m B;
+  (* Primitive gates *)
+  inv : bit -> m bit;
+  and2 : bit * bit -> m bit;
+  nand2 : bit * bit -> m bit;
+  or2 : bit * bit -> m bit;
+  nor2 : bit * bit -> m bit;
+  xor2 : bit * bit -> m bit;
+  xnor2 : bit * bit -> m bit;
+  buf_gate : bit -> m bit; (* Corresponds to the SystemVerilog primitive gate 'buf' *)
+  (* Xilinx UNISIM FPGA gates *)
+  lut1 : (bool -> bool) -> bit -> m bit; (* 1-input LUT *)
+  lut2 : (bool -> bool -> bool) -> (bit * bit) -> m bit; (* 2-input LUT *)
+  lut3 : (bool -> bool -> bool -> bool) -> (bit * bit * bit) -> m bit; (* 3-input LUT *)
+  lut4 : (bool -> bool -> bool -> bool -> bool) -> (bit * bit * bit * bit) ->
+         m bit; (* 4-input LUT *)
+  lut5 : (bool -> bool -> bool -> bool -> bool -> bool) ->
+         (bit * bit * bit * bit * bit) -> m bit; (* 5-input LUT *)
+  lut6 : (bool -> bool -> bool -> bool -> bool -> bool -> bool) ->
+         (bit * bit * bit * bit * bit * bit) -> m bit; (* 6-input LUT *)
+  xorcy : bit * bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
+  muxcy : bit -> bit -> bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
+  (* Synthesizable multiplexors *)
+  indexBitArray : list bit -> list bit -> m bit;
+  indexArray : list (list bit) -> list bit -> m (list bit);
+  (* Synthesizable arithmetic operations. *)
+  unsignedAdd : list bit -> list bit -> m (list bit);
+}.

--- a/cava/cava/Cava/Monad/CavaMonad.v
+++ b/cava/cava/Cava/Monad/CavaMonad.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2019 The Project Oak Authors                                   *)
+(* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -14,21 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-(* Experiments with the primitives that form the core of Cava. *)
-
-Require Import Cava.Monad.CavaMonad.
-Require Import ExtLib.Structures.Monads.
-
-(* Experiments with the primitive Cava gates. *)
-
-Example inv_false : combinational (inv false) = true.
-Proof. reflexivity. Qed.
-
-Example inv_true  : combinational (inv true) = false.
-Proof. reflexivity. Qed.
-
-Example and_00 : combinational (and2 (false, false)) = false.
-Proof. reflexivity. Qed.
-
-Example and_11 : combinational (and2 (true, true)) = true.
-Proof. reflexivity. Qed.
+Require Export Cava.Monad.CavaClass.
+Require Export Cava.Monad.CombinationalMonad.
+Require Export Cava.Monad.Combinators.
+Require Export Cava.Monad.NetlistGeneration.

--- a/cava/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/cava/Cava/Monad/CombinationalMonad.v
@@ -1,0 +1,150 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+From Coq Require Import Ascii String.
+From Coq Require Import Lists.List.
+Import ListNotations.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Export MonadNotation.
+
+From Coq Require Import ZArith.
+
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaClass.
+
+(******************************************************************************)
+(* A boolean combinational logic interpretation for the Cava class            *)
+(******************************************************************************)
+
+Definition notBool (i: bool) : ident bool :=
+  ret (negb i).
+
+Definition andBool '(a, b) : ident bool :=
+  ret (a && b).
+
+Definition nandBool (i: bool * bool) : ident bool :=
+  let (a, b) := i in ret (negb (a && b)).
+
+Definition orBool (i: bool * bool) : ident bool :=
+  let (a, b) := i in ret (a || b).
+
+Definition norBool (i: bool * bool) : ident bool :=
+  let (a, b) := i in ret (negb (a || b)).
+
+Definition xorBool (i: bool * bool) : ident bool :=
+  let (a, b) := i in ret (xorb a b).
+
+Definition xnorBool (i : bool * bool) : ident bool :=
+  let (a, b) := i in ret (negb (xorb a b)).
+
+Definition lut1Bool (f: bool -> bool) (i: bool) : ident bool := ret (f i).
+
+Definition lut2Bool (f: bool -> bool -> bool) (i: bool * bool) : ident bool :=
+  ret (f (fst i) (snd i)).
+
+Definition lut3Bool (f: bool -> bool -> bool -> bool) (i: bool * bool * bool) :
+                    ident bool :=
+  let '(i0, i1, i2) := i in
+  ret (f i0 i1 i2).
+
+Definition lut4Bool (f: bool -> bool -> bool -> bool -> bool)
+                    (i: bool * bool * bool * bool) : ident bool :=
+  let '(i0, i1, i2, i3) := i in
+  ret (f i0 i1 i2 i3).
+
+Definition lut5Bool (f: bool -> bool -> bool -> bool -> bool -> bool)
+                    (i: bool * bool * bool * bool * bool) : ident bool :=
+  let '(i0, i1, i2, i3, i4) := i in
+  ret (f i0 i1 i2 i3 i4).
+
+Definition lut6Bool (f: bool -> bool -> bool -> bool -> bool -> bool -> bool)
+                    (i: bool * bool * bool * bool * bool * bool) : ident bool :=
+  let '(i0, i1, i2, i3, i4, i5) := i in
+  ret (f i0 i1 i2 i3 i4 i5).
+
+Definition xorcyBool (i: bool * bool) : ident bool :=
+  let (ci, li) := i in ret (xorb ci li).
+
+Definition muxcyBool (s : bool) (ci : bool) (di : bool) : ident bool :=
+  ret (match s with
+       | false => di
+       | true => ci
+       end).
+
+Definition indexBitArrayBool (i : list bool) (sel : list bool) :
+                             ident bool :=
+  let selNat := list_bits_to_nat sel in
+  ret (nth (N.to_nat selNat) i false).
+
+Definition indexArrayBool (i : list (list bool)) (sel : list bool) :
+                             ident (list bool) :=
+  let selNat := list_bits_to_nat sel in
+  ret (nth (N.to_nat selNat) i []).
+
+Definition unsignedAddBool (av : list bool) (bv : list bool) :
+                           ident (list bool) :=
+  let a := list_bits_to_nat av in
+  let b := list_bits_to_nat bv in
+  let sumSize := max (length av) (length bv) + 1 in
+  let sum := (a + b)%N in
+  ret (nat_to_list_bits_sized sumSize sum).
+
+Definition bufBool (i : bool) : ident bool :=
+  ret i.
+
+Definition loopBitBool (A B : Type) (f : A * bool -> ident (B * bool)) (a : A) : ident B :=
+  '(b, _) <- f (a, false) ;;
+  ret b.
+
+(******************************************************************************)
+(* Instantiate the Cava class for a boolean combinational logic               *)
+(* interpretation.                                                            *)
+(******************************************************************************)
+
+Instance CavaBool : Cava ident bool :=
+  { zero := ret false;
+    one := ret true;
+    delayBit i := ret i; (* Dummy definition for delayBit for now. *)
+    loopBit a b := loopBitBool a b;
+    inv := notBool;
+    and2 := andBool;
+    nand2 := nandBool;
+    or2 := orBool;
+    nor2 := norBool;
+    xor2 := xorBool;
+    lut1 := lut1Bool;
+    lut2 := lut2Bool;
+    lut3 := lut3Bool;
+    lut4 := lut4Bool;
+    lut5 := lut5Bool;
+    lut6 := lut6Bool;
+    xorcy := xorcyBool;
+    xnor2 := xnorBool;
+    muxcy := muxcyBool;
+    indexBitArray := indexBitArrayBool;
+    indexArray := indexArrayBool;
+    unsignedAdd m n := @unsignedAddBool m n;
+    buf_gate := bufBool;
+}.
+
+(******************************************************************************)
+(* A function to run a monadic circuit description and return the boolean     *)
+(* behavioural simulation result.                                             *)
+(******************************************************************************)
+
+Definition combinational {a} (circuit : ident a) : a := unIdent circuit.

--- a/cava/cava/Cava/Monad/Combinators.v
+++ b/cava/cava/Cava/Monad/Combinators.v
@@ -24,7 +24,7 @@ Require Import Omega.
 
 Export MonadNotation.
 
-Require Import Cava.Monad.Cava.
+Require Import Cava.Monad.CavaClass.
 
 Generalizable All Variables.
 

--- a/cava/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/cava/Cava/Monad/NetlistGeneration.v
@@ -14,75 +14,18 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-(* A codification of the Lava embedded DSL develope for Haskell into
-   Coq for the specification, implementaiton and formal verification of circuits.
-   Experimental work, very much in flux, as Satnam learns Coq!
-*)
-
-Require Import Program.Basics.
-From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
-From Coq Require Numbers.BinNums.
-From Coq Require Import ZArith.
-From Coq Require Import Vector.
-From Coq Require Import Bool.Bvector.
 From Coq Require Import Lists.List.
 Import ListNotations.
-
 Require Import ExtLib.Structures.Monads.
-Require Import ExtLib.Structures.MonadFix.
-Require Export ExtLib.Data.Monads.IdentityMonad.
-Require Export ExtLib.Data.Monads.StateMonad.
 Export MonadNotation.
 
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.BitArithmetic.
+From Coq Require Import ZArith.
+
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaClass.
+
 Require Import Cava.Signal.
-
-Generalizable All Variables.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
-
-(* The Cava class represents circuit graphs with Coq-level inputs and
-   outputs, but does not represent the IO ports of circuits. This allows
-   us to define both circuit netlist interpretations for the Cava class
-   as well as behavioural interpretations for attributing semantics. *)
-Class Cava m bit `{Monad m} := {
-  (* Constant values. *)
-  zero : m bit; (* This component always returns the value 0. *)
-  one : m bit; (* This component always returns the value 1. *)
-  delayBit : bit -> m bit; (* Cava bit-level unit delay. *)
-  loopBit : forall {A B : Type}, ((A * bit)%type -> m (B * bit)%type) -> A -> m B;
-  (* Primitive gates *)
-  inv : bit -> m bit;
-  and2 : bit * bit -> m bit;
-  nand2 : bit * bit -> m bit;
-  or2 : bit * bit -> m bit;
-  nor2 : bit * bit -> m bit;
-  xor2 : bit * bit -> m bit;
-  xnor2 : bit * bit -> m bit;
-  buf_gate : bit -> m bit; (* Corresponds to the SystemVerilog primitive gate 'buf' *)
-  (* Xilinx UNISIM FPGA gates *)
-  lut1 : (bool -> bool) -> bit -> m bit; (* 1-input LUT *)
-  lut2 : (bool -> bool -> bool) -> (bit * bit) -> m bit; (* 2-input LUT *)
-  lut3 : (bool -> bool -> bool -> bool) -> (bit * bit * bit) -> m bit; (* 3-input LUT *)
-  lut4 : (bool -> bool -> bool -> bool -> bool) -> (bit * bit * bit * bit) ->
-         m bit; (* 4-input LUT *)
-  lut5 : (bool -> bool -> bool -> bool -> bool -> bool) ->
-         (bit * bit * bit * bit * bit) -> m bit; (* 5-input LUT *)
-  lut6 : (bool -> bool -> bool -> bool -> bool -> bool -> bool) ->
-         (bit * bit * bit * bit * bit * bit) -> m bit; (* 6-input LUT *)
-  xorcy : bit * bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
-  muxcy : bit -> bit -> bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
-  (* Synthesizable multiplexors *)
-  indexBitArray : list bit -> list bit -> m bit;
-  indexArray : list (list bit) -> list bit -> m (list bit);
-  (* Synthesizable arithmetic operations. *)
-  unsignedAdd : list bit -> list bit -> m (list bit);
-}.
 
 (******************************************************************************)
 (* Netlist implementations for the Cava class.                                *)
@@ -307,125 +250,3 @@ Instance CavaNet : Cava (state CavaState) Signal :=
     indexArray := indexArrayNet;
     unsignedAdd := unsignedAddNet;
 }.
-
-(******************************************************************************)
-(* A second boolean combinational logic interpretation for the Cava class     *)
-(******************************************************************************)
-
-Definition notBool (i: bool) : ident bool :=
-  ret (negb i).
-
-Definition andBool '(a, b) : ident bool :=
-  ret (a && b).
-
-Definition nandBool (i: bool * bool) : ident bool :=
-  let (a, b) := i in ret (negb (a && b)).
-
-Definition orBool (i: bool * bool) : ident bool :=
-  let (a, b) := i in ret (a || b).
-
-Definition norBool (i: bool * bool) : ident bool :=
-  let (a, b) := i in ret (negb (a || b)).
-
-Definition xorBool (i: bool * bool) : ident bool :=
-  let (a, b) := i in ret (xorb a b).
-
-Definition xnorBool (i : bool * bool) : ident bool :=
-  let (a, b) := i in ret (negb (xorb a b)).
-
-Definition lut1Bool (f: bool -> bool) (i: bool) : ident bool := ret (f i).
-
-Definition lut2Bool (f: bool -> bool -> bool) (i: bool * bool) : ident bool :=
-  ret (f (fst i) (snd i)).
-
-Definition lut3Bool (f: bool -> bool -> bool -> bool) (i: bool * bool * bool) :
-                    ident bool :=
-  let '(i0, i1, i2) := i in
-  ret (f i0 i1 i2).
-
-Definition lut4Bool (f: bool -> bool -> bool -> bool -> bool)
-                    (i: bool * bool * bool * bool) : ident bool :=
-  let '(i0, i1, i2, i3) := i in
-  ret (f i0 i1 i2 i3).
-
-Definition lut5Bool (f: bool -> bool -> bool -> bool -> bool -> bool)
-                    (i: bool * bool * bool * bool * bool) : ident bool :=
-  let '(i0, i1, i2, i3, i4) := i in
-  ret (f i0 i1 i2 i3 i4).
-
-Definition lut6Bool (f: bool -> bool -> bool -> bool -> bool -> bool -> bool)
-                    (i: bool * bool * bool * bool * bool * bool) : ident bool :=
-  let '(i0, i1, i2, i3, i4, i5) := i in
-  ret (f i0 i1 i2 i3 i4 i5).
-
-Definition xorcyBool (i: bool * bool) : ident bool :=
-  let (ci, li) := i in ret (xorb ci li).
-
-Definition muxcyBool (s : bool) (ci : bool) (di : bool) : ident bool :=
-  ret (match s with
-       | false => di
-       | true => ci
-       end).
-
-Definition indexBitArrayBool (i : list bool) (sel : list bool) :
-                             ident bool :=
-  let selNat := list_bits_to_nat sel in
-  ret (nth (N.to_nat selNat) i false).
-
-Definition indexArrayBool (i : list (list bool)) (sel : list bool) :
-                             ident (list bool) :=
-  let selNat := list_bits_to_nat sel in
-  ret (nth (N.to_nat selNat) i []).
-
-Definition unsignedAddBool (av : list bool) (bv : list bool) :
-                           ident (list bool) :=
-  let a := list_bits_to_nat av in
-  let b := list_bits_to_nat bv in
-  let sumSize := max (length av) (length bv) + 1 in
-  let sum := (a + b)%N in
-  ret (nat_to_list_bits_sized sumSize sum).
-
-Definition bufBool (i : bool) : ident bool :=
-  ret i.
-
-Definition loopBitBool (A B : Type) (f : A * bool -> ident (B * bool)) (a : A) : ident B :=
-  '(b, _) <- f (a, false) ;;
-  ret b.
-
-(******************************************************************************)
-(* Instantiate the Cava class for a boolean combinational logic               *)
-(* interpretation.                                                            *)
-(******************************************************************************)
-
-Instance CavaBool : Cava ident bool :=
-  { zero := ret false;
-    one := ret true;
-    delayBit i := ret i; (* Dummy definition for delayBit for now. *)
-    loopBit a b := loopBitBool a b;
-    inv := notBool;
-    and2 := andBool;
-    nand2 := nandBool;
-    or2 := orBool;
-    nor2 := norBool;
-    xor2 := xorBool;
-    lut1 := lut1Bool;
-    lut2 := lut2Bool;
-    lut3 := lut3Bool;
-    lut4 := lut4Bool;
-    lut5 := lut5Bool;
-    lut6 := lut6Bool;
-    xorcy := xorcyBool;
-    xnor2 := xnorBool;
-    muxcy := muxcyBool;
-    indexBitArray := indexBitArrayBool;
-    indexArray := indexArrayBool;
-    unsignedAdd m n := @unsignedAddBool m n;
-    buf_gate := bufBool;
-}.
-
-(******************************************************************************)
-(* A function to run a monadic circuit description and return the boolean     *)
-(* behavioural simulation result.                                             *)
-(******************************************************************************)
-
-Definition combinational {a} (circuit : ident a) : a := unIdent circuit.

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -14,23 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import ZArith.
-From Coq Require Import ZArith.BinInt.
-From Coq Require Import PArith.BinPos.
-From Coq Require Import Numbers.NatInt.NZPow.
 Require Import ExtLib.Structures.Monads.
-Export MonadNotation.
-Open Scope monad_scope.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.Netlist.
-Require Import Cava.BitArithmetic.
-
-Require Import Nat Arith Lia.
-
-From Coq Require Import Lists.List.
-Import ListNotations.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
 (******************************************************************************)
 (* A three input adder.                                                       *)

--- a/cava/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/cava/Cava/Monad/XilinxAdder.v
@@ -20,16 +20,12 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.Netlist.
-Require Import Cava.BitArithmetic.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
 Local Open Scope string_scope.
-Local Open Scope type_scope.
 Local Open Scope list_scope.
+Local Open Scope type_scope.
 
 (******************************************************************************)
 (* Build a full-adder with explicit use of Xilinx FPGA fast carry logic       *)
@@ -70,10 +66,7 @@ Definition xilinxAdderWithCarry {m bit} `{Cava m bit} '(cin, (a, b))
 (* for bit-growth at the output.                   *)
 (******************************************************************************)
 
-Local Open Scope list_scope.
-
 Definition xilinxAdder {m bit} `{Cava m bit} a b : m (list bit) :=
   z <- zero ;;
   '(sum, carry) <- xilinxAdderWithCarry (z, (a, b)) ;;
   ret (sum ++ [carry]).
-

--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -45,10 +45,11 @@ library
                      BinNums
                      BitArithmetic
                      Bvector
-                     Cava
+                     CavaClass
                      CC
                      Combinators
                      Combinational
+                     CombinationalMonad
                      Constructive
                      Datatypes
                      DecimalString
@@ -59,6 +60,7 @@ library
                      Monad
                      NaryFunctions
                      Netlist
+                     NetlistGeneration
                      Netlist0
                      Nat
                      PeanoNat

--- a/cava/cava/_CoqProject
+++ b/cava/cava/_CoqProject
@@ -1,12 +1,16 @@
 -R Cava Cava
 
 Cava/BitArithmetic.v
+Cava/Cava.v
 Cava/Signal.v
 Cava/Netlist.v
 Cava/Types.v
-Cava/Monad/Cava.v
+Cava/Monad/CavaMonad.v
+Cava/Monad/CavaClass.v
+Cava/Monad/CombinationalMonad.v
 Cava/Monad/Combinators.v
 Cava/Monad/UnsignedAdders.v
+Cava/Monad/NetlistGeneration.v
 Cava/Monad/XilinxAdder.v
 
 Cava/Arrow.v

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -21,7 +21,6 @@
 
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
-From Coq Require Arith.PeanoNat.
 Require Import Omega.
 
 From Coq Require Import Lists.List.
@@ -29,14 +28,9 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.UnsignedAdders.
-
-Set Implicit Arguments.
 
 (******************************************************************************)
 (* A generic description of all adder trees made from a syntheszable adder    *)
@@ -149,4 +143,3 @@ Definition adder_tree64_128_tb_expected_outputs
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface
   adder_tree64_128_tb_inputs adder_tree64_128_tb_expected_outputs.
-

--- a/cava/monad-examples/FullAdder.v
+++ b/cava/monad-examples/FullAdder.v
@@ -15,26 +15,15 @@
 
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
-From Coq Require Import Vector.
-From Coq Require Import Bool.Bvector.
 From Coq Require Import Lists.List.
 Require Import Omega.
 Import ListNotations.
 
-Require Import Nat Arith Lia.
-
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.BitArithmetic.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.XilinxAdder.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
 
 (******************************************************************************)
 (* Build a half-adder                                                         *)
@@ -136,6 +125,3 @@ Local Open Scope list_scope.
 Definition adderWithGrowth {m bit} `{Cava m bit} '(cin, (a, b)):=
   '(sum, carryOut) <- adder (cin, (a, b)) ;;
   ret (sum ++ [carryOut]).
-
-
-

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -33,8 +33,8 @@ Require Import ExtLib.Structures.Monads.
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.BitArithmetic.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import MonadExamples.FullAdder.
 
 Open Scope N_scope.

--- a/cava/monad-examples/Multiplexers.v
+++ b/cava/monad-examples/Multiplexers.v
@@ -13,26 +13,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Program.Basics.
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
 Import ListNotations.
 
-From Coq Require Arith.PeanoNat.
 Require Import Omega.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Signal.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
 Definition mux2_1 {m bit} `{Cava m bit} '(sel, (a, b)) : m bit :=
   o <- indexBitArray [a; b] [sel] ;;

--- a/cava/monad-examples/NandGate.v
+++ b/cava/monad-examples/NandGate.v
@@ -25,16 +25,12 @@ Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 Open Scope monad_scope.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
 Local Open Scope list_scope.
 Local Open Scope monad_scope.
 Local Open Scope string_scope.
-
-Generalizable All Variables.
 
 (* NAND gate example. Fist, let's define an overloaded NAND gate
    description. *)

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -19,17 +19,12 @@ From Coq Require Import Bool.Bool.
 From Coq Require Import NArith.
 From Coq Require Import Lists.List.
 Import ListNotations.
-Open Scope list_scope.
-Open Scope string_scope.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
-Open Scope monad_scope.
 
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Monad.Cava.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.UnsignedAdders.
 
 (******************************************************************************)
@@ -115,4 +110,3 @@ Definition adder8_3input_tb_expected_outputs :=
 Definition adder8_3input_tb :=
   testBench "adder8_3input_tb" adder8_3inputInterface
   adder8_3input_tb_inputs adder8_3input_tb_expected_outputs.
-

--- a/cava/monad-examples/xilinx/NandLUT.v
+++ b/cava/monad-examples/xilinx/NandLUT.v
@@ -17,21 +17,13 @@
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
-From Coq Require Import ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.XilinxAdder.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
 
 Definition lutNAND {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
   x <- lut2 (andb) i0i1 ;;

--- a/cava/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/cava/monad-examples/xilinx/XilinxAdderExamples.v
@@ -22,16 +22,9 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.XilinxAdder.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
 
 (****************************************************************************)
 (* A few tests to check the unsigned adder.        *)
@@ -106,4 +99,3 @@ Definition adder8_tb_expected_outputs :=
 Definition adder8_tb :=
   testBench "adder8_tb" adder8Interface
   adder8_tb_inputs adder8_tb_expected_outputs.
-

--- a/cava/monad-examples/xilinx/XilinxAdderTree.v
+++ b/cava/monad-examples/xilinx/XilinxAdderTree.v
@@ -21,7 +21,6 @@
 
 From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
-From Coq Require Arith.PeanoNat.
 Require Import Omega.
 
 From Coq Require Import Lists.List.
@@ -29,14 +28,9 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-Require Import Cava.BitArithmetic.
-Require Import Cava.Monad.Cava.
-Require Import Cava.Monad.Combinators.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.XilinxAdder.
-
-Set Implicit Arguments.
 
 (******************************************************************************)
 (* A generic description of all adder trees made from a Xilinx adder          *)
@@ -188,4 +182,3 @@ Definition adder_tree128_256_tb_expected_outputs
 Definition adder_tree128_256_tb :=
   testBench "xadder_tree128_256_tb" adder_tree128_256Interface
   adder_tree128_256_tb_inputs adder_tree128_256_tb_expected_outputs.
-

--- a/cava/opentitan/pinmux/Pinmux.v
+++ b/cava/opentitan/pinmux/Pinmux.v
@@ -15,20 +15,17 @@
 (****************************************************************************)
 
 From Coq Require Import Ascii String.
-Local Open Scope string_scope.
 
 From Coq Require Import Lists.List.
 Import ListNotations.
-Local Open Scope list_scope.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
+
 Open Scope monad_scope.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Netlist.
-Require Import Cava.Signal.
-Require Import Cava.Types.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
 Definition NPeriphIn := 32.
 Definition NPeriphOut := 32.

--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -20,13 +20,8 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Cava.Monad.Cava.
-Require Import Cava.Netlist.
-Require Import Cava.Types.
-
-Local Open Scope list_scope.
-Local Open Scope monad_scope.
-Local Open Scope string_scope.
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
 
 (****************************************************************************)
 (* LUT1 config test                                                         *)


### PR DESCRIPTION
Signed-off-by: Satnam Singh <satnam@google.com>

This breaks some large `.v` files into smaller modules, and simplifies the imports for the Cava core and the monad kernel (in preparation for further refactoring).