### PR TITLE
Unfolding/rewriting performance fixes for CavaExpr

### DIFF
--- a/cava/arrow-examples/Aes/pkg.v
+++ b/cava/arrow-examples/Aes/pkg.v
@@ -24,22 +24,22 @@ Import KappaNotation.
 Open Scope kind_scope.
 
 Notation "|^ x" :=
-  (App (Morphism (foldl1 <[\a b => xor a b]>)) x)
+  (App (Morphism (foldl1 <[\a b => xor a b]> _)) x)
   (in custom expr at level 5, no associativity) : kappa_scope.
 Notation "x && y" :=
   (App (App And x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x & y" :=
-  (App (App (Morphism (bitwise <[and]>)) x) y)
+  (App (App (Morphism (bitwise <[and]> _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x ^ y" :=
-  (App (App (Morphism (bitwise <[xor]>)) x) y)
+  (App (App (Morphism (bitwise <[xor]> _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "'if' i 'then' t 'else' e" :=
-  (App (App (App (Morphism mux_item) i) t) e)
+  (App (App (App (Morphism (mux_item _)) i) t) e)
   (in custom expr at level 5, left associativity) : kappa_scope.
 Notation "x == y" :=
-  (App (App (Morphism equality) x) y)
+  (App (App (Morphism (equality _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 
 Inductive SboxImpl := 

--- a/cava/arrow-examples/Aes/sbox.v
+++ b/cava/arrow-examples/Aes/sbox.v
@@ -83,12 +83,12 @@ Section regression_testing.
 
   (* Check equal at some random points *)
   Goal aes_sbox_lut Combinational (false, #0) = aes_sbox_canright Combinational (false, #0).
-    compute. auto.
+    vm_compute; auto.
   Qed.
   Goal aes_sbox_lut Combinational (false, #88) = aes_sbox_canright Combinational (false, #88).
-    compute. auto.
+    vm_compute; auto.
   Qed.
   Goal aes_sbox_lut Combinational (false, #127) = aes_sbox_canright Combinational (false, #127).
-    compute. auto.
+    vm_compute; auto.
   Qed.
 End regression_testing.

--- a/cava/arrow-examples/ArrowExtraction.v
+++ b/cava/arrow-examples/ArrowExtraction.v
@@ -35,3 +35,15 @@ Extraction Library Mux2_1.
 Extraction Library UnsignedAdder.
 
 Extraction Library ArrowAdderTutorial.
+
+From Cava Require Import Arrow.ArrowExport.
+(* From Cava Require Import Cava.pkg. *)
+Extraction Library CavaNotation.
+Require Import Aes.pkg.
+Extraction Library pkg.
+Require Import Aes.sbox.
+Extraction Library sbox.
+Require Import Aes.sbox_canright_pkg.
+Extraction Library sbox_canright_pkg.
+Require Import Aes.sbox_canright.
+Extraction Library sbox_canright.

--- a/cava/arrow-examples/Combinators.v
+++ b/cava/arrow-examples/Combinators.v
@@ -30,7 +30,7 @@ Local Open Scope kind_scope.
 
 Definition rewrite_kind {x y} (H: x = y) (cava: Cava)
   : << x, Unit >> ~> y :=
-  match decKind x y with
+  match eq_kind_dec x y with
   | left Heq =>
     rew [fun x => << _ >> ~> <<x>> ] Heq in <[\x=>x]> cava
   | right Hneq => (ltac:(contradiction))

--- a/cava/cava/Cava/Arrow/ArrowExport.v
+++ b/cava/cava/Cava/Arrow/ArrowExport.v
@@ -23,3 +23,16 @@ Require Export Cava.Arrow.CombinationalArrow.
 Require Export Cava.Arrow.NetlistArrow.
 Require Export Cava.Arrow.PropArrow.
 
+From Coq Require Import NArith.
+
+Strategy opaque [
+  N2Bv_sized
+  Ndigits.Bv2N
+  Vector.nth_order 
+  Vector.splitat
+  andb 
+  orb 
+  xorb 
+  negb 
+].
+

--- a/cava/cava/Cava/Arrow/CavaExpression.v
+++ b/cava/cava/Cava/Arrow/CavaExpression.v
@@ -25,6 +25,7 @@ Open Scope category_scope.
 Open Scope arrow_scope.
 
 Section Vars.
+  Context {cava: Cava}.
   Context {var: Kind -> Kind -> Type}.
 
   Definition lift_constant (ty: Kind): Type :=
@@ -59,7 +60,7 @@ Section Vars.
     | Snd: forall {x y}, CavaExpr << << x, y >>, Unit >> y
     | Pair: forall {x y}, CavaExpr << x, y, Unit >> << x, y >>
     | Id: forall {x}, CavaExpr <<x, Unit>> x
-    | Morphism: forall {i o}, (forall cava: Cava, i~[cava]~>o) -> CavaExpr i o
+    | Morphism: forall {i o}, (i~[cava]~>o) -> CavaExpr i o
 
     (* Cava routines *)
     | LiftConstant: forall x, lift_constant x -> CavaExpr Unit x
@@ -104,11 +105,11 @@ Section Vars.
   Arguments Kappa.Morph [_ _ _ _ _ var _ _].
   Arguments Kappa.LetRec [_ _ _ _ _ var _ _ _].
 
-  Definition liftCava `{Cava} i {o} (f: remove_rightmost_unit i ~> o)
+  Definition liftCava i {o} (f: remove_rightmost_unit i ~> o)
     : kappa var i o :=
     Kappa.Comp (Kappa.Morph f) (Kappa.Morph (remove_rightmost_tt i)).
 
-  Fixpoint desugar {cava: Cava} {i o} (e: CavaExpr i o) : kappa var i o :=
+  Fixpoint desugar {i o} (e: CavaExpr i o) : kappa var i o :=
     match e with
     | Var x => Kappa.Var x
     | Abs f => Kappa.Abs (fun x => desugar (f x))
@@ -149,7 +150,7 @@ Section Vars.
       | _, H => match H with end
       end
 
-    | Morphism m => Kappa.Morph (m _)
+    | Morphism m => Kappa.Morph m
 
     | EmptyVec => liftCava <<u>> (empty_vec _)
     | Index n => liftCava <<_,_,u>> (index n _)
@@ -165,7 +166,7 @@ End Vars.
 
 Arguments CavaExpr : clear implicits.
 
-Definition Desugar {_ :Cava} {i o} (e: forall var, CavaExpr var i o) : Kappa i o := fun var => desugar (e var).
+Definition Desugar {cava: Cava} {i o} (e: forall var, CavaExpr cava var i o) : Kappa i o := fun var => desugar (e var).
 
 Hint Resolve Desugar : core.
 Hint Resolve desugar : core.

--- a/cava/cava/Cava/Arrow/CavaExpressionProp.v
+++ b/cava/cava/Cava/Arrow/CavaExpressionProp.v
@@ -130,7 +130,7 @@ Lemma no_let_rec_and_stateless_morphisms_is_stateless:
   forall i o (expr: kappa natvar i o) env wf, 
     NoLetRecKappa natvar i o expr ->
     MorphPropKappa natvar (fun _ _ m => has_no_state m) i o expr ->
-    has_no_state ((fun (cava: Cava) => closure_conversion' (object_decidable_equality:=decKind) env expr wf) EvalCava).
+    has_no_state ((fun (cava: Cava) => closure_conversion' (object_decidable_equality:=eq_kind_dec) env expr wf) EvalCava).
 Proof.
   intros. 
   simpl.
@@ -163,7 +163,7 @@ Proof.
     * apply IHenv0.
     * simpl.
       destruct (Nat.eq_dec v (length env0)).
-      destruct (decKind a y).
+      destruct (eq_kind_dec a y).
       unfold evalProjState.
       
       unfold evalMorphism.

--- a/cava/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/cava/Cava/Arrow/CavaNotation.v
@@ -29,7 +29,7 @@ Delimit Scope kappa_scope with kappa.
 
 Module KappaNotation.
   Notation "<[ e ]>" := (
-    fun (cava: Cava) => Closure_conversion (object_decidable_equality:=decKind) (Desugar (fun var => e%kappa))
+    fun (cava: Cava) => Closure_conversion (object_decidable_equality:=eq_kind_dec) (Desugar (fun var => e%kappa))
    ) (at level 1, e custom expr at level 1).
 
   (* Notation "<[ e ]>" := (e%kappa) (at level 1, e custom expr at level 1). *)
@@ -58,8 +58,8 @@ Module KappaNotation.
 
   (* Escaping *)
 
-  Notation "! x" := (Morphism x)(in custom expr at level 2, x global) : kappa_scope.
-  Notation "!( x )" := (Morphism x) (in custom expr, x constr) : kappa_scope.
+  Notation "! x" := (Morphism (x _))(in custom expr at level 2, x global) : kappa_scope.
+  Notation "!( x )" := (Morphism (x _)) (in custom expr, x constr) : kappa_scope.
 
   Notation tupleHelper := (fun x y => App (App Pair x) y).
   Notation "( x , .. , y , z )" := (
@@ -122,7 +122,7 @@ Module KappaNotation.
     , x at level 7
     ) : kappa_scope.
   Notation "v [: x : y ]" :=
-        (App (Slice _ x y _ _) v)
+        (App (Slice _ (x <: nat) (y <: nat) _ _) v)
     (in custom expr at level 2,
     (* v constr, *)
     x constr at level 7,

--- a/cava/cava/Cava/Arrow/CombinationalArrow.v
+++ b/cava/cava/Cava/Arrow/CombinationalArrow.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool ZArith NaryFunctions Vector Lia.
+From Coq Require Import Bool ZArith NArith NaryFunctions Vector Lia.
 From Arrow Require Import Category Arrow.
 From Cava.Arrow Require Import CavaArrow PropArrow.
 
@@ -74,7 +74,7 @@ Instance CombinationalSTKC : ArrowSTKC CoqKindMaybeArrow := { }.
 #[refine] Instance Combinational : Cava := {
   cava_arrow := CoqKindMaybeArrow;
   constant b _ := Some b;
-  constant_bitvec n v _ := Some (nat_to_bitvec_sized n (N.to_nat v));
+  constant_bitvec n v _ := Some (N2Bv_sized n v);
 
   mk_module _ _ _name f := f;
 

--- a/cava/cava/Cava/Arrow/EvaluationArrow.v
+++ b/cava/cava/Cava/Arrow/EvaluationArrow.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool ZArith NaryFunctions Vector Lia.
+From Coq Require Import Bool ZArith NArith NaryFunctions Vector Lia.
 From Arrow Require Import Category Arrow Kappa.
 From Cava.Arrow Require Import CavaArrow PropArrow.
 
@@ -103,7 +103,7 @@ Instance EvalSTKC : ArrowSTKC EvalArrow := { }.
 #[refine] Instance EvalCava : Cava := {
   cava_arrow := EvalArrow;
   constant b := fun_s Unit (fun _ _ => (b, tt));
-  constant_bitvec n v := fun_s Unit (fun _ _ => (nat_to_bitvec_sized n (N.to_nat v), tt));
+  constant_bitvec n v := fun_s Unit (fun _ _ => (N2Bv_sized n v, tt));
 
   mk_module _ _ _name f := f;
 


### PR DESCRIPTION
- Don't use `lia` in `arg_length` definition
- Use `Strategy opaque` to stop unnecessary unfolding