### PR TITLE
Improve quality of SystemVerilog generated for indexing vectors

### DIFF
--- a/cava/cava/Cava2HDL.cabal
+++ b/cava/cava/Cava2HDL.cabal
@@ -105,9 +105,5 @@ library
                      String
                      Traversable
                      Wf
-                     EquivDec
-                     Injection
-                     List0
-                     RelDec
 
   default-language:  Haskell2010


### PR DESCRIPTION
This PR improves the quality of the generated SystemVerilog for several of our example circuits by adding mode smashed vector recovery optimizations. For example:

For the Cava:
```coq
Definition muxBus4_8 {m bit} `{Cava m bit} 
                     (vsel: Vector.t (smashTy bit (BitVec Bit 8)) 4 *
                            Vector.t bit 2) :
                     m (smashTy bit (BitVec Bit 8)) :=
  let (v, sel) := vsel in
  ret (indexAt v sel).
```
Generated SystemVerilog:
```verilog
module muxBus4_8(
  input   logic[1:0] sel,
  input   logic[7:0] i[4],
  output   logic[7:0] o
  );

  timeunit 1ns; timeprecision 1ns;

  logic zero;
  logic one;

  // Constant nets
  assign zero = 1'b0;
  assign one = 1'b1;

  assign o = i[sel];

endmodule
```
For the Cava:
```coq
Definition twoSorter {m bit} `{Cava m bit} {n}
                     (ab: Vector.t (smashTy bit (BitVec Bit n)) 2) :
                     m (Vector.t (Vector.t bit n) 2) :=
   let a := @Vector.nth_order _ 2 ab 0 zero_lt_z in
   let b := @Vector.nth_order _ 2 ab 1 one_lt_z in
   comparison <- greaterThanOrEqual a b ;;
   negComparison <- inv comparison ;;
   let sorted : Vector.t (Vector.t bit n) 2 := [indexAt ab [comparison];
                                                indexAt ab [negComparison]] in
   ret sorted.
```
The generated SystemVerilog:
```verilog
module two_sorter(
  input   logic[7:0] inputs[2],
  output   logic[7:0] sorted[2]
  );

  timeunit 1ns; timeprecision 1ns;

  logic zero;
  logic one;
  logic[1:0] net;

  // Constant nets
  assign zero = 1'b0;
  assign one = 1'b1;

  assign sorted = '{inputs[{net[0]}],inputs[{net[1]}]};
  not inst_1 (net[1],net[0]);
  assign net[0] = inputs[0] >= inputs[1];

endmodule
```
