### PR TITLE
Add non-recursive let and refactor Arrow code

### DIFF
--- a/cava/arrow-examples/Aes/sbox.v
+++ b/cava/arrow-examples/Aes/sbox.v
@@ -91,4 +91,5 @@ Section regression_testing.
   Goal aes_sbox_lut Combinational (false, #127) = aes_sbox_canright Combinational (false, #127).
     vm_compute; auto.
   Qed.
+
 End regression_testing.

--- a/cava/arrow-examples/Combinators.v
+++ b/cava/arrow-examples/Combinators.v
@@ -439,7 +439,7 @@ Section regression_tests.
     (carry, result)
     ]>.
  
-  Lemma interleave_is_stateless : forall n, has_no_state (interleaveVectors n EvalCava).
+  (* Lemma interleave_is_stateless : forall n, has_no_state (interleaveVectors n EvalCava).
   Proof. induction n; auto 20 with stateless. Qed.
 
   Lemma halfAdder_is_stateless : has_no_state (halfAdder EvalCava).
@@ -448,5 +448,5 @@ Section regression_tests.
 
   Lemma fullAdder_is_stateless : has_no_state (fullAdder EvalCava).
   Proof. auto 30 with stateless. Qed.
-  Hint Extern 1 (has_no_state (fullAdder EvalCava)) => apply fullAdder_is_stateless : stateless.
+  Hint Extern 1 (has_no_state (fullAdder EvalCava)) => apply fullAdder_is_stateless : stateless. *)
 End regression_tests.

--- a/cava/arrow-lib/Arrow.v
+++ b/cava/arrow-lib/Arrow.v
@@ -6,6 +6,10 @@ Reserved Infix "**" (at level 30, right associativity).
 
 Generalizable Variable unit product.
 
+Class DecidableEquality T := {
+  eq_dec: forall x y : T, {x = y} + {x <> y}
+}.
+
 (* generalized arrow *)
 Class Arrow (object: Type) (category: Category object) (unit: object) (product: object -> object -> object) := {
   arrow_category := category;

--- a/cava/arrow-lib/ClosureConversion.v
+++ b/cava/arrow-lib/ClosureConversion.v
@@ -1,5 +1,5 @@
 From Coq Require Import Arith Eqdep List Lia.
-From Arrow Require Import Category Arrow Kappa.
+From Arrow Require Import Category Arrow Kappa Equiv.
 
 Import ListNotations.
 Import EqNotations.
@@ -8,364 +8,244 @@ Generalizable All Variables.
 
 Section Arrow.
 
-Context `{arrow: Arrow}.
+Context {object: Type}.
+Context {u: object}.
+Context {category: Category object}.
+Context {product: object -> object -> object}.
+Context {arrow: Arrow object category u product}.
 Context {stkc: ArrowSTKC arrow}.
 Context {arrow_loop: ArrowLoop arrow}.
-Context {object_decidable_equality: forall x y : object, {x = y} + {x <> y}}.
+Context {decidable_equality: DecidableEquality object}.
 
+Local Open Scope category_scope.
 Local Open Scope arrow_scope.
 
 Set Implicit Arguments.
 
-(* todo: make some principled ltac's out of this *)
-Ltac solver :=
-  simpl in *; try subst; try match goal with
+Create HintDb kappa_cc.
+
+(* immediate contradictions *)
+Hint Extern 1 => 
+  match goal with
   | [ H : ?X < ?X |- _ ] => apply Nat.lt_irrefl in H; contradiction
   | [ H : ?X = ?Y, H1: ?X < ?Y |- _ ] => rewrite H in H1; apply Nat.lt_irrefl in H; contradiction
   | [ H : ?X <> ?X |- _ ] => destruct H
   | [ H : None = Some _|- _ ] => inversion H
+  | [ H : reverse_nth [] _ = Some _|- _ ] => inversion H
+  | [ H : In _ [] |- _ ] => inversion H
+  end : kappa_cc.
 
-  | [ |- Some ?X = Some ?X ] => f_equal
-  | [ |- context[eq_nat_dec ?X ?Y] ] => destruct (eq_nat_dec X Y)
+Hint Extern 5 => 
+  match goal with
+  | [ H : Some ?X = Some ?Y |- _ ] => inversion H; clear H
+  | [ H : Some ?X = Some ?Y |- _ ] => inversion H; clear H
+  end : kappa_cc.
 
-  | [ H : Some ?X = Some ?Y |- _ ] => inversion H
+Hint Extern 10 => 
+  match goal with
   | [ H : ?X /\ ?Y |- _ ] => inversion H; clear H
-  | [ H : ?X \/ ?Y |- _ \/ ?Y ] => inversion H; [ left; progress eauto | right; progress eauto ]
   | [ H : ?X \/ ?Y |- _ ] => inversion H; clear H
+  | [ H : ?Y |- _ \/ ?Y ] => right; exact H
+  | [ H : ?Y |- ?Y \/ _ ] => left; exact H
+  end : kappa_cc.
 
-  | [ H : context[eq_nat_dec ?X ?Y] |- _ ] => destruct (eq_nat_dec X Y)
-  | [ H : ?X = ?Y, H2: ?X = ?Y -> ?Z |- _ ] => apply H2 in H
+Hint Extern 15 => 
+  match goal with
+  | [ H0: length ?Y = ?Z, H1: ?X = ?TY |- reverse_nth (?X :: ?Y) ?Z = Some ?TY ] => 
+    unfold reverse_nth;
+    let x := fresh in (
+      elim (Nat.eq_dec Z (length Y)); intro x;
+      [f_equal; exact H1 | rewrite H0 in x; contradiction]
+      )
+  | [ H: reverse_nth (_ :: ?l) ?i = Some _ |- _ ] => cbn in H; destruct (Nat.eq_dec i (length l))
+  | [ H: ?X = length ?Y |- _ ] => rewrite H; clear H
+  | [ H0: ?X, H1: ?X -> ?Y |- _ ] => apply H1 in H0
+  end : kappa_cc.
 
-  | [ H : ?X = ?Y, H2: context[?X] |- _ ] => rewrite H in H2
-  end.
+Hint Extern 50 => simpl; lia : kappa_cc.
 
-Hint Extern 2 => solver : environment.
+Notation ok_lookup := (fun (l: list _) (n: nat) (ty: _) => reverse_nth l n = Some ty).
 
-Ltac env_auto := auto with environment.
-
-(****************************************************************************)
-(* Environment manipulation                                                 *)
-(****************************************************************************)
-
-(* An environment to track the arrow objects corresponding to variables.
-Variables in a Kappa term are then instantiated as a morphism from the environment
-to the object found at an index. *)
-
-Definition environment := list object. 
-
-Fixpoint as_kind (env: environment): object :=
-  match env with
+Fixpoint as_kind (ctxt: list object): object :=
+  match ctxt with
   | [] => u
   | x :: xs => x ** (as_kind xs)
   end.
-
-Fixpoint lookup_kind (env: environment) (i: nat) : option object :=
-  match env with
-  | [] => None
-  | x :: xs =>
-    if eq_nat_dec i (length xs)
-    then Some x
-    else lookup_kind xs i
-  end.
-
-Notation "env ? i" := (lookup_kind env i)(no associativity, at level 50).
-
-(* Shorthand for passing evidence that a lookup is well formed *)
-Notation ok_lookup := (
-  fun  (env: list object) (i: nat) (ty: object) => env ? i = Some ty
-).
 
 (****************************************************************************)
 (* Environmental variable lookup lemmas                                     *)
 (****************************************************************************)
 
-Section env.
-  Variable env: environment.
+Section ctxt.
+  Variable ctxt: list object.
+
+  Tactic Notation "ctxt_induction" := intros; induction ctxt; auto with kappa_cc. 
 
   Lemma lookup_bound: forall ty i, 
-    env ? i = Some ty -> i < length env.
-  Proof.
-    intros; induction env; env_auto.
-  Qed.
+    ok_lookup ctxt i ty -> i < length ctxt.
+  Proof. ctxt_induction. Qed.
 
-  Hint Extern 3 =>
+  Hint Extern 55 =>
     match goal with
-    | [H: lookup_kind _ _ = Some _|- _] => apply lookup_bound in H as H1
-    end : environment.
+    | [ H: ?i <length ?ctxt |- reverse_nth (_ :: ?ctxt) ?i = Some ?ty] => cbn; destruct (Nat.eq_dec i (length ctxt))
+    | [H: reverse_nth _ _ = Some _|- _] => let x := fresh in apply lookup_bound in H as x
+    end : kappa_cc.
 
   Lemma lookup_lower_contra : forall i ty,
-    lookup_kind [] i = Some ty -> False.
-  Proof. env_auto. Qed.
+    reverse_nth (A:=object) [] i = Some ty -> False.
+  Proof. auto with kappa_cc. Qed.
 
   Lemma lookup_upper_contra : forall ty,
-    lookup_kind env (length env) = Some ty -> False.
-  Proof. env_auto. Qed.
+    reverse_nth ctxt (length ctxt) = Some ty -> False.
+  Proof. auto with kappa_cc. Qed.
 
   Hint Extern 1 =>
     match goal with
-    | [H: lookup_kind (length ?X) (?X) = Some _ |- _] => apply lookup_upper_contra in H; contradiction
-    | [H: lookup_kind ?X [] = Some _ |- _] => apply lookup_lower_contra in H; contradiction
-    end : environment.
+    | [H: reverse_nth (length ?X) (?X) = Some _ |- _] => apply lookup_upper_contra in H; contradiction
+    | [H: reverse_nth ?X [] = Some _ |- _] => apply lookup_lower_contra in H; contradiction
+    end : kappa_cc.
 
   Lemma split_lookup : forall i x ty,
-    ((length env = i /\ x = ty) \/ lookup_kind env i = Some ty)
-    -> lookup_kind (x :: env) i = Some ty.
-  Proof. env_auto. Qed.
+    ((length ctxt = i /\ x = ty) \/ reverse_nth ctxt i = Some ty)
+    -> reverse_nth (x :: ctxt) i = Some ty.
+  Proof. auto with kappa_cc. Qed.
 
   Lemma unsplit_lookup : forall i x ty,
-    lookup_kind (x :: env) i = Some ty ->
-    ((length env = i /\ x = ty) \/ lookup_kind env i = Some ty).
-  Proof. env_auto. Qed.
+    reverse_nth (x :: ctxt) i = Some ty ->
+    ((length ctxt = i /\ x = ty) \/ reverse_nth ctxt i = Some ty).
+  Proof. auto with kappa_cc. Qed.
 
   Lemma push_lookup : forall i x ty,
-    i <> length env ->
-    lookup_kind (x :: env) i = Some ty ->
-    lookup_kind env i = Some ty.
-  Proof. env_auto. Qed.
+    i <> length ctxt ->
+    reverse_nth (x :: ctxt) i = Some ty ->
+    reverse_nth ctxt i = Some ty.
+  Proof. auto with kappa_cc. Qed.
 
   Lemma lookup_top_contra: forall i ty ty',
-    i = length env
-    -> lookup_kind (ty :: env) i = Some ty'
+    i = length ctxt
+    -> reverse_nth (ty :: ctxt) i = Some ty'
     -> ty <> ty'
     -> False.
-  Proof. env_auto. Qed.
-End env.
+  Proof. auto with kappa_cc. Qed.
+End ctxt.
 
-Local Open Scope category_scope.
+Definition rewrite_object {x y: object} (H: x = y) 
+  : x ~> y :=
+  match eq_dec x y with
+  | left Heq => rew Heq in id
+  | right Hneq => (ltac:(abstract contradiction))
+  end.
 
-(* Construct an Arrow morphism that takes a variable environment
+(* Construct an Arrow morphism that takes a variable list object
 and returns the variable at an index *)
-Fixpoint extract_nth (env: environment) ty x
-  : (lookup_kind env x = Some ty) -> (as_kind env) ~> ty :=
-  match env return (lookup_kind env x = Some ty) -> (as_kind env) ~> ty with
+Fixpoint extract_nth (ctxt: list object) ty x
+  : (reverse_nth ctxt x = Some ty) -> (as_kind ctxt) ~> ty :=
+  match ctxt return (reverse_nth ctxt x = Some ty) -> (as_kind ctxt) ~> ty with
   | [] => fun H => match lookup_lower_contra H with end
-  | ty' :: env' => fun H =>
-    match eq_nat_dec x (length env') with
+  | ty' :: ctxt' => fun H =>
+    match eq_nat_dec x (length ctxt') with
     | left Heq =>
-      match object_decidable_equality ty' ty with
+      match eq_dec ty' ty with
       | left Heq2 => rew Heq2 in (second drop >>> cancelr) 
-      | right Hneq => match lookup_top_contra env' Heq H Hneq with end
+      | right Hneq => match lookup_top_contra ctxt' Heq H Hneq with end
       end
-    | right Hneq => first drop >>> cancell >>> extract_nth env' x (push_lookup _ _ Hneq H)
+    | right Hneq => first drop >>> cancell >>> extract_nth ctxt' x (push_lookup _ _ Hneq H)
     end
   end.
 
-Definition natvar : object -> object -> Type := fun _ _ => nat.
-
-(* Reverse de Brujin indexing is well formed *)
-Fixpoint wf_debrujin {i o}
-  (env: environment)
-  (expr: kappa natvar i o) {struct expr}
-  : Prop :=
-  match expr with
-  | Var _ i        => ok_lookup env i o
-  | Abs _ x f      => wf_debrujin (x :: env) (f (length env))
-  | App _ e1 e2    => wf_debrujin env e1 /\ wf_debrujin env e2
-  | Comp _ e1 e2   => wf_debrujin env e1 /\ wf_debrujin env e2
-  | Morph _ _      => True
-  | LetRec _ x v f => 
-    wf_debrujin (x :: env) (v (length env)) /\
-    wf_debrujin (x :: env) (f (length env))
-  end.
-
-(****************************************************************************)
-(* de Brujin indexing lemmas                                                *)
-(****************************************************************************)
-
-Section env.
-  Context {env: environment}.
-
-  Local Open Scope arrow_scope.
-
-  Lemma wf_debrujin_succ: forall {x y z} f,
-    @wf_debrujin (x ** y) z env (Abs _ _ f) -> @wf_debrujin y z (x :: env) (f (length env)).
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_var_succ: forall {x y a} v ,
-    wf_debrujin (i:=x) (o:=y) (a :: env) (Var _ v) -> wf_debrujin env (Var _ v) \/ v = length env.
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_compose1: forall {x y z} e1 e2,
-    @wf_debrujin x z env (Comp _ e2 e1) -> @wf_debrujin x y env e1.
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_compose2: forall {x y z} e1 e2,
-    @wf_debrujin x z env (Comp _ e2 e1) -> @wf_debrujin y z env e2.
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_app1: forall {x y z} f e,
-    wf_debrujin env (App _ f e) -> @wf_debrujin (x ** y) z env f.
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_app2: forall {x y z} f e,
-    @wf_debrujin y z env (App _ f e) -> @wf_debrujin u x env e.
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_letrec1: forall {x y z} v f,
-    @wf_debrujin y z env (LetRec natvar x v f)
-    -> @wf_debrujin u x (x :: env) (v (length env)).
-  Proof. env_auto. Qed.
-
-  Lemma wf_debrujin_lax_letrec2: forall {x y z} v f,
-    @wf_debrujin y z env (LetRec natvar x v f)
-    -> @wf_debrujin y z (x :: env) (f (length env)).
-  Proof. env_auto. Qed.
-End env.
-
-(* Perform closure conversion by passing an explicit environment. The PHOAS 
+(* Perform closure conversion by passing an explicit list object. The PHOAS 
 representation is converted to first order form with de Brujin
 indexing as described by Adam Chlipala's Lambda Tamer project. As our source
 language is a Kappa calculus and our target is a Generalized Arrow representation,
-the environment and arguments are manipulated using Arrow combinators amongst
+the list object and arguments are manipulated using Arrow combinators amongst
 other differences.
 
 This implementation is also currently missing logic to remove free variables
-from the environment.
+from the list object.
 *)
 Fixpoint closure_conversion' {i o}
-  (env: environment)
+  (ctxt: list object)
   (expr: kappa natvar i o) {struct expr}
-  : wf_debrujin env expr -> (i ** (as_kind env)) ~> o
+  : wf_phoas_context ctxt expr -> (i ** (as_kind ctxt)) ~> o
   :=
 match expr as expr in kappa _ i' o' return 
-  i' ** (as_kind env) = i ** (as_kind env)
+  i ** (as_kind ctxt) = i' ** (as_kind ctxt)
   -> o' = o
-  -> wf_debrujin env expr -> (i ** (as_kind env)) ~> o 
+  -> wf_phoas_context ctxt expr -> (i ** (as_kind ctxt)) ~> o 
 with
-(* Instantiating a variable is done by 'cancell' to select the environment, 
+(* Instantiating a variable is done by 'cancell' to select the list object, 
 and then indexing using lookup_morphism. *)
-| Var _ v => fun _ H wf => rew H in 
-  (first drop >>> cancell >>> (extract_nth env v wf))
+| Var v => fun _ H2 wf => 
+  first drop >>> cancell >>> (extract_nth ctxt v wf) >>> rewrite_object H2
 
-(* Kappa abstraction requires extending the environment then moving the 
-new environment variable in to place*)
-| Abs _ x f => fun H1 H2 wf =>
-  let f' := closure_conversion' (x :: env) (f (length env)) (wf_debrujin_succ _ wf) in
+(* Kappa abstraction requires extending the list object then moving the 
+new list object variable in to place*)
+| Abs f => fun H1 H2 wf =>
+  let f' := closure_conversion' (_ :: ctxt) (f (length ctxt)) wf in
   (* 
-      input:      (x*y)*environment_variables 
+      input:      (x*y)*list object_variables 
 
   1. 'first swap': Move the first argument into the right hand position
-      first swap: (y*x)*environment_variables ~> o
+      first swap: (y*x)*list object_variables ~> o
       
-  2. 'assoc': move the argument to the front of the environment via reassociation
-      assoc:      y*(x*environment_variables) ~> o
+  2. 'assoc': move the argument to the front of the list object via reassociation
+      assoc:      y*(x*list object_variables) ~> o
 
   3. call f'
-      f':         y*new_environment_variables ~> o
+      f':         y*new_list object_variables ~> o
   *)
-  let ex := (rew H2 in (first swap >>> assoc >>> f')) in
-  rew [fun ty => ty ~> o] H1 in ex
+  rewrite_object H1 >>> first swap >>> assoc >>> f' >>> rewrite_object H2 
 
-(* Application requires the object environment to be piped to the abstraction
+(* Application requires the object list object to be piped to the abstraction
 'f' and applicant 'e'. since running 'closure_conversion' on each binder
-removes the environment, we first need to copy the environment. *)
-| App _ f e => fun H1 H2 wf => 
-  rew [fun ty => ty ~> o] H1 in (
-    rew H2 in (
-      second (copy >>> first (uncancell
-      >>> closure_conversion' env e (wf_debrujin_lax_app2 wf)))
-      >>> unassoc >>> first swap
-      >>> closure_conversion' env f (wf_debrujin_lax_app1 wf)
-    ))
+removes the list object, we first need to copy the list object. *)
+| App f e => fun H1 H2 wf => 
+  rewrite_object H1 
+  >>> second (copy >>> first (uncancell
+  >>> closure_conversion' ctxt e (wf_phoas_context_lax_app2 wf)))
+  >>> unassoc >>> first swap
+  >>> closure_conversion' ctxt f (wf_phoas_context_lax_app1 wf)
+  >>> rewrite_object H2
 
-| Comp _ e1 e2 => fun H1 H2 wf => 
-  rew [fun ty => ty ~> o] H1 in (
-    rew H2 in (
-      second copy
-      >>> unassoc
-      >>> first (closure_conversion' env e2 (wf_debrujin_lax_compose1 wf))
-      >>> closure_conversion' env e1 (wf_debrujin_lax_compose2 wf)
-    ))
+| Comp e1 e2 => fun H1 H2 wf => 
+  rewrite_object H1 
+  >>> second copy
+  >>> unassoc
+  >>> first (closure_conversion' ctxt e2 (wf_phoas_context_lax_compose1 wf))
+  >>> closure_conversion' ctxt e1 (wf_phoas_context_lax_compose2 wf)
+  >>> rewrite_object H2
 
-| Morph _ m => fun H1 H2 wf => 
-  rew [fun ty => ty ~> o] H1 in (
-    rew H2 in (
-      second drop >>> cancelr >>> m
-    ))
+| Morph m => fun H1 H2 wf => 
+  rewrite_object H1 
+  >>> second drop >>> cancelr >>> m
+  >>> rewrite_object H2
 
-| LetRec _ x v f => fun H1 H2 wf =>
+| Let v f => fun H1 H2 wf => 
+  let f' := closure_conversion' (_ :: ctxt) (f (length ctxt)) (wf_phoas_context_lax_let2 wf) in
+  rewrite_object H1 
+  >>> second (copy >>> first (uncancell
+  >>> closure_conversion' ctxt v (wf_phoas_context_lax_let1 wf)))
+  >>> unassoc >>> first swap
+  >>> first swap >>> assoc >>> f'
+  >>> rewrite_object H2
 
-  let v' := closure_conversion' (x :: env) (v (length env)) (wf_debrujin_lax_letrec1 wf) in
-  let f' := closure_conversion' (x :: env) (f (length env)) (wf_debrujin_lax_letrec2 wf) in
+| LetRec v f => fun H1 H2 wf =>
+  let v' := closure_conversion' (_ :: ctxt) (v (length ctxt)) (wf_phoas_context_lax_letrec1 wf) in
+  let f' := closure_conversion' (_ :: ctxt) (f (length ctxt)) (wf_phoas_context_lax_letrec2 wf) in
 
-  rew [fun ty => ty ~> o] H1 in (
-    rew H2 in (
-    (* i**env ~> o *)
-    second (
-      (* env ~> o *)
-      copy >>>
-      (* env*env ~> o *)
-      first (
-        (* env ~> o *)
-        uncancell >>> 
-          (* u*env ~> o *)
+  rewrite_object H1
+                                  (* i**ctxt ~> o *)
+  >>> second (                       (* ctxt ~> o *)
+        copy >>>                     (* ctxt*ctxt ~> o *)
+        first (                         (* ctxt ~> o *)
+          uncancell >>>                 (* u*ctxt ~> o *)
           loopr (assoc >>> second swap >>> v' >>> copy)
-      )
-      (* i'**env ~> o *)
-    )
-    (* i**(i'**env) ~> o *)
+      )                               
+    )                              
     >>> f'
-  ))
+  >>> rewrite_object H2
+  
 end eq_refl eq_refl.
-
-(****************************************************************************)
-(* Kappa term equivalence                                                   *)
-(****************************************************************************)
-
-Section Equivalence.
-  Inductive obj_tup :  Type := obj_pair : object -> object -> obj_tup.
-  Variables var1 var2 : object -> object -> Type.
-
-  Definition vars := existT (fun '(obj_pair x y) => (var1 x y * var2 x y)%type).
-  Definition ctxt := list { '(obj_pair x y) : obj_tup & (var1 x y * var2 x y)%type }.
-
-  Inductive kappa_equivalence:
-    forall i o, ctxt
-    -> kappa var1 i o -> kappa var2 i o
-    -> Prop :=
-  | Var_equiv : forall i o (n1: var1 i o) (n2: var2 i o) E,
-    In (vars (obj_pair i o) (pair n1 n2)) E
-    -> kappa_equivalence E (Var _ n1) (Var _ n2)
-
-  | Abs_equiv : forall x y z 
-    (f1: var1 u x -> kappa var1 y z) 
-    (f2: var2 u x -> kappa var2 y z) 
-    (E:ctxt),
-    (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
-    -> kappa_equivalence E (Abs _ _ f1) (Abs _ _ f2)
-
-  | App_equiv : forall E x y z 
-    (f1 : kappa var1 (x**y) z) 
-    (f2 : kappa var2 (x**y) z) 
-    e1 e2,
-    kappa_equivalence E f1 f2
-    -> kappa_equivalence E e1 e2
-    -> kappa_equivalence E (App _ f1 e1) (App _ f2 e2)
-
-  | Compose_equiv : forall E x y z 
-    (f1: kappa var1 y z) (f2: kappa var2 y z)
-    (g1: kappa var1 x y) (g2: kappa var2 x y),
-    kappa_equivalence E f1 f2
-    -> kappa_equivalence E g1 g2
-    -> kappa_equivalence E (Comp _ f1 g1) (Comp _ f2 g2)
-
-  | Morph_equiv : forall x y E (m: morphism x y), kappa_equivalence E (Morph _ m) (Morph _ m)
-
-  | Letrec_equiv : forall x y z 
-    (v1: var1 u x -> kappa var1 u x) 
-    (v2: var2 u x -> kappa var2 u x) 
-    (f1: var1 u x -> kappa var1 y z) 
-    (f2: var2 u x -> kappa var2 y z) 
-    (E:ctxt),
-    (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (v1 n1) (v2 n2))
-    -> 
-    (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
-    -> 
-    kappa_equivalence E (LetRec _ _ v1 f1) (LetRec _ _ v2 f2).
-End Equivalence.
-
-Axiom Kappa_equivalence : forall {i o} (expr: forall var, kappa var i o) var1 var2,
-  kappa_equivalence nil (expr var1) (expr var2).
 
 Notation variable_pair i o n1 n2 := (vars natvar natvar (obj_pair i o) (pair n1 n2)).
 
@@ -373,17 +253,12 @@ Notation variable_pair i o n1 n2 := (vars natvar natvar (obj_pair i o) (pair n1 
 Notation match_pairs xo xn yi yo yn1 yn2 :=
   (variable_pair u xo xn xn = variable_pair yi yo yn1 yn2).
 
-(* Evidence that if a given variable is in an environment we can lookup_kind the object at the index. *)
-Notation ok_variable_lookup := (fun env E =>
+(* Evidence that if a given variable is in an list object we can reverse_nth the object at the index. *)
+Notation ok_variable_lookup := (fun ctxt E =>
   forall (i o : object) (n1 n2 : natvar i o),
     In (vars natvar natvar (obj_pair i o) (pair n1 n2)) E
-    -> lookup_kind env n1 = Some o
+    -> reverse_nth ctxt n1 = Some o
 ).
-
-Hint Extern 1 =>
-  match goal with
-  | [H1: In _ ?X, H2: ok_variable_lookup _ ?X |- _] => apply H2 in H1
-  end : environment.
 
 (* Recovering a dependent value requires recovering the type equality first to prevent the
 value equality disappearing. *)
@@ -399,28 +274,29 @@ Proof.
   auto.
 Qed.
 
-Hint Extern 3 => eapply recover_dependent_val : environment.
+Hint Extern 10 =>
+  match goal with
+  | [H1: In _ ?X, H2: ok_variable_lookup _ ?X |- _] => apply H2 in H1
+  end : kappa_cc.
 
-Lemma apply_lookup : forall (env: environment) i o n1 n2 E,
+Hint Extern 20 => eapply recover_dependent_val : kappa_cc.
+
+Lemma apply_lookup : forall (ctxt: list object) i o n1 n2 E,
   In (variable_pair i o n1 n2) E
-  -> ok_variable_lookup env E
-  -> lookup_kind env n1 = Some o.
-Proof.
-  env_auto.
-Qed.
+  -> ok_variable_lookup ctxt E
+  -> reverse_nth ctxt n1 = Some o.
+Proof. auto with kappa_cc. Qed.
 
-Hint Resolve split_lookup : environment.
+Hint Resolve split_lookup : kappa_cc.
 
-Lemma apply_extended_lookup: forall env v1 v2 y i o E,
-  match_pairs y (length env) i o v1 v2 \/ In (vars natvar natvar (obj_pair i o) (pair v1 v2)) E
-  -> ok_variable_lookup env E
-  -> lookup_kind (y :: env) v1 = Some o.
-Proof.
-  eauto 7 with environment.
-Qed.
+Lemma apply_extended_lookup: forall ctxt v1 v2 y i o E,
+  match_pairs y (length ctxt) i o v1 v2 \/ In (vars natvar natvar (obj_pair i o) (pair v1 v2)) E
+  -> ok_variable_lookup ctxt E
+  -> reverse_nth (y :: ctxt) v1 = Some o.
+Proof. eauto 7 with kappa_cc. Qed.
 
-Hint Immediate apply_lookup : core.
-Hint Immediate apply_extended_lookup : core.
+Hint Immediate apply_lookup : kappa_cc.
+Hint Immediate apply_extended_lookup : kappa_cc.
 
 (* Apply the auto generated kappa_equivalence_ind induction scheme rather than
 calling induction directly as calling induction directly results in too
@@ -428,30 +304,26 @@ specific hypotheses. *)
 Lemma kappa_wf
   : forall i o E (expr1 expr2: kappa natvar i o),
   kappa_equivalence E expr1 expr2
-  -> forall (env: environment), ok_variable_lookup env E
-  -> wf_debrujin env expr1.
+  -> forall (ctxt: list object), ok_variable_lookup ctxt E
+  -> wf_phoas_context ctxt expr1.
 Proof.
   apply (kappa_equivalence_ind
-  (fun i o E (expr1 expr2 : kappa natvar i o) =>
-    forall (env: environment),
-      ok_variable_lookup env E
-      -> wf_debrujin env expr1)
-      ); eauto with environment.
+    (fun i o E (expr1 expr2 : kappa natvar i o) =>
+      forall (ctxt: list object),
+        ok_variable_lookup ctxt E
+        -> wf_phoas_context ctxt expr1)
+    ); simpl; eauto with kappa_cc.
 Qed.
 
-Hint Resolve kappa_wf : core.
-Hint Resolve Kappa_equivalence : core.
+Hint Resolve kappa_wf : kappa_cc.
 
-Theorem Kappa_wf: forall {i o} (expr: forall var, kappa var i o), @wf_debrujin _ _ [] (expr _).
-Proof.
-  intros.
-  eapply kappa_wf.
-  apply Kappa_equivalence.
-  intros.
-  inversion H.
+Theorem Kappa_wf: forall {i o} (expr: forall var, kappa var i o), wf_phoas_context [] (expr _).
+Proof. 
+  Hint Extern 5 (kappa_equivalence _ _ _) => apply Kappa_equivalence : kappa_cc.
+  eauto with kappa_cc.
 Qed.
 
-Definition closure_conversion {i o} (expr: Kappa i o) (wf: wf_debrujin [] (expr _)): i ~> o
+Definition closure_conversion {i o} (expr: Kappa i o) (wf: wf_phoas_context [] (expr _)): i ~> o
   := uncancelr >>> closure_conversion' [] (expr _) wf.
 
 Definition Closure_conversion {i o} (expr: Kappa i o): i ~> o
@@ -462,19 +334,3 @@ Hint Resolve closure_conversion : core.
 Hint Resolve Closure_conversion : core.
 
 End Arrow.
-
-Ltac wf_kappa_via_compute :=
-  compute;
-  tauto.
-
-Ltac wf_kappa_via_equiv :=
-  match goal with
-  | [ |- wf_debrujin _ _] => eapply (@kappa_wf _ _ nil%list)
-  end; intros;
-  repeat match goal with 
-  | [ |- kappa_equivalence _ _ _] => constructor;intros
-  end; 
-  repeat match goal with 
-  | [ H: In _ nil |- _] => inversion H
-  | [ |- In _ _ ] => simpl; tauto
-  end.

--- a/cava/arrow-lib/Equiv.v
+++ b/cava/arrow-lib/Equiv.v
@@ -1,0 +1,67 @@
+From Coq Require Import List PeanoNat Arith.Peano_dec.
+From Arrow Require Import Category Arrow Kappa.
+
+Import ListNotations.
+
+Set Implicit Arguments.
+Set Asymmetric Patterns.
+
+Section Arrow.
+  Context `{arrow: Arrow}.
+
+  Section Equivalence.
+    Inductive obj_tup : Type := obj_pair : object -> object -> obj_tup.
+    Variables var1 var2 : object -> object -> Type.
+
+    Definition vars := existT (fun '(obj_pair x y) => (var1 x y * var2 x y)%type).
+    Definition ctxt := list { '(obj_pair x y) : obj_tup & (var1 x y * var2 x y)%type }.
+
+    Inductive kappa_equivalence:
+      forall i o, ctxt
+      -> kappa var1 i o -> kappa var2 i o
+      -> Prop :=
+    | Var_equiv : forall i o (n1: var1 i o) (n2: var2 i o) E,
+      In (vars (obj_pair i o) (pair n1 n2)) E
+      -> kappa_equivalence E (Var n1) (Var n2)
+
+    | Abs_equiv : forall x y z 
+      (f1: var1 u x -> kappa var1 y z) 
+      (f2: var2 u x -> kappa var2 y z) 
+      (E: ctxt),
+      (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
+      -> kappa_equivalence E (Abs f1) (Abs f2)
+
+    | App_equiv : forall E x y z 
+      (f1 : kappa var1 (product x y) z) 
+      (f2 : kappa var2 (product x y) z) 
+      e1 e2,
+      kappa_equivalence E f1 f2
+      -> kappa_equivalence E e1 e2
+      -> kappa_equivalence E (App f1 e1) (App f2 e2)
+
+    | Compose_equiv : forall E x y z 
+      (f1: kappa var1 y z) (f2: kappa var2 y z)
+      (g1: kappa var1 x y) (g2: kappa var2 x y),
+      kappa_equivalence E f1 f2
+      -> kappa_equivalence E g1 g2
+      -> kappa_equivalence E (Comp f1 g1) (Comp f2 g2)
+
+    | Morph_equiv : forall x y E (m: morphism x y), kappa_equivalence E (Morph m) (Morph m)
+
+    | Letrec_equiv : forall x y z 
+      (v1: var1 u x -> kappa var1 u x) 
+      (v2: var2 u x -> kappa var2 u x) 
+      (f1: var1 u x -> kappa var1 y z) 
+      (f2: var2 u x -> kappa var2 y z) 
+      (E: ctxt),
+      (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (v1 n1) (v2 n2))
+      -> 
+      (forall n1 n2, kappa_equivalence (vars (obj_pair u x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
+      -> 
+      kappa_equivalence E (LetRec v1 f1) (LetRec v2 f2).
+  End Equivalence.
+
+  Definition Wf {i o} (e: Kappa i o) := forall var1 var2, kappa_equivalence [] (e var1) (e var2).
+
+  Axiom Kappa_equivalence : forall {i o} (expr: forall var, kappa var i o), Wf expr.
+End Arrow.

--- a/cava/arrow-lib/Kappa.v
+++ b/cava/arrow-lib/Kappa.v
@@ -1,56 +1,201 @@
+From Coq Require Import List Peano_dec.
 From Arrow Require Import Category Arrow.
 
+Import ListNotations.
+
+Set Implicit Arguments.
+Set Asymmetric Patterns.
+
 Section Arrow.
-  Context `{A: ArrowSTKC}.
+  Context `{arrow: Arrow}.
+
+  Notation object_pair := (object * object)%type.
+  Definition natvar : object -> object -> Type := fun _ _ => nat.
+  Definition unitvar : object -> object -> Type := fun _ _ => unit.
 
   Section Vars.
     Variable (var: object -> object -> Type).
 
-    Local Open Scope arrow_scope.
-    Local Open Scope category_scope.
-
     Inductive kappa : object -> object -> Type :=
     | Var : forall {x y},   var x y -> kappa x y
-    | Abs : forall x {y z}, (var u x -> kappa y z) -> kappa (x ** y) z
-    | App : forall {x y z}, kappa (x ** y) z -> kappa u x -> kappa y z
+    | Abs : forall {x y z}, (var u x -> kappa y z) -> kappa (product x y) z
+    | App : forall {x y z}, kappa (product x y) z -> kappa u x -> kappa y z
     | Comp: forall {x y z}, kappa y z -> kappa x y -> kappa x z
     | Morph : forall {x y}, morphism x y -> kappa x y
-    | LetRec : forall x {y z}, 
-        (var u x -> kappa u x)
-      -> (var u x -> kappa y z) 
-      -> kappa y z.
-
-    Inductive NoLetRecKappa: forall i o, kappa i o -> Prop :=
-    | NoLetRecVar: forall x y v, NoLetRecKappa x y (Var v)
-    | NoLetRecAbs: forall x y z f,
-      (forall (k: var u x), NoLetRecKappa y z (f k)) -> NoLetRecKappa (x**y) z (Abs _ f)
-    | NoLetRecApp: forall x y z f e,
-      NoLetRecKappa (x ** y) z f -> NoLetRecKappa u x e -> NoLetRecKappa y z (App f e)
-    | NoLetRecComp: forall x y z f g,
-      NoLetRecKappa y z f -> NoLetRecKappa x y g -> NoLetRecKappa x z (Comp f g)
-    | NoLetRecMorph : forall x y m, NoLetRecKappa x y (Morph m).
-
-    Section prop.
-      Variable (P: forall x y, morphism x y -> Prop).
-
-      Inductive MorphPropKappa: forall i o, kappa i o -> Prop :=
-      | MorphPropVar: forall x y v, MorphPropKappa x y (Var v)
-      | MorphPropAbs: forall x y z f, (forall (k: var u x), MorphPropKappa y z (f k)) -> MorphPropKappa (x**y) z (Abs _ f)
-      | MorphPropApp: forall x y z f e,
-        MorphPropKappa (x ** y) z f -> MorphPropKappa u x e -> MorphPropKappa y z (App f e)
-      | MorphPropComp: forall x y z f g,
-        MorphPropKappa y z f -> MorphPropKappa x y g -> MorphPropKappa x z (Comp f g)
-      | MorphPropMorph : forall x y m, P x y m -> MorphPropKappa x y (Morph m).
-    End prop.
-
+    | Let: forall {x y z}, kappa u x -> (var u x -> kappa y z) -> kappa y z
+    | LetRec : forall {x y z}, (var u x -> kappa u x) -> (var u x -> kappa y z) -> kappa y z.
   End Vars.
 
-  Definition Kappa i o := forall var, kappa var i o.
+  Fixpoint reverse_nth {A} (l: list A) (n: nat) {struct l}: option A := 
+    match l with
+    | [] => None
+    | x :: xs => 
+      match eq_nat_dec n (length xs) with
+      | left _ => Some x
+      | right Hneq => reverse_nth xs n
+      end
+    end.
 
+  Notation ok_lookup := (fun (l: list _) (n: nat) (ty: _) => reverse_nth l n = Some ty).
+
+  Fixpoint wf_phoas_context {i o}
+    (ctxt: list object)
+    (expr: kappa natvar i o) {struct expr}
+    : Prop :=
+    match expr with
+    | Var _ _ n  => ok_lookup ctxt n o
+    | Abs x _ _ f => wf_phoas_context (x :: ctxt) (f (length ctxt))
+    | App _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2 
+    | Comp _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2
+    | Morph _ _ _ => True
+    | Let x _ _ v f => wf_phoas_context (x :: ctxt) (f (length ctxt)) /\ wf_phoas_context ctxt v 
+    | LetRec x _ _ v f => wf_phoas_context (x :: ctxt) (v (length ctxt)) /\ wf_phoas_context (x :: ctxt) (f (length ctxt))
+    end.
+
+  Section ctxt.
+    Context {ctxt: list object}.
+  
+    Lemma wf_phoas_context_lax_abs: forall {x y z} f,
+      @wf_phoas_context (product x y) z ctxt (Abs f) -> @wf_phoas_context y z (x :: ctxt) (f (length ctxt)).
+    Proof. auto. Qed.
+
+    Hint Extern 10 => 
+      match goal with
+      | [H: wf_phoas_context (_ :: ?ctxt) (Var _ ?v) |- _] => 
+        unfold wf_phoas_context, reverse_nth in H;
+        destruct (PeanoNat.Nat.eq_dec v (length ctxt))
+      | [H: wf_phoas_context _ _ |- _] => inversion H
+      end : core.
+  
+    Lemma wf_phoas_context_lax_var: forall {x y a} v ,
+      wf_phoas_context (i:=x) (o:=y) (a :: ctxt) (Var _ v) -> wf_phoas_context ctxt (Var _ v) \/ v = length ctxt.
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_compose1: forall {x y z} e1 e2,
+      @wf_phoas_context x z ctxt (Comp e2 e1) -> @wf_phoas_context x y ctxt e1.
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_compose2: forall {x y z} e1 e2,
+      @wf_phoas_context x z ctxt (Comp e2 e1) -> @wf_phoas_context y z ctxt e2.
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_app1: forall {x y z} f e,
+      wf_phoas_context ctxt (App f e) -> @wf_phoas_context (product x y) z ctxt f.
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_app2: forall {x y z} f e,
+      @wf_phoas_context y z ctxt (App f e) -> @wf_phoas_context u x ctxt e.
+    Proof. auto. Qed.
+
+    Lemma wf_phoas_context_lax_let1: forall {x y z} v f,
+      @wf_phoas_context y z ctxt (Let v f)
+      -> @wf_phoas_context u x ctxt v.
+    Proof. auto. Qed.
+
+    Lemma wf_phoas_context_lax_let2: forall {x y z} v f,
+      @wf_phoas_context y z ctxt (Let (x:=x) v f)
+      -> @wf_phoas_context y z (x :: ctxt) (f (length ctxt)).
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_letrec1: forall {x y z} v f,
+      @wf_phoas_context y z ctxt (LetRec v f)
+      -> @wf_phoas_context u x (x :: ctxt) (v (length ctxt)).
+    Proof. auto. Qed.
+  
+    Lemma wf_phoas_context_lax_letrec2: forall {x y z} v f,
+      @wf_phoas_context y z ctxt (LetRec (x:=x) v f)
+      -> @wf_phoas_context y z (x :: ctxt) (f (length ctxt)).
+    Proof. auto. Qed.
+  End ctxt.
+    
+
+  Fixpoint wf_phoas_context_elim {i o}
+    (ctxt: list object)
+    (expr: kappa natvar i o) {struct expr}
+    : Prop :=
+    match expr with
+    | Var _ _ n  => ok_lookup ctxt n o
+    | Abs x _ _ f => wf_phoas_context_elim (x :: ctxt) (f (length ctxt))
+    | App _ _ _ e1 e2 => forall (p: Prop),
+      (wf_phoas_context_elim ctxt e1 -> wf_phoas_context_elim ctxt e2 -> p) -> p
+    | Comp _ _ _ e1 e2 => forall (p: Prop),
+      (wf_phoas_context_elim ctxt e1 -> wf_phoas_context_elim ctxt e2 -> p) -> p
+    | Morph _ _ _ => True
+    | Let x _ _ v f => forall (p: Prop), 
+      (wf_phoas_context_elim ctxt v -> wf_phoas_context_elim (x :: ctxt) (f (length ctxt)) -> p) -> p
+    | LetRec x _ _ v f => forall (p: Prop),
+      (wf_phoas_context_elim (x :: ctxt) (v (length ctxt))
+      -> wf_phoas_context_elim (x :: ctxt) (f (length ctxt)) -> p) -> p
+    end.
+
+  Goal forall x, wf_phoas_context [] (Abs (x:=x) (y:=u) (z:=x) (fun x => Let (Var _ x) (fun y => Var _ y))).
+  Proof. cbn; auto. Qed.
+  Goal forall x, wf_phoas_context_elim [] (Abs (x:=x) (y:=u) (z:=x) (fun x => Let (Var _ x) (fun y => Var _ y))).
+  Proof. cbn; auto. Qed.
+
+  Lemma phoas_context_elim {i o} (expr: kappa natvar i o): forall (ctxt: list object),
+    wf_phoas_context_elim ctxt expr -> wf_phoas_context ctxt expr.
+  Proof.
+    induction expr; cbn [wf_phoas_context_elim] in *; 
+      simpl; intros;
+      try constructor;
+      try apply H;
+      try apply H0;
+      try apply H1;
+      auto.
+  Qed.
+
+  Lemma wf_let_is_wf_app_abs {x i o}
+    (v: kappa natvar u x)
+    (f: natvar u x -> kappa natvar i o)
+    : forall (ctxt: list object), wf_phoas_context ctxt (Let v f) -> wf_phoas_context ctxt (App (Abs f) v).
+  Proof. now cbn. Qed.
+  
+  Fixpoint no_letrec {i o} (e: kappa unitvar i o): bool :=
+    match e with 
+    | Var _ _ _ => true 
+    | Abs _ _ _ f => no_letrec (f tt)
+    | App _ _ _ f e => no_letrec f && no_letrec e 
+    | Comp _ _ _ e1 e2 => no_letrec e1 && no_letrec e2
+    | Morph _ _ _ => true
+    | Let _ _ _ v f => no_letrec v && no_letrec (f tt) 
+    | LetRec _ _ _ f1 f2 => false
+    end.
+
+  Fixpoint morph_prop {i o}
+    (P: forall x y, morphism x y -> Prop)
+    (e: kappa unitvar i o)
+    : Prop :=
+    match e with 
+    | Var _ _ _ => True 
+    | Abs _ _ _ f => morph_prop P (f tt)
+    | App _ _ _ f e => forall p: Prop, (morph_prop P f -> morph_prop P e -> p) -> p
+    | Comp _ _ _ e1 e2 => forall p: Prop, (morph_prop P e1 -> morph_prop P e2 -> p) -> p
+    | Morph _ _ m => P _ _ m
+    | Let _ _ _ v f => forall p: Prop, (morph_prop P v -> morph_prop P (f tt) -> p) -> p
+    | LetRec _ _ _ f1 f2 => forall p: Prop, (morph_prop P (f1 tt) -> morph_prop P (f2 tt) -> p) -> p
+    end.
+
+    Definition Kappa i o := forall var, kappa var i o.
 End Arrow.
 
-Hint Constructors NoLetRecKappa : core.
-Hint Extern 5 (NoLetRecKappa _ _ _ _) => apply NoLetRecAbs : core.
-Hint Constructors MorphPropKappa : core.
-Hint Extern 5 (MorphPropKappa _ _ _ _ _) => apply MorphPropAbs : core.
-Hint Extern 10 (MorphPropKappa _ _ _ _ _) => apply MorphPropComp : core.
+Ltac dispatch_wf_phoas_context := 
+  apply phoas_context_elim;
+  lazy -[reverse_nth];
+  repeat lazymatch goal with
+  | [ |- True ] => exact I
+  | [ |- forall p, (?H1 -> ?H2 -> p) -> p ] => 
+    let x := fresh in (let y := fresh in (
+      intros x y; apply y; clear x y
+    ))
+  end; 
+  repeat lazymatch goal with
+  | [ |- reverse_nth _ _ = Some _] => exact eq_refl
+  end. 
+
+Arguments Kappa.Var {_ _ _ _ _ var _ _}.
+Arguments Kappa.Abs {_ _ _ _ _ var _ _ _}.
+Arguments Kappa.App {_ _ _ _ _ var _ _ _}.
+Arguments Kappa.Comp {_ _ _ _ _ var _ _ _}.
+Arguments Kappa.Morph {_ _ _ _ _ var _ _}.
+Arguments Kappa.LetRec {_ _ _ _ _ var _ _ _}.

--- a/cava/arrow-lib/_CoqProject
+++ b/cava/arrow-lib/_CoqProject
@@ -6,4 +6,5 @@ Coq.v
 Kleisli.v
 
 Kappa.v
+Equiv.v
 ClosureConversion.v

--- a/cava/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/cava/Cava/Arrow/ArrowKind.v
@@ -15,6 +15,7 @@
 (****************************************************************************)
 
 From Coq Require Import Lists.List NaryFunctions Arith NArith Vector Eqdep_dec.
+From Arrow Require Import Arrow.
 
 Import ListNotations.
 Import VectorNotations.
@@ -32,6 +33,10 @@ Proof.
   decide equality.
   exact (PeanoNat.Nat.eq_dec n n0).
 Defined.
+
+Instance kind_decidable_equality_inst : DecidableEquality Kind := {
+  eq_dec := eq_kind_dec
+}.
 
 (* TODO: Coq.Init.Logic f_equal2 is opaque, f_equal is not, should transparency here be upstreamed? *)
 Lemma f_equal2 {A B C} {x y:A}  {a b: B} (f: A -> B -> C) : x = y -> a = b -> f x a = f y b.

--- a/cava/cava/Cava/Arrow/CavaExpression.v
+++ b/cava/cava/Cava/Arrow/CavaExpression.v
@@ -98,13 +98,6 @@ Section Vars.
   Bind Scope kind_scope with CavaExpr.
   Delimit Scope kind_scope with CavaExpr.
 
-  Arguments Kappa.Var [_ _ _ _ _ var _ _].
-  Arguments Kappa.Abs [_ _ _ _ _ var _ _ _].
-  Arguments Kappa.App [_ _ _ _ _ var _ _ _].
-  Arguments Kappa.Comp [_ _ _ _ _ var _ _ _].
-  Arguments Kappa.Morph [_ _ _ _ _ var _ _].
-  Arguments Kappa.LetRec [_ _ _ _ _ var _ _ _].
-
   Definition liftCava i {o} (f: remove_rightmost_unit i ~> o)
     : kappa var i o :=
     Kappa.Comp (Kappa.Morph f) (Kappa.Morph (remove_rightmost_tt i)).
@@ -172,8 +165,3 @@ Hint Resolve Desugar : core.
 Hint Resolve desugar : core.
 Hint Unfold Desugar : core.
 Hint Unfold desugar : core.
-
-Hint Extern 5 (NoLetRecKappa natvar _ _ (liftCava _ _)) =>
-      apply NoLetRecComp; apply NoLetRecMorph : stateless.
-Hint Extern 5 (MorphPropKappa natvar _ _ (liftCava _ _)) =>
-      apply MorphPropComp : stateless.

--- a/cava/cava/Cava/Arrow/CavaExpressionProp.v
+++ b/cava/cava/Cava/Arrow/CavaExpressionProp.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Arrow Require Import Category Arrow Kappa ClosureConversion.
+(* temporarily disabled *)
+(* From Arrow Require Import Category Arrow Kappa ClosureConversion.
 From Cava Require Import Arrow.CavaArrow Arrow.EvaluationArrow Arrow.CavaExpression.
 
 From Coq Require Import Arith NArith Lia NaryFunctions.
@@ -227,4 +228,4 @@ Proof.
 Qed.
 
 Hint Extern 15 => apply (no_let_rec_and_stateless_morphisms_is_stateless _ _) : stateless.
-Hint Extern 20 => refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _ ) : stateless.
+Hint Extern 20 => refine (OnlyUnitsTuple _ _ OnlyUnitsUnit _ ) : stateless. *)

--- a/cava/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/cava/Cava/Arrow/CavaNotation.v
@@ -29,7 +29,7 @@ Delimit Scope kappa_scope with kappa.
 
 Module KappaNotation.
   Notation "<[ e ]>" := (
-    fun (cava: Cava) => Closure_conversion (object_decidable_equality:=eq_kind_dec) (Desugar (fun var => e%kappa))
+    fun (cava: Cava) => Closure_conversion (Desugar (fun var => e%kappa))
    ) (at level 1, e custom expr at level 1).
 
   (* Notation "<[ e ]>" := (e%kappa) (at level 1, e custom expr at level 1). *)
@@ -130,7 +130,7 @@ Module KappaNotation.
     ) : kappa_scope.
 End KappaNotation.
 
-Definition make_module {i o} 
+Definition make_module {i o}
   (name: string)
   (expr: forall cava: Cava, i ~[cava]~> o)
   : forall cava: Cava, i ~[cava]~> o
@@ -207,7 +207,7 @@ Section regression_examples.
 
   Definition add' (n: nat)
     : forall cava: Cava, <<Vector Bit n, Vector Bit n, Unit>> ~> (Vector Bit n)
-    := 
+    :=
     match Nat.eq_dec (Init.Nat.max n n) n with
     | left Heq => rew [fun x => forall cava: Cava, _~>Vector Bit x] Heq in <[\x y=> x +% y]>
     | right Hneq => (ltac:(lia))


### PR DESCRIPTION
In preparation of removing redundant CavaExpr expression in favour of arrow-lib Kappa, which CavaExpr currently immediately desugars to.