### PR TITLE
Add expression-arrow automated proof of stateless circuits

### DIFF
--- a/cava/arrow-examples/ArrowExtraction.v
+++ b/cava/arrow-examples/ArrowExtraction.v
@@ -22,14 +22,14 @@ From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import Library.
+Require Import Combinators.
 Require Import SyntaxExamples.
 Require Import Mux2_1.
 Require Import UnsignedAdder.
 
 Require Import ArrowAdderTutorial.
 
-Extraction Library Library.
+Extraction Library Combinators.
 Extraction Library SyntaxExamples.
 Extraction Library Mux2_1.
 Extraction Library UnsignedAdder.

--- a/cava/arrow-examples/Combinators.v
+++ b/cava/arrow-examples/Combinators.v
@@ -330,4 +330,26 @@ Section regression_tests.
     let '(carry, result) = !(rippleCarryAdder' _) b merged in
     (carry, result)
     ]>.
+  
+  Lemma interleave_is_stateless : forall n, has_no_state (interleaveVectors n EvalCava).
+  Proof.
+    intros.
+    induction n.
+    * cbv [interleaveVectors Closure_conversion closure_conversion].
+      refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _ ).
+      apply (no_let_rec_and_stateless_morphisms_is_stateless _ _).
+      - cbv [Desugar desugar]; auto.
+        repeat (constructor; intros).
+      - cbv [Desugar desugar]; auto.
+        repeat (constructor; intros).
+    * cbv [interleaveVectors Closure_conversion closure_conversion].
+      refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _ ).
+      apply (no_let_rec_and_stateless_morphisms_is_stateless _ _).
+      - cbv [Desugar desugar]; auto.
+        repeat (constructor; intros).
+      - cbv [Desugar desugar]; auto.
+        repeat (constructor; intros).
+        apply IHn.
+  Qed.
+
 End regression_tests.

--- a/cava/arrow-examples/UnsignedAdder.v
+++ b/cava/arrow-examples/UnsignedAdder.v
@@ -16,7 +16,7 @@
 
 From Arrow Require Import Category ClosureConversion.
 From Cava Require Import Arrow.ArrowExport.
-From ArrowExamples Require Import Library.
+From ArrowExamples Require Import Combinators.
 
 From Coq Require Import Strings.String Bvector List NArith Nat Lia Plus.
 Import ListNotations.

--- a/cava/arrow-examples/_CoqProject
+++ b/cava/arrow-examples/_CoqProject
@@ -2,7 +2,7 @@
 -R ../arrow-lib Arrow
 -R . ArrowExamples
 
-Library.v 
+Combinators.v 
 
 Mux2_1.v
 SyntaxExamples.v

--- a/cava/arrow-lib/ClosureConversion.v
+++ b/cava/arrow-lib/ClosureConversion.v
@@ -181,6 +181,10 @@ Section env.
     @wf_debrujin (x ** y) z env (Abs _ _ f) -> @wf_debrujin y z (x :: env) (f (length env)).
   Proof. env_auto. Qed.
 
+  Lemma wf_debrujin_var_succ: forall {x y a} v ,
+    wf_debrujin (i:=x) (o:=y) (a :: env) (Var _ v) -> wf_debrujin env (Var _ v) \/ v = length env.
+  Proof. env_auto. Qed.
+
   Lemma wf_debrujin_lax_compose1: forall {x y z} e1 e2,
     @wf_debrujin x z env (Comp _ e2 e1) -> @wf_debrujin x y env e1.
   Proof. env_auto. Qed.

--- a/cava/arrow-lib/Kappa.v
+++ b/cava/arrow-lib/Kappa.v
@@ -7,18 +7,45 @@ Section Arrow.
     Variable (var: object -> object -> Type).
 
     Local Open Scope arrow_scope.
+    Local Open Scope category_scope.
 
     Inductive kappa : object -> object -> Type :=
-      | Var : forall {x y},   var x y -> kappa x y
-      | Abs : forall x {y z}, (var u x -> kappa y z) -> kappa (x ** y) z
-      | App : forall {x y z}, kappa (x ** y) z -> kappa u x -> kappa y z
-      | Comp: forall {x y z}, kappa y z -> kappa x y -> kappa x z
-      | Morph : forall {x y}, morphism x y -> kappa x y
-      | LetRec : forall x {y z}, 
-          (var u x -> kappa u x)
-        -> (var u x -> kappa y z) 
-        -> kappa y z.
+    | Var : forall {x y},   var x y -> kappa x y
+    | Abs : forall x {y z}, (var u x -> kappa y z) -> kappa (x ** y) z
+    | App : forall {x y z}, kappa (x ** y) z -> kappa u x -> kappa y z
+    | Comp: forall {x y z}, kappa y z -> kappa x y -> kappa x z
+    | Morph : forall {x y}, morphism x y -> kappa x y
+    | LetRec : forall x {y z}, 
+        (var u x -> kappa u x)
+      -> (var u x -> kappa y z) 
+      -> kappa y z.
+
+    Inductive NoLetRecKappa: forall i o, kappa i o -> Prop :=
+    | NoLetRecVar: forall x y v, NoLetRecKappa x y (Var v)
+    | NoLetRecAbs: forall x y z f,
+      (forall (k: var u x), NoLetRecKappa y z (f k)) -> NoLetRecKappa (x**y) z (Abs _ f)
+    | NoLetRecApp: forall x y z f e,
+      NoLetRecKappa (x ** y) z f -> NoLetRecKappa u x e -> NoLetRecKappa y z (App f e)
+    | NoLetRecComp: forall x y z f g,
+      NoLetRecKappa y z f -> NoLetRecKappa x y g -> NoLetRecKappa x z (Comp f g)
+    | NoLetRecMorph : forall x y m, NoLetRecKappa x y (Morph m).
+
+    Section prop.
+      Variable (P: forall x y, morphism x y -> Prop).
+
+      Inductive MorphPropKappa: forall i o, kappa i o -> Prop :=
+      | MorphPropVar: forall x y v, MorphPropKappa x y (Var v)
+      | MorphPropAbs: forall x y z f, (forall (k: var u x), MorphPropKappa y z (f k)) -> MorphPropKappa (x**y) z (Abs _ f)
+      | MorphPropApp: forall x y z f e,
+        MorphPropKappa (x ** y) z f -> MorphPropKappa u x e -> MorphPropKappa y z (App f e)
+      | MorphPropComp: forall x y z f g,
+        MorphPropKappa y z f -> MorphPropKappa x y g -> MorphPropKappa x z (Comp f g)
+      | MorphPropMorph : forall x y m, P x y m -> MorphPropKappa x y (Morph m).
+
+    End prop.
+
   End Vars.
 
   Definition Kappa i o := forall var, kappa var i o.
+
 End Arrow.

--- a/cava/cava/Cava/Arrow/CavaExpression.v
+++ b/cava/cava/Cava/Arrow/CavaExpression.v
@@ -173,3 +173,208 @@ Hint Resolve Desugar : core.
 Hint Resolve desugar : core.
 Hint Unfold Desugar : core.
 Hint Unfold desugar : core.
+
+From Cava Require Import Arrow.EvaluationArrow.
+
+Import EqNotations.
+
+(* TODO: This is defined in the standard library but P is restricted to `A -> Prop`:
+  upstream fix to github.com/coq/coq *)
+Lemma rew_sigT {A x} {P : A -> Type} (Q : forall a, P a -> Type) (u : { p : P x & Q x p }) {y} (H : x = y)
+    : rew [fun a => { p : P a & Q a p }] H in u
+      = existT
+          (Q y)
+          (rew H in projT1 u)
+          (match H with 
+          | eq_refl => projT2 u
+          end).
+Proof.
+  destruct H, u; reflexivity.
+Qed.
+
+Lemma blank_rew: forall ty ty' H x, eq_rect ty (fun (_ : Kind) => Kind) x ty' H = x.
+Proof.
+  intros.
+  destruct H.
+  simpl.
+  reflexivity.
+Qed.
+
+From Coq Require Import Program.Equality.
+
+(* TODO: It should be possible to generalize these for all arrows/kappa,
+but the proofs are more difficult and may require additional hypothesis which are 
+implicit here, such as '**' being injective. *)
+Lemma morph_prop_abs_inj: forall {x y z k a},
+  MorphPropKappa natvar (fun _ _ => has_no_state) (x ** y) z (Kappa.Abs natvar x k) -> 
+  MorphPropKappa natvar (fun _ _ => has_no_state) y z (k a).
+Proof.
+  intros.
+  dependent induction H.
+  apply H.
+Qed.
+
+Lemma no_let_rec_abs_inj: forall {x y z k a},
+  NoLetRecKappa (A0:=EvalCava) natvar (x ** y) z (Kappa.Abs natvar x k) ->
+  NoLetRecKappa natvar y z (k a).
+Proof.
+  intros.
+  dependent induction H.
+  apply H.
+Qed.
+
+Lemma morph_prop_app_inj: forall {x y z f e},
+  MorphPropKappa natvar (fun _ _ => has_no_state) y z (Kappa.App natvar f e) -> 
+  MorphPropKappa natvar (fun _ _ => has_no_state) (x**y) z f /\
+  MorphPropKappa natvar (fun _ _ => has_no_state) u x e.
+Proof.
+  intros.
+  dependent induction H.
+  split.
+  apply H.
+  apply H0.
+Qed.
+
+Lemma no_let_rec_app_inj: forall {x y z f e},
+  NoLetRecKappa (A0:=EvalCava) natvar y z (Kappa.App natvar f e) -> 
+  NoLetRecKappa natvar (x**y) z f /\
+  NoLetRecKappa natvar u x e.
+Proof.
+  intros.
+  dependent induction H.
+  split.
+  apply H.
+  apply H0.
+Qed.
+
+Lemma morph_prop_comp_inj: forall {x y z e1 e2},
+  MorphPropKappa natvar (fun _ _ => has_no_state) x z (Kappa.Comp natvar e1 e2) -> 
+  MorphPropKappa natvar (fun _ _ => has_no_state) y z e1 /\
+  MorphPropKappa natvar (fun _ _ => has_no_state) x y e2.
+Proof.
+  intros.
+  dependent induction H.
+  split.
+  apply H.
+  apply H0.
+Qed.
+
+Lemma no_let_rec_comp_inj: forall {x y z e1 e2},
+  NoLetRecKappa (A0:=EvalCava) natvar x z (Kappa.Comp natvar e1 e2) -> 
+  NoLetRecKappa natvar y z e1 /\
+  NoLetRecKappa natvar x y e2.
+Proof.
+  intros.
+  dependent induction H.
+  split.
+  apply H.
+  apply H0.
+Qed.
+
+Lemma morph_prop_morph_inj: forall {x y m},
+  MorphPropKappa natvar (fun _ _ => has_no_state) x y (Kappa.Morph natvar m) -> 
+  has_no_state m.
+Proof.
+  intros.
+  dependent induction H.
+  apply H.
+Qed.
+
+Lemma no_let_rec_and_stateless_morphisms_is_stateless : forall i o (expr: kappa natvar i o) env wf, 
+  NoLetRecKappa natvar i o expr ->
+  MorphPropKappa natvar (fun _ _ m => has_no_state m) i o expr ->
+  has_no_state ((fun (cava: Cava) => closure_conversion' (object_decidable_equality:=decKind) env expr wf) EvalCava).
+Proof.
+  intros. 
+  simpl.
+
+  apply (kappa_ind natvar (fun o0 o1 expr => 
+    forall env,
+    forall wf: wf_debrujin env expr, 
+    NoLetRecKappa natvar o0 o1 expr ->
+    MorphPropKappa natvar (fun _ _ m => has_no_state m) o0 o1 expr ->
+    has_no_state
+    (closure_conversion' (arrow:=EvalCava) env expr wf)));
+  intros; unfold has_no_state; cbn.
+
+  
+  - (* Var case *)
+    (* TODO: could this be simplified ? Discriminating on the environment
+      works but may be more surgical than necessary. *)
+    induction env0.
+    inversion wf0.
+
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    apply wf_debrujin_var_succ in wf0 as wf1.
+    inversion wf1.
+    simpl.
+    inversion H1.
+    apply lookup_bound in H3.
+    destruct (Nat.eq_dec v (length env0)).
+    * exfalso; lia.
+    * apply IHenv0.
+    * simpl.
+      destruct (Nat.eq_dec v (length env0)).
+      destruct (decKind a y).
+      unfold evalProjState.
+      
+      unfold evalMorphism.
+      setoid_rewrite
+        (rew_sigT (P:=(fun _ => Kind))
+        (fun y state => denote a * denote (as_kind env0) -> denote state -> denote y * denote state)
+        _ 
+        e0).
+      simpl.
+      rewrite blank_rew.
+      refine (OnlyUnitsTuple _ _ OnlyUnitsUnit OnlyUnitsUnit).
+      destruct (lookup_top_contra env0 e wf0 n).
+      simpl.
+      apply IHenv0.
+
+  - (* Abs case *)
+    simpl in *.
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+
+    apply (H1 (length env0) (List.cons x env0) (wf_debrujin_succ k wf0)).
+    apply (no_let_rec_abs_inj H2).
+    apply (morph_prop_abs_inj H3).
+
+  - (* App case *)
+    simpl in *.
+    pose (no_let_rec_app_inj H3) as H5.
+    pose (morph_prop_app_inj H4) as H6.
+    inversion H5.
+    inversion H6.
+    refine (OnlyUnitsTuple _ _ _ _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    apply (H2 _ _ H8 H10).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    apply (H1 _ _ H7 H9).
+  
+  - (* Comp case *)
+    simpl in *.
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    pose (no_let_rec_comp_inj H3) as H5.
+    pose (morph_prop_comp_inj H4) as H6.
+    inversion H5.
+    inversion H6.
+    refine (OnlyUnitsTuple _ _ _ _).
+    apply (H2 _ _ H8 H10).
+    apply (H1 _ _ H7 H9).
+  
+  - (* Morph case *)
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _).
+    apply (morph_prop_morph_inj H2).
+
+  - (* LetRec case *)
+    inversion H3.
+
+  - apply H.
+  - apply H0.
+Qed.

--- a/cava/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/cava/Cava/Arrow/CavaNotation.v
@@ -29,8 +29,7 @@ Delimit Scope kappa_scope with kappa.
 
 Module KappaNotation.
   Notation "<[ e ]>" := (
-    fun (cava: Cava) => 
-    Closure_conversion (object_decidable_equality:=decKind) (Desugar (fun var => e%kappa))
+    fun (cava: Cava) => Closure_conversion (object_decidable_equality:=decKind) (Desugar (fun var => e%kappa))
    ) (at level 1, e custom expr at level 1).
 
   (* Notation "<[ e ]>" := (e%kappa) (at level 1, e custom expr at level 1). *)


### PR DESCRIPTION
This adds an automated process for proving a circuit built from expressions containing no loops and only stateless subexpressions is stateless. 

This also renames the `Library` to `Combinators`- I didn't use `ArrowCombinators` as the file is under `arrow-examples/` rather than the main `cava` directory.