### PR TITLE
A two sorter example.

### DIFF
--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -72,4 +72,7 @@ Class Cava m `{Monad m} bit := {
                 m (Vector.t bit (1 + max a b));
   addNN : forall {a : nat}, Vector.t bit a -> Vector.t bit a ->
                 m (Vector.t bit a);
+  (* Synthesizable relational operators *)
+  greaterThanOrEqual : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
+                       m bit;
 }.

--- a/cava/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/cava/Cava/Monad/CombinationalMonad.v
@@ -135,6 +135,13 @@ Definition unsignedAddBool {m n : nat}
   let sum := (a + b)%N in
   ret (N2Bv_sized sumSize sum).
 
+Definition greaterThanOrEqualBool {m n : nat}
+                                  (av : Bvector m) (bv : Bvector n) :
+                                  ident bool :=
+  let a := N.to_nat (Bv2N av) in
+  let b := N.to_nat (Bv2N bv) in
+  ret (b <=? a).
+
 Local Open Scope N_scope.
 
 Definition addNNBool {m : nat}
@@ -186,6 +193,7 @@ Program Instance CavaBool : Cava ident bool :=
     indexBitConst sz := @indexConstBool Bit sz;
     slice k sz := @sliceBool k sz;
     unsignedAdd m n := @unsignedAddBool m n;
+    greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
     addNN m := @addNNBool m;
 }.
 

--- a/cava/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/cava/Cava/Monad/NetlistGeneration.v
@@ -239,6 +239,14 @@ Definition sliceNet {k: Kind} {sz: nat}
                     smashTy (Signal Bit) (BitVec k len) :=
   sliceVector v startAt len H.              
 
+Definition greaterThanOrEqualNet {m n : nat} 
+                                 (a : Vector.t (Signal Bit) m) (b : Vector.t (Signal Bit) n) :
+                                 state CavaState (Signal Bit) :=
+  comparison <- newWire ;;
+  addInstance (GreaterThanOrEqual (VecLit a) (VecLit b) comparison) ;;
+  ret comparison.
+
+
 (******************************************************************************)
 (* Instantiate the Cava class for CavaNet which describes circuits without    *)
 (* any top-level pins or other module-level data                              *)
@@ -272,4 +280,5 @@ Instance CavaNet : Cava (state CavaState) (Signal _) :=
     slice k sz start len v h := @sliceNet k sz start len v h;
     unsignedAdd m n := @unsignedAddNet m n;
     addNN m := @addNNNet m;
+    greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
 }.

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -93,9 +93,6 @@ Inductive Instance : Type :=
   | Xor:       Signal Bit -> Signal Bit -> Signal Bit -> Instance
   | Xnor:      Signal Bit -> Signal Bit -> Signal Bit -> Instance
   | Buf:       Signal Bit -> Signal Bit -> Instance
-  (* Dynamic indexing *)
-  | IndexDynamic: forall {T: Type} {n isz: nat}, Vector.t T n ->
-                  Vector.t (Signal Bit) isz -> T -> Instance
   (* A Cava unit delay bit component. *)
   | DelayBit:  Signal Bit -> Signal Bit -> Instance
   (* Assignment of bit wire *)
@@ -105,6 +102,11 @@ Inductive Instance : Type :=
                                         Signal (BitVec Bit b) ->
                                         Signal (BitVec Bit c) ->
                                         Instance
+  (* Relational operations *)
+  | GreaterThanOrEqual: forall {a b : nat}, Signal (BitVec Bit a) ->
+                                            Signal (BitVec Bit b) ->
+                                            Signal Bit ->
+                                            Instance
   | Component: forall {k}, string -> list (string * ConstExpr) ->
                                      list (string * Signal k) ->
                                      Instance.
@@ -367,7 +369,7 @@ Definition deLitInstance (inst: Instance) : state CavaState Instance :=
   | DelayBit i o => deLitUnaryOp DelayBit i o
   | AssignSignal a b => deLitUnaryOp AssignSignal a b
   | UnsignedAdd a b c => deLitBinaryOp UnsignedAdd a b c
-  | IndexDynamic v i o => ret (IndexDynamic v i o)
+  | GreaterThanOrEqual a b g => deLitBinaryOp GreaterThanOrEqual a b g
   | Component name pars args =>
       let argNames := map fst args in
       let argSignals := map snd args in

--- a/cava/cava/Cava2SystemVerilog.hs
+++ b/cava/cava/Cava2SystemVerilog.hs
@@ -173,6 +173,8 @@ generateInstance _ (Component _ name parameters connections) instNr =
   mkInstance name parameters connections instNr
 generateInstance _ (UnsignedAdd _ _ _ a b c) _
    = "  assign " ++ showSignal c ++ " = " ++ showSignal a ++ " + " ++ showSignal b ++ ";"
+generateInstance _ (GreaterThanOrEqual _ _ a b g) _
+   = "  assign " ++ showSignal g ++ " = " ++ showSignal a ++ " >= " ++ showSignal b ++ ";"
 
 primitiveInstance :: String -> [Signal] -> Int -> String
 primitiveInstance instName args instNr

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -79,7 +79,6 @@ Definition adderTree4 {m bit} `{Cava m bit} {sz: nat}
 
 Definition v0_3 := [v0; v1; v2; v3].
 Definition sum_v0_3 : Bvector 8 := combinational (adderTree4 v0_3).
-Compute sum_v0_3.
 
 Example sum_v0_v1_v2_v3 : combinational (adderTree4 v0_3) = N2Bv_sized 8 30.
 Proof. reflexivity. Qed.

--- a/cava/monad-examples/ExamplesSV.hs
+++ b/cava/monad-examples/ExamplesSV.hs
@@ -22,6 +22,7 @@ import Multiplexers
 import FullAdder
 import UnsignedAdderExamples
 import AdderTree
+import Sorter
 
 main :: IO ()
 main = do writeSystemVerilog nand2Netlist
@@ -42,3 +43,5 @@ main = do writeSystemVerilog nand2Netlist
           writeTestBench adder_tree4_8_tb
           writeSystemVerilog fullAdderNetlist
           writeTestBench fullAdder_tb
+          writeSystemVerilog two_sorter_Netlist
+          writeTestBench two_sorter_tb

--- a/cava/monad-examples/Makefile
+++ b/cava/monad-examples/Makefile
@@ -21,7 +21,7 @@
 ################################################################################
 
 SV = nand2.sv mux2_1.sv muxBus4_8.sv adder4.sv fullAdder.sv pipelinedNAND.sv \
-     loopedNAND.sv adder_tree4_8.sv
+     loopedNAND.sv adder_tree4_8.sv two_sorter.sv
 
 BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)

--- a/cava/monad-examples/MonadExtraction.v
+++ b/cava/monad-examples/MonadExtraction.v
@@ -20,6 +20,7 @@ Require Import Multiplexers.
 Require Import FullAdder.
 Require Import UnsignedAdderExamples.
 Require Import AdderTree.
+Require Import Sorter.
 From Coq Require Import Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
@@ -34,3 +35,4 @@ Extraction Library Multiplexers.
 Extraction Library FullAdder.
 Extraction Library UnsignedAdderExamples.
 Extraction Library AdderTree.
+Extraction Library Sorter.

--- a/cava/monad-examples/Sorter.v
+++ b/cava/monad-examples/Sorter.v
@@ -1,0 +1,123 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import ExtLib.Structures.Monads.
+
+From Coq Require Import Ascii String.
+
+From Coq Require Import Lists.List.
+Import ListNotations.
+
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
+Import VectorNotations.
+
+From Coq Require Import NArith.Ndigits.
+
+Require Import Cava.Cava.
+Require Import Cava.VectorUtils.
+Require Import Cava.Monad.CavaMonad.
+
+From Coq Require Import Lia Omega.
+
+Local Open Scope vector_scope.
+
+Definition twoSorter {m bit} `{Cava m bit} {n}
+                     (ab: smashTy bit (BitVec (BitVec Bit n) 2)) :
+                     m (Vector.t (Vector.t bit n) 2) :=
+   let a := @Vector.nth_order _ 2 ab 0 (ltac:(lia)) in
+   let b := @Vector.nth_order _ 2 ab 1 (ltac:(lia)) in
+   comparison <- greaterThanOrEqual a b ;;
+   negComparison <- inv comparison ;;
+   let sorted : Vector.t (Vector.t bit n) 2 := [indexAt ab [comparison];
+                                                indexAt ab [negComparison]] in
+   ret sorted.
+
+Definition two_sorter_Interface bitSize
+  := combinationalInterface "two_sorter"
+     (mkPort "inputs" (BitVec (BitVec Bit bitSize) 2))
+     (mkPort "sorted" (BitVec (BitVec Bit bitSize) 2))
+     [].
+
+Definition two_sorter_Netlist
+  := makeNetlist (two_sorter_Interface 8) twoSorter.
+
+Definition v0 := N2Bv_sized 8   5.
+Definition v1 := N2Bv_sized 8 157.
+Definition v2 := N2Bv_sized 8 255.
+Definition v3 := N2Bv_sized 8  63.
+
+Definition two_sorter_tb_inputs : list (Vector.t (Bvector 8) _) :=
+  [[v0; v1];
+   [v1; v0];
+   [v1; v2];
+   [v2; v1];
+   [v2; v3];
+   [v3; v2]
+  ].
+
+Definition adder_tree4_8_tb_expected_outputs : list (Vector.t (Bvector 8) _) :=
+  map (fun i => combinational (twoSorter i)) two_sorter_tb_inputs.
+
+Definition two_sorter_tb :=
+  testBench "two_sorter_tb" (two_sorter_Interface 8)
+  two_sorter_tb_inputs adder_tree4_8_tb_expected_outputs.
+
+Definition twoSorterSpec {bw: nat} (ab : Vector.t (Bvector bw) 2) :
+                                   Vector.t (Bvector bw) 2 :=
+  let a := @Vector.nth_order _ 2 ab 0 (ltac:(lia)) in
+  let b := @Vector.nth_order _ 2 ab 1 (ltac:(lia)) in
+  if N.to_nat (Bv2N b) <=? N.to_nat (Bv2N a) then
+    [b; a]
+  else
+    [a; b].                                      
+
+Lemma two_sorter_correct: forall (n m: nat) (a b: Bvector m),
+      combinational (twoSorter [a; b]) = twoSorterSpec [a; b].
+Proof.
+Abort. (* Proof unfolds in a complicated way. *)
+
+(*
+
+TODO: Fix type error:
+Error:
+In environment
+unpair : forall n : nat, t (nat * nat) n -> t nat (2 * n)
+n : nat
+v : t (nat * nat) n
+n' : nat
+v0 : t (nat * nat) (S n')
+x : nat * nat
+xs : t (nat * nat) n'
+a : nat
+b : nat
+The term "a :: b :: unpair n' xs" has type "t nat (S (S (2 * n')))"
+while it is expected to have type "t nat (2 * S n')".
+
+Fixpoint unpair {n} (v: Vector.t (nat * nat) n) : Vector.t nat (2*n) :=
+  match n, v return Vector.t nat (2*n) with
+  | O, vv => []
+  | S n', vv => let (x, xs) := Vector.uncons v in
+                let (a, b) := x in
+                a :: b :: unpair xs
+  end.
+
+Definition riffle {n} (v: Vector.t nat (2*n)) : Vector.t nat (2*n) :=
+  let '(a, b) := halveV v in
+  let abz := vcombine a b in
+  unpair abz.
+
+*)

--- a/cava/monad-examples/_CoqProject
+++ b/cava/monad-examples/_CoqProject
@@ -7,4 +7,5 @@ FullAdder.v
 FullAdderNat.v
 UnsignedAdderExamples.v
 AdderTree.v
+Sorter.v
 MonadExtraction.v


### PR DESCRIPTION
The leaf component I want to use for a recursive Batcher's bitonic merger/sorter.
The two sorter works in Verilog simulation.

However, I expected the proof of the two sorter's correctness to be easy, but it unfolds in a complicated way.
The next step is to define riffile, but the dependent `Vector.t` types need to be ironed out.