### PR TITLE
Use the usual Fst Snd naming convention in Kappa

### DIFF
--- a/cava/cava/Cava/Arrow/Arrow.v
+++ b/cava/cava/Cava/Arrow/Arrow.v
@@ -193,10 +193,10 @@ Notation "<< x >>" := (x) : kind_scope.
 Notation "<< x , .. , y , z >>" := (Tuple x .. (Tuple y z )  .. ) : kind_scope.
 
 Fixpoint vec_to_nprod (A: Type) n (v: Vector.t A n): A^n :=
-match v with
-| [] => tt
-| x::xs => (x, vec_to_nprod A _ xs)
-end%vector.
+  match v with
+  | [] => tt
+  | x::xs => (x, vec_to_nprod A _ xs)
+  end%vector.
 
 (* log2_up is used for getting the necessary number of bits required to represent an index.
 Currently some of the Arrow.Cava and Kappa parts take non-zero sized vectors, and so we require a 
@@ -246,7 +246,7 @@ Class Cava := {
   *)
   slice_vec n x y o: x < n -> y <= x -> Vector n o ~> Vector (x - y + 1) o;
   to_vec o: o ~> Vector 1 o;
-  append n o: Vector n o ** o ~> Vector (n+1) o;
+  append n o: Vector n o ** o ~> Vector (S n) o;
   concat n m o: Vector n o ** Vector m o ~> Vector (n + m) o;
   split n m o: m < n -> Vector n o ~> (Vector m o ** Vector (n - m) o);
 }.

--- a/cava/cava/Cava/Arrow/Instances/Combinational.v
+++ b/cava/cava/Cava/Arrow/Instances/Combinational.v
@@ -119,7 +119,7 @@ Instance CombinationalLoop : ArrowLoop CoqKindMaybeArrow := { loopl _ _ _ _ _ :=
   to_vec o x := Some [x]%vector;
   append n o '(v, x) :=
     let z := (x :: v)%vector in
-    Some _;
+    Some z;
 
   concat n m o '(x, y) := Some (Vector.append x y);
   split n m o H x :=
@@ -149,12 +149,6 @@ Proof.
     apply (splitat (x-y+1)) in X.
     apply (fst) in X.
     exact (Some X).
-
-  (* append *)
-  - assert (n + 1 = S n).
-    omega.
-    rewrite H.
-    auto.
 
   (* split *)
   - assert ( m + (n - m) = n).

--- a/cava/cava/Cava/Arrow/Instances/Constructive.v
+++ b/cava/cava/Cava/Arrow/Instances/Constructive.v
@@ -51,7 +51,7 @@ Inductive structure: Kind -> Kind -> Type :=
   | IndexVec: forall {n o}, structure << Vector n o, Vector (log2_up_min_1 n) Bit >> o
   | SliceVec: forall {n} x y {o}, x < n -> y <= x -> structure << Vector n o >> (Vector (x - y + 1) o)
   | ToVec: forall {o}, structure o (Vector 1 o)
-  | Append: forall {n o}, structure << Vector n o, o >> (Vector (n+1) o)
+  | Append: forall {n o}, structure << Vector n o, o >> (Vector (S n) o)
   | Concat: forall {n m o}, structure << Vector n o, Vector m o >> (Vector (n+m) o)
   | Split: forall {n m o}, m < n -> structure << Vector n o >> <<Vector m o , Vector (n-m) o>>.
 

--- a/cava/cava/Cava/Arrow/Instances/Netlist.v
+++ b/cava/cava/Cava/Arrow/Instances/Netlist.v
@@ -266,17 +266,12 @@ Section NetlistEval.
   to_vec o i := ret [i]%vector;
   append n o '(array, e) :=
     let result := (e :: array)%vector in
-    ret _;
+    ret result;
   concat n m o '(x, y) := ret (Vector.append x y);
   split n m o H x :=
     ret (@Vector.splitat (denote o) m (n - m) _);
   }.
   Proof.
-    - assert (n + 1 = S n).
-      omega.
-      rewrite <- H in result.
-      exact result.
-
     - assert ( m + (n - m) = n).
       omega.
       rewrite H0.

--- a/cava/cava/Cava/Arrow/Kappa/Syntax.v
+++ b/cava/cava/Cava/Arrow/Kappa/Syntax.v
@@ -35,8 +35,8 @@ Module KappaNotation.
   (* todo: turn into a recursive pattern *)
   Notation "'let' '( x , y ) = e1 'in' e2"
     := (
-    Let (App TupleLeft e1) (fun x => 
-      Let (App TupleRight e1) (fun y => e2
+    Let (App Fst e1) (fun x =>
+      Let (App Snd e1) (fun y => e2
       )
     )
     ) 
@@ -54,8 +54,8 @@ Module KappaNotation.
 
   (* Pre defined functions *)
 
-  Notation "'fst'" := (TupleLeft) (in custom expr at level 4) : kappa_scope.
-  Notation "'snd'" := (TupleRight) (in custom expr at level 4) : kappa_scope.
+  Notation "'fst'" := (Fst) (in custom expr at level 4) : kappa_scope.
+  Notation "'snd'" := (Snd) (in custom expr at level 4) : kappa_scope.
 
   Notation "'not'" := (Not) (in custom expr at level 4) : kappa_scope.
   Notation "'and'" := (And) (in custom expr at level 4) : kappa_scope.
@@ -77,10 +77,10 @@ Module KappaNotation.
   Notation "'concat'" := (Concat _ _) (in custom expr at level 4) : kappa_scope.
   Notation "'split_at' x" := (Split _ x _) (in custom expr at level 4, x constr at level 4) : kappa_scope.
 
-  Notation "'true'" := (Constant true) (in custom expr at level 2) : kappa_scope.
-  Notation "'false'" := (Constant false) (in custom expr at level 2) : kappa_scope.
+  Notation "'true'" := (@LiftConstant _ Bit true) (in custom expr at level 2) : kappa_scope.
+  Notation "'false'" := (@LiftConstant _ Bit false) (in custom expr at level 2) : kappa_scope.
 
-  Notation "# x" := (ConstantVec x) (in custom expr at level 2, x constr at level 4) : kappa_scope.
+  Notation "# x" := (@LiftConstant _ (Vector _ Bit) x)%N (in custom expr at level 2, x constr at level 4) : kappa_scope.
 
   Notation "v [ x ]" := (App (App (IndexVec _) v) x) (in custom expr at level 4) : kappa_scope.
   Notation "x :: y" := (App (App (Concat _ _) (kappa_to_vec x)) y) (in custom expr at level 4) : kappa_scope.


### PR DESCRIPTION
Change the type of `append` from `n + 1` to `S n`. `S n` is
definitionally correct and so requires less work in proving type
equality.