### PR TITLE
Close Arrow expressions so that variables are out of scope for splices

### DIFF
--- a/cava/arrow-examples/SyntaxExamples.v
+++ b/cava/arrow-examples/SyntaxExamples.v
@@ -25,11 +25,10 @@ Import ListNotations.
 
 Section notation.
   Import KappaNotation. 
-
-  Variable var: Kind -> Kind -> Type.
+  Local Open Scope kind_scope.
 
   Definition xilinxFullAdder
-    : CavaExpr var << Bit, << Bit, Bit >>, Unit >> << Bit, Bit >> :=
+    : forall cava: Cava, << Bit, << Bit, Bit >>, Unit >> ~> << Bit, Bit >> :=
     <[ \ cin ab =>
       let '(a,b) = ab in
       let part_sum = xor a b in
@@ -40,9 +39,6 @@ Section notation.
 End notation.
 
 Open Scope kind_scope.
-Definition xilinxFullAdder_arrow {cava: Cava}
-  : << Bit, << Bit, Bit >> >> ~> <<Bit, Bit>>
-  := to_arrow @xilinxFullAdder.
 
-Lemma xilinxFullAdder_is_combinational: wf_combinational xilinxFullAdder_arrow.
+Lemma xilinxFullAdder_is_combinational: wf_combinational (xilinxFullAdder _).
 Proof. combinational_obvious. Qed.

--- a/cava/arrow-examples/UnsignedAdder.v
+++ b/cava/arrow-examples/UnsignedAdder.v
@@ -25,163 +25,140 @@ Local Open Scope string_scope.
 
 Section notation.
   Import KappaNotation.
+  Local Open Scope kind_scope.
 
-  Section var.
-    Variable var: Kind -> Kind -> Type.
+  Definition rewrite_vector {A x y} (H: x = y)
+    (cava: Cava): << Vector A x, Unit >> ~> <<Vector A y>>
+    :=
+  match PeanoNat.Nat.eq_dec x y with
+  | left Heq =>
+    rew [fun x => << _, _ >> ~> <<Vector A x>> ] Heq in <[\x=>x]> cava
+  | right Hneq => (ltac:(contradiction))
+  end.
 
-    Definition rewrite_vector {A x y} (H: x = y)
-      : CavaExpr var << Vector A x, Unit >> <<Vector A y>>
-      :=
-    match PeanoNat.Nat.eq_dec x y with
-    | left Heq =>
-      rew [fun x => CavaExpr var << _, _ >> <<Vector A x>> ] Heq in Id
-    | right Hneq => (ltac:(exfalso;contradiction))
-    end.
+  Definition rewrite_kind {x y} (H: x = y)
+    (cava: Cava): << x, Unit >> ~> y
+    :=
+  match decKind x y with
+  | left Heq =>
+    rew [fun x => << _ >> ~> <<x>> ] Heq in <[\x=>x]> cava
+  | right Hneq => (ltac:(contradiction))
+  end.
 
-    Definition rewrite_kind {x y} (H: x = y)
-      : CavaExpr var << x, Unit >> y
-      :=
-    match decKind x y with
-    | left Heq =>
-      rew [fun x => CavaExpr var << _ >> <<x>> ] Heq in Id
-    | right Hneq => (ltac:(exfalso;contradiction))
-    end.
+  Definition unsigned_adder a b c
+  : forall cava: Cava, << Vector Bit a, Vector Bit b, Unit >> ~> (Vector Bit c) :=
+  <[ \ x y => unsigned_add a b c x y ]>.
 
-    Definition unsigned_adder a b c
-    : CavaExpr var << Vector Bit a, Vector Bit b, Unit >> (Vector Bit c) :=
-    <[ \ x y => unsigned_add a b c x y ]>.
+  Definition adder3 s1 s2 s3
+  : forall cava: Cava, << Vector Bit s1, Vector Bit s2, Vector Bit s3, Unit >> ~> (Vector Bit _) :=
+  <[ \ a b c => a + b + c ]>.
 
-    Definition adder3 s1 s2 s3
-    : CavaExpr var << Vector Bit s1, Vector Bit s2, Vector Bit s3, Unit >> (Vector Bit _) :=
-    <[ \ a b c => a + b + c ]>.
+  Definition split_pow2 A n
+    : forall cava: Cava, << Vector A (2^(S n)), Unit >> ~> <<Vector A (2^n), Vector A (2^n)>>.
+    refine (<[\ x => 
+      let '(l,r) = split_at (2^n) x in
+      (l, !(rewrite_vector _) r)
+        ]>);
+    induction n; simpl; auto; nia.
+  Defined.
 
-    Definition split_pow2 A n
-      : CavaExpr var << Vector A (2^(S n)), Unit >> <<Vector A (2^n), Vector A (2^n)>>.
-      refine (<[\ x => 
-        let '(l,r) = split_at (2^n) x in
-        (l, !(rewrite_vector _) r)
-         ]>);
-      induction n; simpl; auto; nia.
-    Defined.
-
-    Fixpoint tree (A: Kind) (n: nat)
-      (f: CavaExpr var << A, A, Unit >> A) {struct n}
-      : CavaExpr var << Vector A (2^(n+1)), Unit >> A :=
-    match n with
-    | O => <[ \ vec =>
-        let '(a,vec') = uncons vec in
-        let '(b,_) = uncons vec' in
+  Fixpoint tree (A: Kind) (n: nat)
+    (f: forall cava: Cava, << A, A, Unit >> ~> A) {struct n}
+    : forall cava: Cava, << Vector A (2^(n+1)), Unit >> ~> A :=
+  match n with
+  | O => <[ \ vec =>
+      let '(a,vec') = uncons vec in
+      let '(b,_) = uncons vec' in
+      !f a b
+    ]>
+  | S n' => 
+    <[\ x =>
+        let '(left,right) = !(split_pow2 A (n'+1)) x in
+        let a = !(tree A n' f) left in
+        let b = !(tree A n' f) right in
         !f a b
-      ]>
-    | S n' => 
-      <[\ x =>
-          let '(left,right) = !(split_pow2 A (n'+1)) x in
-          let a = !(tree A n' f) left in
-          let b = !(tree A n' f) right in
-          !f a b
-      ]>
+    ]>
+  end.
+
+  Definition tree_adder a n
+  : forall cava: Cava, << Vector (Vector Bit a) (2^(n+1)), Unit >> ~> (Vector Bit a) :=
+  <[ \ v => !(tree (Vector Bit a) n (unsigned_adder a a a)) v  ]>.
+
+  Fixpoint dt_tree_fold'
+    (n k: nat)
+    (T: nat -> Kind)
+    (f: forall n, forall cava: Cava, << T n, T n, Unit >> ~> (T (S n))) {struct n}
+    : forall cava: Cava, << Vector (T k) (2^(n + 1)), Unit >> ~> (T (S (n + k))) :=
+  match n with
+  | O => 
+    <[ \ vec =>
+      let '(a,vec') = uncons vec in
+      let '(b,_) = uncons vec' in
+      !(rewrite_kind (ltac:(auto))) (!(f k) a b)
+    ]>
+  | S n' =>  
+    <[\ x =>
+        let '(left,right) = !(split_pow2 (T k) (n'+1)) x in
+        let a = !(dt_tree_fold' n' k T f) left in
+        let b = !(dt_tree_fold' n' k T f) right in
+        !(f _) a b
+    ]>
+  end.
+
+  Definition dt_tree_fold
+    (n: nat)
+    (T: nat -> Kind)
+    (f: forall n, forall cava: Cava, << T n, T n, Unit >> ~> T (S n)) 
+    (cava: Cava)
+    : << Vector (T 0) (2^(n + 1)), Unit >> ~> T (S n) :=
+    match PeanoNat.Nat.eq_dec (S (n + 0)) (S n) with
+    | left Heq => rew [fun x => <<_>> ~> <<T x>> ] Heq in dt_tree_fold' n 0 T f cava
+    | right Hneq => (ltac:(exfalso; abstract lia))
     end.
 
-    Definition tree_adder a n
-    : CavaExpr var << Vector (Vector Bit a) (2^(n+1)), Unit >> (Vector Bit a) :=
-    <[ \ v => !(tree (Vector Bit a) n (unsigned_adder a a a)) v  ]>.
+  Lemma max_nn_add_1_is_S_n: forall n, 1 + max n n = S n.
+  Proof. intros; rewrite PeanoNat.Nat.max_id; auto. Qed.
 
-    Fixpoint dt_tree_fold'
-      (n k: nat)
-      (T: nat -> Kind)
-      (f: forall n, CavaExpr var << T n, T n, Unit >> (T (S n))) {struct n}
-      : CavaExpr var << Vector (T k) (2^(n + 1)), Unit >> (T (S (n + k))) :=
-    match n with
-    | O => 
-      <[ \ vec =>
-        let '(a,vec') = uncons vec in
-        let '(b,_) = uncons vec' in
-        !(rewrite_kind (ltac:(auto))) (!(f k) a b)
-      ]>
-    | S n' =>  
-      <[\ x =>
-          let '(left,right) = !(split_pow2 (T k) (n'+1)) x in
-          let a = !(dt_tree_fold' n' k T f) left in
-          let b = !(dt_tree_fold' n' k T f) right in
-          !(f _) a b
-      ]>
-    end.
+  Definition growth_adder n 
+  : forall cava: Cava, << Vector Bit n, Vector Bit n, Unit >> ~> Vector Bit (S n) :=
+  <[ \ a b => !(rewrite_vector (max_nn_add_1_is_S_n _)) (a + b) ]>.
 
-    Definition dt_tree_fold
-      (n: nat)
-      (T: nat -> Kind)
-      (f: forall n, CavaExpr var << T n, T n, Unit >> (T (S n))) 
-      : CavaExpr var << Vector (T 0) (2^(n + 1)), Unit >> (T (S n)) :=
-      match PeanoNat.Nat.eq_dec (S (n + 0)) (S n) with
-      | left Heq => rew [fun x => CavaExpr var <<_>> <<T x>> ] Heq in dt_tree_fold' n 0 T f
-      | right Hneq => (ltac:(exfalso; abstract lia))
-      end.
-
-    Lemma max_nn_add_1_is_S_n: forall n, 1 + max n n = S n.
-    Proof. intros; rewrite PeanoNat.Nat.max_id; auto. Qed.
-
-    Definition growth_adder n 
-    : CavaExpr var << Vector Bit n, Vector Bit n, Unit >> (Vector Bit (S n)) :=
-    <[ \ a b => !(rewrite_vector (max_nn_add_1_is_S_n _)) (a + b) ]>.
-
-    Definition growth_tree_adder a n
-    : CavaExpr var << Vector (Vector Bit a) (2^(n+1)), Unit >> (Vector Bit (S (n + a)) ) :=
-    <[ \ v => !(dt_tree_fold' n a (Vector Bit) (growth_adder)) v  ]>.
-
-  End var.
+  Definition growth_tree_adder a n
+  : forall cava: Cava, << Vector (Vector Bit a) (2^(n+1)), Unit >> ~> Vector Bit (S (n + a)) :=
+  <[ \ v => !(dt_tree_fold' n a (Vector Bit) (growth_adder)) v  ]>.
 
 End notation.
 
 Open Scope kind_scope.
-Definition adder445 {cava: Cava}: 
-    << Vector Bit 4, Vector Bit 4 >> ~[cava]~> (Vector Bit 5) 
-  := to_arrow (fun var => unsigned_adder var 4 4 5).
+Definition adder445: forall cava: Cava,
+    << Vector Bit 4, Vector Bit 4, Unit >> ~[cava]~> (Vector Bit 5) 
+  := unsigned_adder 4 4 5.
 
-Lemma adder445_is_combinational: wf_combinational adder445.
+Lemma adder445_is_combinational: wf_combinational (adder445 _).
 Proof. combinational_obvious. Qed.
 
-Definition adder88810 {cava: Cava}: 
-    << Vector Bit 8, Vector Bit 8, Vector Bit 8 >> ~[cava]~> (Vector Bit 10) 
-  := to_arrow (fun var => adder3 var 8 8 8).
+Definition adder88810: forall cava: Cava,
+    << Vector Bit 8, Vector Bit 8, Vector Bit 8, Unit >> ~[cava]~> (Vector Bit 10) 
+  := adder3 8 8 8.
 
-Lemma adder88810_is_combinational: wf_combinational adder88810.
+Lemma adder88810_is_combinational: wf_combinational (adder88810 _).
 Proof. combinational_obvious. Qed.
 
-Lemma adder_tree_4_wf: forall (cava:Cava), wf_debrujin [] (desugar (tree_adder _ 4 1)).
-Proof. compute; tauto. Qed.
-Lemma adder_tree_8_wf: forall (cava:Cava), wf_debrujin [] (desugar (tree_adder _ 4 2)).
-Proof. compute; tauto. Qed.
-Lemma adder_tree_64_wf: forall (cava:Cava), wf_debrujin [] (desugar (tree_adder _ 4 5)).
-Proof. compute; tauto. Qed.
+Definition adder444_tree_4: forall cava: Cava, 
+  << Vector (Vector Bit 4) 4, Unit >> ~[cava]~> (Vector Bit 4) 
+  := tree_adder 4 1.
 
-Lemma growth_tree_8_wf: forall (cava:Cava), wf_debrujin [] (desugar (growth_tree_adder _ 4 2)).
-Proof. compute; tauto. Show Proof. Qed.
+Definition adder444_tree_8: forall cava: Cava, 
+  << Vector (Vector Bit 4) 8, Unit >> ~[cava]~> (Vector Bit 4) 
+  := tree_adder 4 2.
 
-Definition adder444_tree_4 {cava: Cava}: 
-  << Vector (Vector Bit 4) 4 >> ~[cava]~> (Vector Bit 4) 
-  := insert_rightmost_tt1 _ >>> Arrow.uncancelr >>> 
-  (closure_conversion' (object_decidable_equality:=decKind) []
-    (desugar (tree_adder _ 4 1))
-    (adder_tree_4_wf cava)).
-Definition adder444_tree_8 {cava: Cava}: 
-  << Vector (Vector Bit 4) 8 >> ~[cava]~> (Vector Bit 4) 
-  := insert_rightmost_tt1 _ >>> Arrow.uncancelr >>> 
-  closure_conversion' (object_decidable_equality:=decKind) []
-  ((desugar (tree_adder _ 4 2)))
-  (adder_tree_8_wf cava).
-Definition adder444_tree_64 {cava: Cava}: 
-  << Vector (Vector Bit 4) 64 >> ~[cava]~> (Vector Bit 4) 
-  := insert_rightmost_tt1 _ >>> Arrow.uncancelr >>> 
-  closure_conversion' (object_decidable_equality:=decKind) []
-  ((desugar (tree_adder _ 4 5)))
-  (adder_tree_64_wf  cava).
+Definition adder444_tree_64: forall cava: Cava,
+  << Vector (Vector Bit 4) 64, Unit >> ~[cava]~> (Vector Bit 4) 
+  := tree_adder 4 5.
 
-Definition growth_tree_8 {cava: Cava}: 
-  << Vector (Vector Bit 4) 8>> ~[cava]~> (Vector Bit 7) 
-  := insert_rightmost_tt1 _ >>> Arrow.uncancelr >>> 
-  (closure_conversion' (object_decidable_equality:=decKind) []
-    (desugar (growth_tree_adder _ 4 2))
-    (growth_tree_8_wf cava)).
+Definition growth_tree_8: forall cava: Cava, 
+  << Vector (Vector Bit 4) 8, Unit >> ~[cava]~> (Vector Bit 7) 
+  := growth_tree_adder 4 2.
 
 Require Import Cava.Types.
 Require Import Cava.Netlist.
@@ -258,7 +235,7 @@ Definition adder444_tree_4_inputs :=
   map (fun '(x, y, z, w) => [N2Bv_sized 4 x; N2Bv_sized 4 y; N2Bv_sized 4 z; N2Bv_sized 4 w]%vector)
   [(0, 0, 0, 1); (1, 1, 1, 1); (1, 3, 5, 2); (15, 1, 1, 1)]%N.
 
-Lemma adder444_tree_4_is_combinational: wf_combinational adder444_tree_4.
+Lemma adder444_tree_4_is_combinational: wf_combinational (adder444_tree_4 _).
 Proof. combinational_obvious. Qed.
 
 Definition adder444_tree_4_tb_expected_outputs
@@ -279,7 +256,7 @@ Definition growth_tree_8_inputs :=
   ;[15; 15; 15; 15; 15; 15; 15; 15]%vector %N
   ].
 
-Lemma growth_tree_8_is_combinational: wf_combinational growth_tree_8.
+Lemma growth_tree_8_is_combinational: wf_combinational (growth_tree_8 _).
 Proof. combinational_obvious. Qed.
 
 Definition growth_tree_8_tb_expected_outputs

--- a/cava/cava/Cava/Arrow/CavaArrow.v
+++ b/cava/cava/Cava/Arrow/CavaArrow.v
@@ -81,6 +81,7 @@ Ltac reduce_kind_eq :=
 Declare Scope kind_scope.
 Bind Scope kind_scope with Kind.
 Delimit Scope kind_scope with Kind.
+Delimit Scope kind_scope with Category.
 
 Notation "<< x >>" := (x) : kind_scope.
 Notation "<< x , .. , y , z >>" := (Tuple x .. (Tuple y z )  .. ) : kind_scope.
@@ -141,6 +142,8 @@ Class Cava := {
 
   constant : bool -> (Unit ~> Bit);
   constant_bitvec n: N -> (Unit ~> Vector Bit n);
+
+  mk_module i o: string -> (i~>o) -> (i~>o);
 
   not_gate:  Bit        ~> Bit;
   and_gate:  Bit ** Bit ~> Bit;

--- a/cava/cava/Cava/Arrow/NetlistArrow.v
+++ b/cava/cava/Cava/Arrow/NetlistArrow.v
@@ -184,6 +184,8 @@ Section NetlistEval.
       | false => Gnd
     end) (nat_to_bitvec_sized n (N.to_nat v)));
 
+    mk_module _ _ _name f := f;
+
     not_gate i :=
       o <- newWire ;;
       addInstance (Not i o) ;;
@@ -322,8 +324,8 @@ Section NetlistEval.
   Close Scope string_scope.
   Local Open Scope category_scope.
 
-  Definition arrow_netlist {X Y} (circuit: X ~[NetlistCava]~> Y)
-    : denote X -> state CavaState (denote Y) :=
-    circuit.
+  Definition arrow_netlist {X Y} (circuit: forall cava: Cava, X ~[cava]~> Y)
+    : denote (remove_rightmost_unit X) -> state CavaState (denote Y) :=
+    insert_rightmost_tt1 _ >>> circuit _.
 
 End NetlistEval.

--- a/cava/cava/Cava/Arrow/PropArrow.v
+++ b/cava/cava/Cava/Arrow/PropArrow.v
@@ -58,6 +58,7 @@ Instance NoDelays : Cava := {
 
   constant b := True;
   constant_bitvec n v := True;
+  mk_module _ _ _name f := f;
   not_gate := True;
   and_gate := True;
   nand_gate := True;
@@ -91,6 +92,7 @@ Instance NoLoops : Cava := {
 
   constant b := True;
   constant_bitvec n v := True;
+  mk_module _ _ _name f := f;
   not_gate := True;
   and_gate := True;
   nand_gate := True;


### PR DESCRIPTION
- Also add method for delimiting modules, currently unused.