### PR TITLE
Recover smashed arrays in Haskell back-end

### DIFF
--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -57,7 +57,7 @@ Class Cava m `{Monad m} bit := {
   *)
   (* Dynamic indexing *)                                   
   indexAt : forall {k: Kind} {sz isz: nat},
-            smashTy bit (BitVec k sz) -> Vector.t bit isz -> smashTy bit k;
+            Vector.t (smashTy bit k) sz -> Vector.t bit isz -> smashTy bit k;
   indexBitAt : forall {sz isz: nat}, Vector.t bit sz ->
                                      Vector.t bit isz -> bit;
   (* Static indexing *)
@@ -65,8 +65,8 @@ Class Cava m `{Monad m} bit := {
                Vector.t (smashTy bit k) sz -> nat -> smashTy bit k;
   indexBitConst : forall {sz: nat}, Vector.t bit sz -> nat -> bit;
   slice : forall {k: Kind}  {sz: nat} (startAt len: nat),
-                 smashTy bit (BitVec k sz) ->
-                 (startAt + len <= sz) -> smashTy bit (BitVec k len) ;
+                 Vector.t (smashTy bit k) sz ->
+                 (startAt + len <= sz) -> Vector.t (smashTy bit k) len ;
   (* Synthesizable arithmetic operations. *)
   unsignedAdd : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
                 m (Vector.t bit (1 + max a b));

--- a/cava/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/cava/Cava/Monad/CombinationalMonad.v
@@ -102,7 +102,7 @@ Fixpoint defaultKindBool (k: Kind) : smashTy bool k :=
 
 Definition indexAtBool {k: Kind}
                        {sz isz: nat}
-                       (i : smashTy bool (BitVec k sz))
+                       (i : Vector.t (smashTy bool k) sz)
                        (sel : Bvector isz) : smashTy bool k :=
   let selN := Bv2N sel in
   match lt_dec (N.to_nat selN) sz with
@@ -111,7 +111,7 @@ Definition indexAtBool {k: Kind}
   end.
 
 Definition indexConstBool {k: Kind} {sz: nat}
-                          (i : smashTy bool (BitVec k sz))
+                          (i : Vector.t (smashTy bool k) sz)
                           (sel : nat) : smashTy bool k :=
   match lt_dec sel sz with
   | left H => @Vector.nth_order _ _ i sel H
@@ -121,9 +121,9 @@ Definition indexConstBool {k: Kind} {sz: nat}
 Definition sliceBool {k: Kind}
                      {sz: nat} 
                      (startAt len : nat)
-                     (v: smashTy bool (BitVec k sz))
+                     (v: Vector.t (smashTy bool k) sz)
                      (H: startAt + len <= sz) :
-                     smashTy bool (BitVec k len) :=
+                     Vector.t (smashTy bool k) len :=
   sliceVector v startAt len H.                   
 
 Definition unsignedAddBool {m n : nat}

--- a/cava/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/cava/Cava/Monad/NetlistGeneration.v
@@ -221,22 +221,22 @@ Definition loopBitNet (A B : Type) (f : (A * Signal Bit)%type -> state CavaState
   ret b.
 
 Definition indexAtNet {k: Kind} {sz isz: nat}
-                      (v: smashTy (Signal Bit) (BitVec k sz))
+                      (v: Vector.t (smashTy (Signal Bit) k) sz)
                       (i: Vector.t (Signal Bit) isz) :
                       smashTy (Signal Bit) k :=
-  smash (IndexAt (vecLitS v) (VecLit i)).            
+  smash (IndexAt (VecLit (Vector.map vecLitS v)) (VecLit i)).            
 
 Definition indexConstNet {k: Kind} {sz: nat}
-                         (v: smashTy (Signal Bit) (BitVec k sz))
+                         (v: Vector.t (smashTy (Signal Bit) k) sz)
                          (i: nat) :
                          smashTy (Signal Bit) k :=
-  smash (IndexConst (vecLitS v) i). 
+  smash (IndexConst (VecLit(Vector.map vecLitS v)) i). 
 
 Definition sliceNet {k: Kind} {sz: nat}
                     (startAt len: nat)
-                    (v: smashTy (Signal Bit) (BitVec k sz))
+                    (v: Vector.t (smashTy (Signal Bit) k) sz)
                     (H: startAt + len <= sz) :
-                    smashTy (Signal Bit) (BitVec k len) :=
+                    Vector.t (smashTy (Signal Bit) k) len :=
   sliceVector v startAt len H.              
 
 Definition greaterThanOrEqualNet {m n : nat} 
@@ -245,7 +245,6 @@ Definition greaterThanOrEqualNet {m n : nat}
   comparison <- newWire ;;
   addInstance (GreaterThanOrEqual (VecLit a) (VecLit b) comparison) ;;
   ret comparison.
-
 
 (******************************************************************************)
 (* Instantiate the Cava class for CavaNet which describes circuits without    *)

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -322,6 +322,8 @@ Import EqNotations.
    that will be illegal in SystemVerilog. It returns the re-written instances.
 *)
 
+(* NOTE: this is not dead code, it is called from the Haskell back-end.       *)
+
 Fixpoint deLitSignal {w: Kind} (s: Signal w) : state CavaState (Signal w) :=
   let f := fun ty => Signal ty in
   match s as s in Signal w' return w'=w -> state CavaState (Signal w) with
@@ -335,7 +337,7 @@ Fixpoint deLitSignal {w: Kind} (s: Signal w) : state CavaState (Signal w) :=
       iD <- @deLitSignal (BitVec Bit isz) i ;;
       ret (rew [f] H in (IndexAt vD iD))
   | @IndexConst k sz v i => fun H => vD <- @deLitSignal (BitVec k sz) v ;;
-                                     ret (rew [f] H in (IndexConst vD i))
+                                     ret (rew [f] H in (IndexConst vD i))                             
   | @Slice k sz start len v => fun H => vD <- @deLitSignal (BitVec k sz) v ;;
                                         ret (rew [f] H in (Slice start len vD))
   | _ => fun _ => ret s
@@ -431,8 +433,8 @@ Definition wireUpCircuit (intf : CircuitInterface)
   i <- instantiateInputPorts (circuitInputs intf) ;;
   o <- circuit i ;;
   let outType := circuitOutputs intf in 
-  instantiateOutputPorts outType o ;;
-  deLitInstances.
+  instantiateOutputPorts outType o.
+  (* deLitInstances. *)
 
 Definition makeNetlist (intf : CircuitInterface)                      
                        (circuit : signalSmashTy (mapShape port_shape (circuitInputs intf)) ->

--- a/cava/cava/Cava/Signal.v
+++ b/cava/cava/Cava/Signal.v
@@ -32,12 +32,10 @@ Inductive Signal : Kind -> Type :=
   | LocalBitVec: forall k s, N -> Signal (BitVec k s)
   | VecLit: forall {k s}, Vector.t (Signal k) s -> Signal (BitVec k s)
   (* Dynamic index *)
-  | IndexAt: forall {k sz isz}, Signal (BitVec k sz) ->
-             Signal (BitVec Bit isz) -> Signal k
+  | IndexAt:  forall {k sz isz}, Signal (BitVec k sz) ->
+              Signal (BitVec Bit isz) -> Signal k
   (* Static indexing *)
   | IndexConst: forall {k sz}, Signal (BitVec k sz) -> nat -> Signal k
-  (* Static indexing of smashed vectors *)
-  | IndexConstS: forall {k sz}, Vector.t (Signal k) sz -> nat -> Signal k
   (* Static slice *)
   | Slice: forall {k sz} (start len: nat), Signal (BitVec k sz) ->
                                            Signal (BitVec k len).
@@ -50,3 +48,4 @@ Fixpoint defaultKindSignal (k: Kind) : Signal k :=
   | BitVec k s => VecLit (Vector.const (defaultKindSignal k) s)
   | ExternalType s => UninterpretedSignal "default-error"
   end.
+

--- a/cava/monad-examples/Multiplexers.v
+++ b/cava/monad-examples/Multiplexers.v
@@ -141,14 +141,14 @@ Definition muxBusAlt {m bit} `{Cava m bit} {k} {sz isz: nat}
   ret (indexAt v sel).
 
 Definition muxBus {m bit} `{Cava m bit} {sz isz dsz: nat}
-                     (vsel: smashTy bit (BitVec (BitVec Bit dsz) sz) *
+                     (vsel: Vector.t (smashTy bit (BitVec Bit dsz)) sz *
                             Vector.t bit isz) :
                      m (smashTy bit (BitVec Bit dsz)) :=
   let (v, sel) := vsel in
   ret (indexAt v sel).
 
 Definition muxBus4_8 {m bit} `{Cava m bit} 
-                     (vsel: smashTy bit (BitVec (BitVec Bit 8) 4) *
+                     (vsel: Vector.t (smashTy bit (BitVec Bit 8)) 4 *
                             Vector.t bit 2) :
                      m (smashTy bit (BitVec Bit 8)) :=
   let (v, sel) := vsel in

--- a/cava/monad-examples/Sorter.v
+++ b/cava/monad-examples/Sorter.v
@@ -35,11 +35,14 @@ From Coq Require Import Lia Omega.
 
 Local Open Scope vector_scope.
 
+Lemma zero_lt_z: 0 < 2. auto. Qed.
+Lemma one_lt_z: 1 < 2. auto. Qed.
+
 Definition twoSorter {m bit} `{Cava m bit} {n}
-                     (ab: smashTy bit (BitVec (BitVec Bit n) 2)) :
+                     (ab: Vector.t (smashTy bit (BitVec Bit n)) 2) :
                      m (Vector.t (Vector.t bit n) 2) :=
-   let a := @Vector.nth_order _ 2 ab 0 (ltac:(lia)) in
-   let b := @Vector.nth_order _ 2 ab 1 (ltac:(lia)) in
+   let a := @Vector.nth_order _ 2 ab 0 zero_lt_z in
+   let b := @Vector.nth_order _ 2 ab 1 one_lt_z in
    comparison <- greaterThanOrEqual a b ;;
    negComparison <- inv comparison ;;
    let sorted : Vector.t (Vector.t bit n) 2 := [indexAt ab [comparison];


### PR DESCRIPTION
This improves the quality of the generated SystemVerilog for many uses of dynamic and static indexing.
There is still an explosion in the unsmshing and de-literalization process that makes the two sorter example not work out well (but still generated valid SystemVerilog that is synthesis equivalent to a good implementation). Slicing also still needs to be supported. These two points will be addressed in a subsequent PR.