### PR TITLE
Implement declaration and instantiation of black-box components

### DIFF
--- a/cava/cava/Cava/Signal.v
+++ b/cava/cava/Cava/Signal.v
@@ -23,7 +23,8 @@ From Cava Require Import VectorUtils.
 
 Inductive Signal : Kind -> Type :=
   | UndefinedSignal : Signal Void
-  | UninterpretedSignal: forall {t}, string -> Signal (ExternalType t)
+  | UninterpretedSignal: forall {t: string}, string -> Signal (ExternalType t)
+  | UninterpretedSignalIndex: forall (t: string), N -> Signal (ExternalType t)
   | Gnd: Signal Bit
   | Vcc: Signal Bit
   | Wire: N -> Signal Bit

--- a/cava/cava/Cava/Types.v
+++ b/cava/cava/Cava/Types.v
@@ -263,3 +263,16 @@ Fixpoint vecLitS {k: Kind} (v: smashTy (Signal Bit) k) : Signal k :=
   | ExternalType s, _ => UninterpretedSignal "vecLitS-error"
   end.
   
+Fixpoint signalNetSmashTy (s : @shape Kind) : Type :=
+  match s with
+  | Empty  => unit
+  | One t => Signal t
+  | Tuple2 s1 s2  => (signalNetSmashTy s1) * (signalNetSmashTy s2)
+  end.
+
+Fixpoint recoverShape (sh: shape) (v: signalNetSmashTy sh) :=
+  match sh, v with
+  | Empty, _ => Empty
+  | One t, ov => One (USignal ov)
+  | Tuple2 s1 s2, (v1, v2) => Tuple2 (recoverShape s1 v1) (recoverShape s2 v2)
+  end.

--- a/cava/opentitan/pinmux/Makefile
+++ b/cava/opentitan/pinmux/Makefile
@@ -16,7 +16,7 @@
 
 .PHONY: all coq clean
 
-all:		coq
+all:		coq pinmux.sv
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
@@ -27,5 +27,13 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+PinmuxSV:	PinmuxSV.hs
+		ghc --make $^
+
+pinmux.sv:	coq PinmuxSV
+		./PinmuxSV
+
 clean:		
 		-@$(MAKE) -f Makefile.coq clean
+		rm -rf PinmuxSV.hi PinmuxSV.o PinmuxSV Makefile.coq.conf \
+		       Pinmux.vo Pinmux.o Pinmux.hs Pinmux.hi pinmux.sv

--- a/cava/opentitan/pinmux/PinmuxExtraction.v
+++ b/cava/opentitan/pinmux/PinmuxExtraction.v
@@ -1,0 +1,27 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Pinmux.
+
+From Coq Require Import Extraction.
+From Coq Require Import extraction.ExtrHaskellZInteger.
+From Coq Require Import extraction.ExtrHaskellString.
+From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellNatInteger.
+
+Extraction Language Haskell.
+
+Extraction Library Pinmux.

--- a/cava/opentitan/pinmux/PinmuxSV.hs
+++ b/cava/opentitan/pinmux/PinmuxSV.hs
@@ -1,0 +1,23 @@
+{- Copyright 2020 The Project Oak Authors
+  
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-}
+
+
+module Main where
+
+import Cava2SystemVerilog
+import Pinmux
+
+main :: IO ()
+main = do writeSystemVerilog pinmux_netlist

--- a/cava/opentitan/pinmux/_CoqProject
+++ b/cava/opentitan/pinmux/_CoqProject
@@ -1,2 +1,3 @@
 -R ../../cava/Cava Cava
 Pinmux.v
+PinmuxExtraction.v


### PR DESCRIPTION
This PR allows blax-box components to be instantiated from circuit interface declarations. The PR demonstrates it use for instantiating the pinmux_reg_top component:
```
Definition pinmux_reg_top_Interface :=
   sequentialInterface "pinmux_reg_top"
   "clk_i" PositiveEdge "rst_ni" NegativeEdge
   (mkPort "tl_i" (ExternalType "tlul_pkg::tl_h2d_t"),
    mkPort "devmode_i" Bit)
   (mkPort "tl_o" (ExternalType "tlul_pkg::tl_d2h_t"),
    mkPort "reg2hw" (ExternalType "pinmux_reg_pkg::pinmux_reg2hw_t"))
   [].
...
  const1 <- one ;;
  '(tl_o, reg2hw) <- blackBox pinmux_reg_top_Interface (tl_i, const1) ;;
```
This generates SystemVerilog for the black-box component:
```verilog
  pinmux_reg_top inst_4 (.clk_i(clk_i),.rst_ni(rst_ni),.tl_i(tl_i),.devmode_i(one),.tl_o(ext_0),.reg2hw(ext_1));
```
although modules that use `blackBox` can't have a simulation interpretation since we don't know the semantics of the black-box.