### PR TITLE
Recover slice indexing for smashed vectors

### DIFF
--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -70,8 +70,6 @@ Class Cava m `{Monad m} bit := {
   (* Synthesizable arithmetic operations. *)
   unsignedAdd : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
                 m (Vector.t bit (1 + max a b));
-  addNN : forall {a : nat}, Vector.t bit a -> Vector.t bit a ->
-                m (Vector.t bit a);
   (* Synthesizable relational operators *)
   greaterThanOrEqual : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
                        m bit;

--- a/cava/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/cava/Cava/Monad/CombinationalMonad.v
@@ -28,6 +28,8 @@ From Coq Require Import Fin.
 From Coq Require Import NArith.Ndigits.
 From Coq Require Import ZArith.
 
+From Coq Require Import Lia.
+
 Require Import Cava.Cava.
 From Cava Require Import Kind.
 From Cava Require Import Signal.
@@ -124,8 +126,8 @@ Definition sliceBool {k: Kind}
                      (v: Vector.t (smashTy bool k) sz)
                      (H: startAt + len <= sz) :
                      Vector.t (smashTy bool k) len :=
-  sliceVector v startAt len H.                   
-
+  sliceVector v startAt len H.
+                
 Definition unsignedAddBool {m n : nat}
                            (av : Bvector m) (bv : Bvector n) :
                            ident (Bvector (1 + max m n)) :=
@@ -141,18 +143,6 @@ Definition greaterThanOrEqualBool {m n : nat}
   let a := N.to_nat (Bv2N av) in
   let b := N.to_nat (Bv2N bv) in
   ret (b <=? a).
-
-Local Open Scope N_scope.
-
-Definition addNNBool {m : nat}
-                     (av : Bvector m) (bv : Bvector m) :
-                     ident (Bvector m) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let sum := (a + b) mod 2^(N.of_nat m) in
-  ret (N2Bv_sized m sum).
-
-Local Close Scope N_scope.
 
 Definition bufBool (i : bool) : ident bool :=
   ret i.
@@ -194,7 +184,6 @@ Program Instance CavaBool : Cava ident bool :=
     slice k sz := @sliceBool k sz;
     unsignedAdd m n := @unsignedAddBool m n;
     greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
-    addNN m := @addNNBool m;
 }.
 
 (******************************************************************************)

--- a/cava/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/cava/Cava/Monad/NetlistGeneration.v
@@ -200,15 +200,6 @@ Definition unsignedAddNet {m n : nat}
   let smashedSum := Vector.map (fun i => IndexConst sum i) (vseq 0 (1 + (max m n))) in
   ret smashedSum.
 
-Definition addNNNet {m : nat} 
-                    (a : Vector.t (Signal Bit) m)
-                    (b : Vector.t (Signal Bit) m) :
-                    state CavaState (Vector.t (Signal Bit) m) :=
-  sum <- newVector Bit m ;;
-  addInstance (UnsignedAdd (VecLit a) (VecLit b) sum) ;;
-  let smashedSum := Vector.map (fun i => IndexConst sum i) (vseq 0 m) in
-  ret smashedSum.
-
 Definition delayBitNet (i : Signal Bit) : state CavaState (Signal Bit) :=
   o <- newWire ;;
   addInstance (DelayBit i o) ;;
@@ -278,6 +269,5 @@ Instance CavaNet : Cava (state CavaState) (Signal _) :=
     indexBitConst sz := @indexConstNet Bit sz;
     slice k sz start len v h := @sliceNet k sz start len v h;
     unsignedAdd m n := @unsignedAddNet m n;
-    addNN m := @addNNNet m;
     greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
 }.

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -26,17 +26,28 @@ Require Import Cava.Monad.CavaMonad.
 (* An adder with two inputs of the same size and no bit-growth                *)
 (******************************************************************************)
 
-Lemma n_le_max_n_n : forall n, n <= S(max n n).
-Proof.
-  intros. lia.
-Qed.
+Lemma n_le_n_plus_1 : forall n, 0 + n <= 1 + n.
+Proof. auto. Defined.
 
-(*
+Lemma max_n_n : forall n, max n n = n.
+Proof.
+  intros.
+  induction n.
+  - reflexivity.
+  - simpl. rewrite IHn. reflexivity.
+Defined.  
+
+Definition deMax {m bit} `{Cava m bit} {n} (v: Vector.t bit (1 + max n n)) :
+                 Vector.t (smashTy bit Bit) (1+n).
+Proof.
+  rewrite max_n_n in v.
+  unfold smashTy. apply v.
+Defined. 
+   
 Definition addN {m bit} `{Cava m bit} {n}
                 (a: Vector.t bit n) (b: Vector.t bit n) : m (Vector.t bit n) :=               
   s <- unsignedAdd a b ;;
-  ret (slice 0 n _ (n_le_max_n_n n)).
-*)
+  ret (slice 0 n (deMax s) (n_le_n_plus_1 _)).
 
 (******************************************************************************)
 (* A three input adder.                                                       *)

--- a/cava/cava/Cava/VectorUtils.v
+++ b/cava/cava/Cava/VectorUtils.v
@@ -87,30 +87,20 @@ Defined.
 (* Slicing a Vector.t                                                         *)
 (******************************************************************************)
 
-Definition sliceVector {T: Type} {sz: nat}
-                       (v: Vector.t T sz)
-                       (startAt len: nat)
-                       (H: startAt + len <= sz) :
-                       (Vector.t T len).
-Proof.
-  intros.
+Import EqNotations.
 
-  pose (sz - startAt) as x.
-  assert (sz = startAt + x).
-  lia.
-  rewrite H0 in v.
-  refine (let (discard, vR) := Vector.splitat startAt v in _).
-  clear discard.
-  assert(len <= x).
-  lia.
-  pose (x - len) as y.
-  assert (x = len + y).
-  lia.
-
-  rewrite H2 in vR.
-  refine (let (vL, discard) := Vector.splitat len vR in _).
-  exact vL.
-Defined.
+Fixpoint sliceVector {T: Type} {s: nat} (v: Vector.t T s) (startAt len : nat)
+                     (H: startAt + len <= s) : Vector.t T len :=
+  match Nat.eq_dec s (startAt + (s - startAt)) with 
+    | left Heq =>
+      let '(_, v) := Vector.splitat startAt (rew [fun x => Vector.t T x] Heq in v)
+      in
+        match Nat.eq_dec (s-startAt) (len + ((s-startAt) - len)) with 
+        | left Heq => fst (Vector.splitat len (rew [fun x => Vector.t T x] Heq in v))
+        | right Hneq => (ltac:(abstract lia))
+        end
+    | right Hneq => (ltac:(abstract lia))
+    end.
 
 (* An experimental alternative vector representation *)
 

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -41,7 +41,7 @@ Require Import Cava.Monad.UnsignedAdders.
 Definition adderTree {m bit} `{Cava m bit} {sz: nat}
                      (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
                      m (Vector.t bit sz) :=              
-  tree n addNN v.
+  tree n addN v.
 
 (******************************************************************************)
 (* Some tests.                                                                *)

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -51,11 +51,6 @@ Definition bv5_30 := N2Bv_sized 5 30.
 (* Test adders with no bit-growth and equal-sized inputs                      *)
 (******************************************************************************)
 
-Definition addN {m bit} `{Cava m bit} {sz: nat}
-                (a: Vector.t bit sz) (b: Vector.t bit sz) :
-                m (Vector.t bit sz)
-  := addNN a b.
-  
 (* Check 0 + 0 = 0 *)
 Example add0_0 : combinational (addN bv4_0 bv4_0) = bv4_0.
 Proof. reflexivity. Qed.


### PR DESCRIPTION
Vector slices are now recovered. The adder with no bit-growth is no longer in the kernel of the monad backend but is defined as a library function using indexing. The generated SystemVerilog for one of the adder trees shows correct slicing that captures the truncation required for no bit-growth.
```verilog
module adder_tree4_8(
  input   logic[7:0] inputs[4],
  output   logic[7:0] sum
  );

  timeunit 1ns; timeprecision 1ns;

  logic zero;
  logic one;
  logic[8:0] v0;
  logic[8:0] v1;
  logic[8:0] v2;

  // Constant nets
  assign zero = 1'b0;
  assign one = 1'b1;

  assign sum = v2[7:0];
  assign v2 = v0[7:0] + v1[7:0];
  assign v1 = inputs[2] + inputs[3];
  assign v0 = inputs[0] + inputs[1];

endmodule
```