### PR TITLE
Switch Cava monad kernel to use smashed vectors

### DIFF
--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -18,31 +18,13 @@ From Coq Require Vector.
 Require Import ExtLib.Structures.Monads.
 
 From Cava Require Import Kind.
-
-Fixpoint denoteVecKind (bit: Type) (vec: Type -> nat -> Type) (k: Kind) : Type :=
-  match k with
-  | Bit => bit
-  | BitVec k2 s => vec (denoteVecKind bit vec k2) s
-  | _ => unit
-  end.
+From Cava Require Import Types.
 
 (* The Cava class represents circuit graphs with Coq-level inputs and
    outputs, but does not represent the IO ports of circuits. This allows
    us to define both circuit netlist interpretations for the Cava class
    as well as behavioural interpretations for attributing semantics. *)
-Class Cava m `{Monad m} bit (vec: Kind -> nat -> Type) := {
-  denoteKind: Kind -> Type;
-  denoteKindV: forall {k s}, denoteKind (BitVec k s) = vec k s;
-  vecBoolList: forall {s: nat}, Vector.t bit s -> vec Bit s;
-  vecList : forall {k: Kind} {s: nat}, Vector.t (denoteKind k) s ->
-            vec k s;
-  (* Convert a dynamic vector to a "static" list *)
-  vecToList: forall {k: Kind} {s: nat}, vec k s -> list (denoteKind k);
-  vecToVector: forall {k: Kind} {s: nat}, vec k s -> Vector.t (denoteKind k) s;
-  vecToVector1: forall {s: nat}, vec Bit s -> Vector.t bit s;
-  vecToVector2: forall {s: nat} (k2: Kind) (s2: nat), vec (BitVec k2 s2) s -> Vector.t (vec k2 s2) s;
-  defaultKind: forall {k: Kind}, @denoteKind k;
-  defaultBitVec : forall {sz}, vec Bit sz;          
+Class Cava m `{Monad m} bit := {
   (* Constant values. *)
   zero : m bit; (* This component always returns the value 0. *)
   one : m bit; (* This component always returns the value 1. *)
@@ -74,15 +56,20 @@ Class Cava m `{Monad m} bit (vec: Kind -> nat -> Type) := {
      functions rather than values in the monad type `m`.
   *)
   (* Dynamic indexing *)                                   
-  indexAt : forall {k: Kind} {sz isz: nat}, vec k sz -> vec Bit isz -> denoteKind k;
-  indexBitAt : forall {sz isz: nat}, vec Bit sz ->
-                                     vec Bit isz -> bit;
+  indexAt : forall {k: Kind} {sz isz: nat},
+            smashTy bit (BitVec k sz) -> Vector.t bit isz -> smashTy bit k;
+  indexBitAt : forall {sz isz: nat}, Vector.t bit sz ->
+                                     Vector.t bit isz -> bit;
   (* Static indexing *)
-  indexConst : forall {k: Kind} {sz: nat}, vec k sz -> nat -> denoteKind k;
-  indexBitConst : forall {sz: nat}, vec Bit sz -> nat -> bit;
-  slice : forall {k: Kind} {sz: nat} (startAt len: nat), vec k sz ->
-                 (startAt + len <= sz) -> vec k len;
+  indexConst : forall {k: Kind} {sz: nat},
+               Vector.t (smashTy bit k) sz -> nat -> smashTy bit k;
+  indexBitConst : forall {sz: nat}, Vector.t bit sz -> nat -> bit;
+  slice : forall {k: Kind}  {sz: nat} (startAt len: nat),
+                 smashTy bit (BitVec k sz) ->
+                 (startAt + len <= sz) -> smashTy bit (BitVec k len) ;
   (* Synthesizable arithmetic operations. *)
-  unsignedAdd : forall {a b : nat}, vec Bit a -> vec Bit b -> m (vec Bit (1 + max a b));
-  addNN : forall {a : nat}, vec Bit a -> vec Bit a -> m (vec Bit a);
+  unsignedAdd : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
+                m (Vector.t bit (1 + max a b));
+  addNN : forall {a : nat}, Vector.t bit a -> Vector.t bit a ->
+                m (Vector.t bit a);
 }.

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -31,10 +31,12 @@ Proof.
   intros. lia.
 Qed.
 
+(*
 Definition addN {m bit} `{Cava m bit} {n}
-                (a: vec Bit n) (b: vec Bit n) : m (vec Bit n) :=
+                (a: Vector.t bit n) (b: Vector.t bit n) : m (Vector.t bit n) :=               
   s <- unsignedAdd a b ;;
-  ret (slice 0 n s (n_le_max_n_n n)).
+  ret (slice 0 n _ (n_le_max_n_n n)).
+*)
 
 (******************************************************************************)
 (* A three input adder.                                                       *)
@@ -42,10 +44,10 @@ Definition addN {m bit} `{Cava m bit} {n}
 
 Definition adder_3input {m bit} `{Cava m bit}
                         {aSize bSize cSize}
-                        (a : vec Bit aSize)
-                        (b : vec Bit bSize)
-                        (c : vec Bit cSize) :
-                        m (vec Bit (1 + max (1 + max aSize bSize) cSize))
+                        (a : Vector.t bit aSize)
+                        (b : Vector.t bit bSize)
+                        (c : Vector.t bit cSize) :
+                        m (Vector.t bit (1 + max (1 + max aSize bSize) cSize))
                         :=
   a_plus_b <- unsignedAdd a b ;;
   sum <- unsignedAdd a_plus_b c ;;

--- a/cava/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/cava/Cava/Monad/XilinxAdder.v
@@ -66,14 +66,12 @@ Qed.
 (* An unsigned adder built using the fast carry full-adder.                   *)
 (******************************************************************************)
 
-Definition xilinxAdderWithCarry {m bit vec} `{Cava m bit vec} {n: nat}
-            (cinab : bit * (vec Bit n * vec Bit n))
-           : m (vec Bit n * bit) 
+Definition xilinxAdderWithCarry {m bit} `{Cava m bit} {n: nat}
+            (cinab : bit * (Vector.t bit n * Vector.t bit n))
+           : m (Vector.t bit n * bit) 
   := let '(cin, (a, b)) := cinab in
-     let aV : Vector.t bit n := vecToVector1 a in
-     let bV : Vector.t bit n := vecToVector1 b in
-     '(sum, cout) <- colV n xilinxFullAdder cin (vcombine aV bV) ;;
-     ret (vecBoolList sum, cout).
+     '(sum, cout) <- colV n xilinxFullAdder cin (vcombine a b) ;;
+     ret (sum, cout).
 
 (* A quick sanity check of the Xilinx adder with carry in and out *)
 Example xilinx_add_17_52:
@@ -86,9 +84,9 @@ Proof. reflexivity. Qed.
 (* An unsigned adder with no bit-growth and no carry in                       *)
 (******************************************************************************)
 
-Definition xilinxAdder {m bit vec} `{Cava m bit vec} {n: nat}
-            (a: vec Bit n) (b: vec Bit n)
-           : m (vec Bit n) :=
+Definition xilinxAdder {m bit} `{Cava m bit} {n: nat}
+            (a: Vector.t bit n) (b: Vector.t bit n)
+           : m (Vector.t bit n) :=
   z <- zero ;;
   '(sum, carry) <- xilinxAdderWithCarry (z, (a, b)) ;;
   ret sum.

--- a/cava/cava/Cava/Signal.v
+++ b/cava/cava/Cava/Signal.v
@@ -19,6 +19,7 @@ From Coq Require Import ZArith.
 From Coq Require Import Vector.
 
 From Cava Require Import Kind.
+From Cava Require Import VectorUtils.
 
 Inductive Signal : Kind -> Type :=
   | UndefinedSignal : Signal Void
@@ -35,14 +36,17 @@ Inductive Signal : Kind -> Type :=
              Signal (BitVec Bit isz) -> Signal k
   (* Static indexing *)
   | IndexConst: forall {k sz}, Signal (BitVec k sz) -> nat -> Signal k
+  (* Static indexing of smashed vectors *)
+  | IndexConstS: forall {k sz}, Vector.t (Signal k) sz -> nat -> Signal k
   (* Static slice *)
   | Slice: forall {k sz} (start len: nat), Signal (BitVec k sz) ->
                                            Signal (BitVec k len).
 
+(* A default unsmashed value for a given Kind. *)
 Fixpoint defaultKindSignal (k: Kind) : Signal k :=
   match k with
   | Void => UndefinedSignal
   | Bit => Gnd
-  | BitVec k s => VecLit(Vector.const (defaultKindSignal k) s)
+  | BitVec k s => VecLit (Vector.const (defaultKindSignal k) s)
   | ExternalType s => UninterpretedSignal "default-error"
   end.

--- a/cava/cava/Cava/VectorUtils.v
+++ b/cava/cava/Cava/VectorUtils.v
@@ -20,7 +20,8 @@ Import ListNotations.
 From Coq Require Import Vector.
 Import VectorNotations.
 
-Require Import Arith.
+From Coq Require Import ZArith.
+Require Import Nat Arith Lia.
 
 From ExtLib Require Import Structures.Applicative.
 From ExtLib Require Import Structures.Traversable.
@@ -80,6 +81,35 @@ Program Definition vseq (start len: nat) : Vector.t nat len :=
   Vector.of_list (List.seq start len).
 Next Obligation.
   rewrite List.seq_length. reflexivity.
+Defined.
+
+(******************************************************************************)
+(* Slicing a Vector.t                                                         *)
+(******************************************************************************)
+
+Definition sliceVector {T: Type} {sz: nat}
+                       (v: Vector.t T sz)
+                       (startAt len: nat)
+                       (H: startAt + len <= sz) :
+                       (Vector.t T len).
+Proof.
+  intros.
+
+  pose (sz - startAt) as x.
+  assert (sz = startAt + x).
+  lia.
+  rewrite H0 in v.
+  refine (let (discard, vR) := Vector.splitat startAt v in _).
+  clear discard.
+  assert(len <= x).
+  lia.
+  pose (x - len) as y.
+  assert (x = len + y).
+  lia.
+
+  rewrite H2 in vR.
+  refine (let (vL, discard) := Vector.splitat len vR in _).
+  exact vL.
 Defined.
 
 (* An experimental alternative vector representation *)

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -38,19 +38,10 @@ Require Import Cava.Monad.UnsignedAdders.
 (* by using the tree combinator.                                              *)
 (******************************************************************************)
 
-(* List based adder tree *)
-Definition adderTree {m bit vec} `{Cava m bit vec} {sz: nat}
-                     (n: nat) (v: vec (BitVec Bit sz) (2^(n+1))) :
-                      m (vec Bit sz) :=
-  let vv : Vector.t (vec Bit sz) (2^(n+1)) := vecToVector2 Bit sz v in                
-  tree addNN defaultBitVec n vv.
-
-(* Vector based adder tree which currently does not work *)
-Definition adderTreeV  {m bit vec} `{Cava m bit vec} {sz: nat}
-                       (n: nat) (v: vec (BitVec Bit sz) (2^(n+1))) :
-                       m (vec Bit sz) :=
-  let vv : Vector.t (vec Bit sz) (2^(n+1)) := vecToVector2 Bit sz v in                
-  treeV n addNN vv.
+Definition adderTree {m bit} `{Cava m bit} {sz: nat}
+                     (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
+                     m (Vector.t bit sz) :=              
+  tree n addNN v.
 
 (******************************************************************************)
 (* Some tests.                                                                *)
@@ -68,8 +59,8 @@ Local Open Scope string_scope.
 
 Local Open Scope nat_scope.
 
-Definition adderTree2 {m bit vec} `{Cava m bit vec} {sz}
-                      (v : vec (BitVec Bit sz) 2) : m (vec Bit sz)
+Definition adderTree2 {m bit} `{Cava m bit} {sz: nat}
+                      (v : Vector.t (Vector.t bit sz) 2) : m (Vector.t bit sz)
   := adderTree 0 v.
 
 Local Open Scope vector_scope.
@@ -82,12 +73,13 @@ Proof. reflexivity. Qed.
 
 (* An adder tree with 4 inputs. *)
 
-Definition adderTree4 {m bit} `{Cava m bit} {sz}
-                      (v : vec (BitVec Bit sz) 4) : m (vec Bit sz)
+Definition adderTree4 {m bit} `{Cava m bit} {sz: nat}
+                      (v : Vector.t (Vector.t bit sz) 4) : m (Vector.t bit sz)
   := adderTree 1 v.
 
 Definition v0_3 := [v0; v1; v2; v3].
 Definition sum_v0_3 : Bvector 8 := combinational (adderTree4 v0_3).
+Compute sum_v0_3.
 
 Example sum_v0_v1_v2_v3 : combinational (adderTree4 v0_3) = N2Bv_sized 8 30.
 Proof. reflexivity. Qed.

--- a/cava/monad-examples/xilinx/XilinxAdderTree.v
+++ b/cava/monad-examples/xilinx/XilinxAdderTree.v
@@ -37,11 +37,10 @@ Require Import Cava.Monad.XilinxAdder.
 (* by using the tree combinator.                                              *)
 (******************************************************************************)
 
-Definition adderTree {m bit vec} `{Cava m bit vec} {sz: nat}
-                     (n: nat) (v: vec (BitVec Bit sz) (2^(n+1))) :
-                     m (vec Bit sz) :=
-  let vv : Vector.t (vec Bit sz) (2^(n+1)) := vecToVector2 Bit sz v in 
-  tree xilinxAdder defaultBitVec n vv.
+Definition adderTree {m bit} `{Cava m bit} {sz: nat}
+                     (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
+                     m (Vector.t bit sz) := 
+  tree n xilinxAdder v.
 
 (******************************************************************************)
 (* Some tests.                                                                *)
@@ -62,8 +61,8 @@ Local Open Scope string_scope.
 Local Open Scope nat_scope.
 Local Open Scope vector_scope.
 
-Definition adderTree2 {m bit vec} `{Cava m bit vec} {sz}
-                      (v : vec (BitVec Bit sz) 2) : m (vec Bit sz)
+Definition adderTree2 {m bit} `{Cava m bit} {sz: nat}
+                      (v : Vector.t (Vector.t bit sz) 2) : m (Vector.t bit sz)
   := adderTree 0 v.
 
 Definition v0_v1 : Vector.t (Bvector 8) 2 := [v0; v1].
@@ -75,8 +74,8 @@ Proof. reflexivity. Qed.
 (* An adder tree with 4 inputs.                                               *)
 (******************************************************************************)
 
-Definition adderTree4 {m bit} `{Cava m bit} {sz}
-                      (v : vec (BitVec Bit sz) 4) : m (vec Bit sz)
+Definition adderTree4 {m bit} `{Cava m bit} {sz: nat}
+                      (v : Vector.t (Vector.t bit sz) 4) : m (Vector.t bit sz)
   := adderTree 1 v.
 
 Local Open Scope N_scope.


### PR DESCRIPTION
Having the `vec` parameter in the monad-kernel typeclass was causing a lot of issues even though it meant we did not need to smash vectors. This PR removes this level of parameterization and uses `Vector.t` instead which leads to simpler and easier to use interfaces for circuits. The key functions for smashing and wrapping up smashed values are in the `Types.v` file.