### PR TITLE
Remove redundant CavaExpr in favor of Kappa

### DIFF
--- a/cava/arrow-examples/Aes/pkg.v
+++ b/cava/arrow-examples/Aes/pkg.v
@@ -15,7 +15,7 @@
 (****************************************************************************)
 
 From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
-From Arrow Require Import Category Arrow.
+From Arrow Require Import Category Arrow Kappa.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From ArrowExamples Require Import Combinators.
@@ -24,22 +24,22 @@ Import KappaNotation.
 Open Scope kind_scope.
 
 Notation "|^ x" :=
-  (App (Morphism (foldl1 <[\a b => xor a b]> _)) x)
+  (App (Morph (foldl1 <[\a b => xor a b]> _)) x)
   (in custom expr at level 5, no associativity) : kappa_scope.
 Notation "x && y" :=
-  (App (App And x) y)
+  (App (App (Morph and_gate) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x & y" :=
-  (App (App (Morphism (bitwise <[and]> _)) x) y)
+  (App (App (Morph (bitwise <[and]> _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x ^ y" :=
-  (App (App (Morphism (bitwise <[xor]> _)) x) y)
+  (App (App (Morph (bitwise <[xor]> _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "'if' i 'then' t 'else' e" :=
-  (App (App (App (Morphism (mux_item _)) i) t) e)
+  (App (App (App (Morph (mux_item _)) i) t) e)
   (in custom expr at level 5, left associativity) : kappa_scope.
 Notation "x == y" :=
-  (App (App (Morphism (equality _)) x) y)
+  (App (App (Morph (equality _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 
 Inductive SboxImpl := 

--- a/cava/arrow-examples/Aes/sbox_canright_pkg.v
+++ b/cava/arrow-examples/Aes/sbox_canright_pkg.v
@@ -47,10 +47,10 @@ Definition aes_mul_gf2p2
 
 Section regression_checks.
   Notation aes_mul_gf2p2_eval x y := 
-    (bitvec_to_nat (evaluate aes_mul_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x, N2Bv_sized 2 y))).
+    (bitvec_to_nat (combinational_evaluation aes_mul_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x, N2Bv_sized 2 y))).
   Notation aes_mul_gf2p2_test x y o := 
     (forall (wf: wf_combinational (aes_mul_gf2p2 _)), 
-    evaluate aes_mul_gf2p2 wf (N2Bv_sized 2 x, N2Bv_sized 2 y) = N2Bv_sized 2 o).
+    combinational_evaluation aes_mul_gf2p2 wf (N2Bv_sized 2 x, N2Bv_sized 2 y) = N2Bv_sized 2 o).
 
   Goal aes_mul_gf2p2_test 0 0 0. auto. Qed.
   Goal aes_mul_gf2p2_test 0 1 0. auto. Qed.
@@ -75,10 +75,10 @@ Definition aes_scale_omega2_gf2p2
 
 Section regression_checks.
   Notation aes_scale_omega2_gf2p2_eval x := 
-    (bitvec_to_nat (evaluate aes_scale_omega2_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x))).
+    (bitvec_to_nat (combinational_evaluation aes_scale_omega2_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x))).
   Notation aes_scale_omega2_gf2p2_test x o := 
     (forall (wf: wf_combinational (aes_scale_omega2_gf2p2 _)), 
-    evaluate aes_scale_omega2_gf2p2 wf (N2Bv_sized 2 x) = N2Bv_sized 2 o).
+    combinational_evaluation aes_scale_omega2_gf2p2 wf (N2Bv_sized 2 x) = N2Bv_sized 2 o).
 
   Goal aes_scale_omega2_gf2p2_test 0 0. auto. Qed.
   Goal aes_scale_omega2_gf2p2_test 1 3. auto. Qed.
@@ -176,10 +176,10 @@ Section regression_checks.
     <[\x => let vec = !S2X in vec[x] ]>.
   Goal
     (forall wf: wf_combinational (S2X_indexer _), 
-      evaluate S2X_indexer wf (N2Bv_sized 3 2) = N2Bv_sized 8 5). 
+      combinational_evaluation S2X_indexer wf (N2Bv_sized 3 2) = N2Bv_sized 8 5). 
     auto. Qed.
   Goal
     (forall wf: wf_combinational (S2X_indexer _), 
-      evaluate S2X_indexer wf (N2Bv_sized 3 4) = N2Bv_sized 8 18). 
+      combinational_evaluation S2X_indexer wf (N2Bv_sized 3 4) = N2Bv_sized 8 18). 
     auto. Qed.
 End regression_checks.

--- a/cava/arrow-examples/ArrowAdderTutorial.v
+++ b/cava/arrow-examples/ArrowAdderTutorial.v
@@ -177,7 +177,7 @@ Definition fullAdder_netlist :=
   makeNetlist fullAdderInterface (arrow_netlist fullAdder).
 
 Definition fullAdder_tb_expected_outputs  : list (bool * bool)
-  := (List.map (fun i => evaluate fullAdder fullAdder_is_combinational i) fullAdder_tb_inputs) .
+  := (List.map (fun i => combinational_evaluation fullAdder fullAdder_is_combinational i) fullAdder_tb_inputs) .
 
 Definition fullAdder_tb :=
   testBench "fullAdder_tb" fullAdderInterface

--- a/cava/arrow-examples/Mux2_1.v
+++ b/cava/arrow-examples/Mux2_1.v
@@ -67,7 +67,7 @@ Definition mux2_1_tb_inputs : list (bool * (bool * bool)) :=
 (* Using `evaluate_to_terms` for a nicer extracted value *)
 Definition mux2_1_tb_expected_outputs : list bool :=
 
- map (fun i => evaluate mux2_1 mux2_1_is_combinational i) mux2_1_tb_inputs.
+ map (fun i => combinational_evaluation mux2_1 mux2_1_is_combinational i) mux2_1_tb_inputs.
 
 Definition mux2_1_tb :=
   testBench "mux2_1_tb" mux2_1_Interface

--- a/cava/arrow-examples/UnsignedAdder.v
+++ b/cava/arrow-examples/UnsignedAdder.v
@@ -125,7 +125,7 @@ Definition adder445_tb_inputs :=
   [(0, 0); (1, 2); (15, 1); (15, 15)]%N.
 
 Definition adder445_tb_expected_outputs
-  := map (fun i => evaluate adder445 adder445_is_combinational i) adder445_tb_inputs.
+  := map (fun i => combinational_evaluation adder445 adder445_is_combinational i) adder445_tb_inputs.
 
 Definition adder445_tb
   := testBench "adder445_tb" adder445_interface
@@ -139,7 +139,7 @@ Definition adder88810_tb_inputs :=
   [(17, 23, 95); (4, 200, 30); (255, 255, 200)]%N.
 
 Definition adder88810_tb_expected_outputs
-  := map (fun i => evaluate adder88810 adder88810_is_combinational i) adder88810_tb_inputs.
+  := map (fun i => combinational_evaluation adder88810 adder88810_is_combinational i) adder88810_tb_inputs.
 
 Definition adder88810_tb
   := testBench "adder88810_tb" adder88810_interface
@@ -162,7 +162,7 @@ Lemma adder444_tree_4_is_combinational: wf_combinational (adder444_tree_4 _).
 Proof. combinational_obvious. Qed.
 
 Definition adder444_tree_4_tb_expected_outputs
-  := map (fun i => evaluate adder444_tree_4 adder444_tree_4_is_combinational i) adder444_tree_4_inputs.
+  := map (fun i => combinational_evaluation adder444_tree_4 adder444_tree_4_is_combinational i) adder444_tree_4_inputs.
 
 Definition adder444_tree_4_tb
   := testBench "adder444_tree_4_tb" adder444_tree_4_interface
@@ -183,7 +183,7 @@ Lemma growth_tree_8_is_combinational: wf_combinational (growth_tree_8 _).
 Proof. combinational_obvious. Qed.
 
 Definition growth_tree_8_tb_expected_outputs
-  := map (fun i => evaluate growth_tree_8 growth_tree_8_is_combinational i) growth_tree_8_inputs.
+  := map (fun i => combinational_evaluation growth_tree_8 growth_tree_8_is_combinational i) growth_tree_8_inputs.
 
 Definition growth_tree_8_tb
   := testBench "growth_tree_8_tb" growth_tree_8_interface

--- a/cava/arrow-lib/Arrow.v
+++ b/cava/arrow-lib/Arrow.v
@@ -37,8 +37,6 @@ Coercion arrow_category: Arrow >-> Category.
 Declare Scope arrow_scope.
 Bind Scope arrow_scope with Arrow.
 Delimit Scope arrow_scope with Arrow.
-Bind Scope arrow_scope with Category.
-Delimit Scope arrow_scope with Category.
 
 Notation "x ** y" := (product x y)
   (at level 30, right associativity) : arrow_scope.

--- a/cava/arrow-lib/Kappa.v
+++ b/cava/arrow-lib/Kappa.v
@@ -6,6 +6,7 @@ Import ListNotations.
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
+
 Section Arrow.
   Context `{arrow: Arrow}.
 
@@ -176,14 +177,27 @@ Section Arrow.
     | LetRec _ _ _ f1 f2 => forall p: Prop, (morph_prop P (f1 tt) -> morph_prop P (f2 tt) -> p) -> p
     end.
 
-    Definition Kappa i o := forall var, kappa var i o.
+  Definition Kappa i o := forall var, kappa var i o.
+
+  (* common functions *)
+
+  Open Scope category_scope.
+  Context {arrow_drop: ArrowDrop arrow}.
+
+  Definition kappa_fst {var x y}: kappa var (product (product x y) u) x := 
+    Morph var (cancelr >>> second drop >>> cancelr).
+  Definition kappa_snd {var x y}: kappa var (product (product x y) u) y := 
+    Morph var (cancelr >>> first drop >>> cancell).
+  Definition kappa_pair {var x y}: kappa var (product x (product y u)) (product x y) := 
+    Morph var (second cancelr).
+
 End Arrow.
 
 Ltac dispatch_wf_phoas_context := 
   apply phoas_context_elim;
   lazy -[reverse_nth];
   repeat lazymatch goal with
-  | [ |- True ] => exact I
+  | [ |- True ] => constructor
   | [ |- forall p, (?H1 -> ?H2 -> p) -> p ] => 
     let x := fresh in (let y := fresh in (
       intros x y; apply y; clear x y

--- a/cava/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/cava/Cava/Arrow/ArrowKind.v
@@ -185,3 +185,19 @@ match ty with
 | Tuple l r => Tuple l (remove_rightmost_unit r)
 | x => x
 end.
+
+Fixpoint denote_kind (ty: Kind): Type :=
+  match ty with 
+  | Tuple l r => denote_kind l * denote_kind r
+  | Bit => bool
+  | Vector ty n => Vector.t (denote_kind ty) n
+  | Unit => unit
+  end.
+
+Fixpoint kind_default (ty: Kind): denote_kind ty :=
+  match ty return denote_kind ty with 
+  | Tuple l r => (kind_default l, kind_default r)
+  | Bit => false
+  | Vector ty n => const (kind_default ty) n
+  | Unit => tt
+  end.

--- a/cava/cava/Cava/Arrow/CavaArrow.v
+++ b/cava/cava/Cava/Arrow/CavaArrow.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Arrow Require Import Category Arrow ClosureConversion.
+From Arrow Require Import Category Arrow Kappa ClosureConversion.
 From Coq Require Import Lists.List NaryFunctions String Arith NArith VectorDef Lia.
 
 Import ListNotations.
@@ -25,6 +25,7 @@ From Cava Require Export Arrow.ArrowKind.
 
 Local Open Scope category_scope.
 Local Open Scope arrow_scope.
+
 
 (* Class CircuitLaws `(A: Arrow, ! ArrowCopy A, ! ArrowSwap A, ! ArrowDrop A) := {
   cancelr_unit_uncancelr {x}: @cancelr x >>> uncancelr =M= id;
@@ -50,6 +51,7 @@ Local Open Scope arrow_scope.
 }. *)
 
 (* Cava *)
+Notation "[ x ~~> .. ~~> y ~~> z ]" := (morphism (Tuple x .. (Tuple y Unit) ..) z) : arrow_scope.
 Class Cava := {
   cava_cat :> Category Kind;
   cava_arrow :> Arrow Kind cava_cat Unit Tuple;
@@ -63,36 +65,36 @@ Class Cava := {
 
   mk_module i o: string -> (i~>o) -> (i~>o);
 
-  not_gate:  Bit        ~> Bit;
-  and_gate:  Bit ** Bit ~> Bit;
-  nand_gate: Bit ** Bit ~> Bit;
-  or_gate:   Bit ** Bit ~> Bit;
-  nor_gate:  Bit ** Bit ~> Bit;
-  xor_gate:  Bit ** Bit ~> Bit;
-  xnor_gate: Bit ** Bit ~> Bit;
-  buf_gate:  Bit        ~> Bit;
+  not_gate:  [ Bit ~~> Bit ];
+  and_gate:  [ Bit ~~> Bit ~~> Bit];
+  nand_gate: [ Bit ~~> Bit ~~> Bit];
+  or_gate:   [ Bit ~~> Bit ~~> Bit];
+  nor_gate:  [ Bit ~~> Bit ~~> Bit];
+  xor_gate:  [ Bit ~~> Bit ~~> Bit];
+  xnor_gate: [ Bit ~~> Bit ~~> Bit];
+  buf_gate:  [ Bit         ~~> Bit];
 
-  delay_gate {o} : o ~> o;
+  delay_gate {o} : [ o ~~> o ];
 
-  xorcy:     Bit ** Bit ~> Bit;
-  muxcy:     Bit ** (Bit ** Bit) ~> Bit;
+  xorcy:     [ Bit ~~> Bit ~~> Bit ];
+  muxcy:     [ Bit ~~> (Bit ** Bit) ~~> Bit ];
   
-  unsigned_add a b c: Vector Bit a ** Vector Bit b ~> Vector Bit c;
-  unsigned_sub a: Vector Bit a ** Vector Bit a ~> Vector Bit a;
+  unsigned_add a b c: [ Vector Bit a ~~> Vector Bit b ~~> Vector Bit c ];
+  unsigned_sub a: [ Vector Bit a ~~> Vector Bit a ~~> Vector Bit a ];
 
-  lut n: (bool^^n --> bool) -> Vector Bit n ~> Bit;
+  lut n: (bool^^n --> bool) -> [Vector Bit n ~~> Bit];
 
   empty_vec o: u ~> Vector o 0;
-  index n o: Vector o n ** vec_index n ~> o;
-  cons n o: o ** Vector o n ~> Vector o (S n);
-  snoc n o: Vector o n ** o ~> Vector o (S n);
-  uncons n o: Vector o (S n) ~> o ** Vector o n;
-  unsnoc n o: Vector o (S n) ~> Vector o n ** o;
-  concat n m o: Vector o n ** Vector o m ~> Vector o (n + m);
-  split n m o: Vector o (n+m) ~> (Vector o n ** Vector o m);
+  index n o: [Vector o n ~~> vec_index n ~~> o];
+  cons n o: [o ~~> Vector o n ~~> Vector o (S n)];
+  snoc n o: [Vector o n ~~> o ~~> Vector o (S n)];
+  uncons n o: [Vector o (S n) ~~> o ** Vector o n];
+  unsnoc n o: [Vector o (S n) ~~> Vector o n ** o];
+  concat n m o: [Vector o n ~~> Vector o m ~~> Vector o (n + m)];
+  split n m o: [Vector o (n+m) ~~> Vector o n ** Vector o m];
   (* slice n x y where x >= y, x is inclusive 
   So, somevec[1:0] is the vector [vec[0],vec[1]] : Vector 2 _ *)
-  slice n x y o: x < n -> y <= x -> Vector o n ~> Vector o (x - y + 1);
+  slice n x y o: x < n -> y <= x -> [Vector o n ~~> Vector o (x - y + 1)];
 }.
 
 Coercion cava_cat: Cava >-> Category.

--- a/cava/cava/Cava/Arrow/CavaExpression.v
+++ b/cava/cava/Cava/Arrow/CavaExpression.v
@@ -14,8 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Arrow Require Import Category Arrow Kappa ClosureConversion.
+From Arrow Require Import Category Arrow Kappa Equiv ClosureConversion.
 From Cava Require Import Arrow.CavaArrow.
+From Cava Require Arrow.CombinationalArrow.
 
 From Coq Require Import Arith NArith Lia NaryFunctions.
 
@@ -24,144 +25,36 @@ Import EqNotations.
 Open Scope category_scope.
 Open Scope arrow_scope.
 
-Section Vars.
-  Context {cava: Cava}.
-  Context {var: Kind -> Kind -> Type}.
+Notation CavaExpr var := (kappa var).
 
-  Definition lift_constant (ty: Kind): Type :=
-    match ty with
-    | Bit => bool
-    | Vector Bit n => N
-    | _ => False
-    end.
+Section combinational_semantics.
+  Import Arrow.CombinationalArrow.
+  
+  Definition coq_func i o := denote_kind i -> denote_kind o.
 
-  (*
-    `CavaExpr` includes constructors for
-    - Kappa Calculus,
-    - the Cava methods,
-    - lifting any morphism from the Constructive arrow instance,
-    - and miscellaneous methods
-
-    The kappa calculus and LiftMorphism constructors are the only 5
-    "primitive"/required constructors, the rest are a to help syntax
-    or type inference and desugar simply to combinations of the others.
-    *)
-  (* TODO: cleanup / have a more modular EDSL representation *)
-  Inductive CavaExpr : Kind -> Kind -> Type :=
-    (* Kappa Calculus *)
-    | Var: forall {x y},    var x y -> CavaExpr x y
-    | Abs: forall {x y z},  (var Unit x -> CavaExpr y z) -> CavaExpr << x, y >> z
-    | App: forall {x y z},  CavaExpr << x, y >> z -> CavaExpr Unit x -> CavaExpr y z
-    | Com: forall {x y z},  CavaExpr y z -> CavaExpr x y -> CavaExpr x z
-
-    (* Helper syntax *)
-    | Let: forall {x y z},  CavaExpr Unit x -> (var Unit x -> CavaExpr y z) -> CavaExpr y z
-    | Fst: forall {x y}, CavaExpr << << x, y >>, Unit >> x
-    | Snd: forall {x y}, CavaExpr << << x, y >>, Unit >> y
-    | Pair: forall {x y}, CavaExpr << x, y, Unit >> << x, y >>
-    | Id: forall {x}, CavaExpr <<x, Unit>> x
-    | Morphism: forall {i o}, (i~[cava]~>o) -> CavaExpr i o
-
-    (* Cava routines *)
-    | LiftConstant: forall x, lift_constant x -> CavaExpr Unit x
-
-    | Not: CavaExpr << Bit, Unit >> Bit
-    | And: CavaExpr << Bit, Bit, Unit >> Bit
-    | Nand: CavaExpr << Bit, Bit, Unit >> Bit
-    | Or:   CavaExpr << Bit, Bit, Unit >> Bit
-    | Nor:  CavaExpr << Bit, Bit, Unit >> Bit
-    | Xor:  CavaExpr << Bit, Bit, Unit >> Bit
-    | Xnor: CavaExpr << Bit, Bit, Unit >> Bit
-    | Buf:  CavaExpr << Bit, Unit >>      Bit
-    | Delay: forall {o}, CavaExpr << o, Unit >> o
-    | Xorcy: CavaExpr << Bit, Bit, Unit >> Bit
-    | Muxcy: CavaExpr << Bit, Tuple Bit Bit, Unit >> Bit
-    | UnsignedAdd: forall a b c, CavaExpr << Vector Bit a, Vector Bit b, Unit >> (Vector Bit c)
-    (* specialized adds *)
-    | UnsignedAdd1: forall a b, CavaExpr << Vector Bit a, Vector Bit b, Unit >> (Vector Bit (max a b))
-    | UnsignedAdd2: forall a b, CavaExpr << Vector Bit a, Vector Bit b, Unit >> (Vector Bit (1+max a b))
-
-    | UnsignedSub: forall a, CavaExpr << Vector Bit a, Vector Bit a, Unit >> (Vector Bit a)
-
-    | Lut n: (bool^^n --> bool) -> CavaExpr << Vector Bit n, Unit >> Bit
-
-    | EmptyVec: forall {o}, CavaExpr Unit (Vector o 0)
-    | Index: forall n {o}, CavaExpr << Vector o n, Vector Bit (Nat.log2_up n), Unit >> o
-    | Cons: forall n {o}, CavaExpr << o, Vector o n, Unit >> (Vector o (S n))
-    | Snoc: forall n {o}, CavaExpr << Vector o n, o, Unit >> (Vector o (S n))
-    | Uncons: forall n {o}, CavaExpr << Vector o (S n), Unit >> << o, Vector o n >>
-    | Unsnoc: forall n {o}, CavaExpr << Vector o (S n), Unit >> << Vector o n, o >>
-    | Concat: forall n m {o}, CavaExpr << Vector o n, Vector o m, Unit >> (Vector o (n + m))
-    | Split: forall n m {o}, CavaExpr << Vector o (n+m), Unit >> <<Vector o n, Vector o m>>
-    | Slice: forall n x y {o}, x < n -> y <= x -> CavaExpr << Vector o n, Unit >> (Vector o (x - y + 1)) .
-
-  Bind Scope kind_scope with CavaExpr.
-  Delimit Scope kind_scope with CavaExpr.
-
-  Definition liftCava i {o} (f: remove_rightmost_unit i ~> o)
-    : kappa var i o :=
-    Kappa.Comp (Kappa.Morph f) (Kappa.Morph (remove_rightmost_tt i)).
-
-  Fixpoint desugar {i o} (e: CavaExpr i o) : kappa var i o :=
-    match e with
-    | Var x => Kappa.Var x
-    | Abs f => Kappa.Abs (fun x => desugar (f x))
-    | App e1 e2 => Kappa.App (desugar e1) (desugar e2)
-    | Com f g => Kappa.Comp (desugar f) (desugar g)
-    | Let x f => Kappa.App (Kappa.Abs (fun x => desugar (f x))) (desugar x)
-
-    | Fst  => Kappa.Morph (cancelr >>> second drop >>> cancelr)
-    | Snd  => Kappa.Morph (cancelr >>> first drop >>> cancell)
-
-    | Pair => Kappa.Morph (second cancelr)
-
-    | Id => liftCava <<_,u>> id
-
-    | Not  => liftCava <<_,u>> not_gate
-    | And  => liftCava <<_,_,u>> and_gate
-    | Nand => liftCava <<_,_,u>> nand_gate
-    | Or   => liftCava <<_,_,u>> or_gate
-    | Nor  => liftCava <<_,_,u>> nor_gate
-    | Xor  => liftCava <<_,_,u>> xor_gate
-    | Xnor => liftCava <<_,_,u>> xnor_gate
-    | Buf  => liftCava <<_,u>> buf_gate
-
-    | Delay  => Kappa.Comp (Kappa.Morph delay_gate) (Kappa.Morph cancelr)
-
-    | Xorcy  => liftCava <<_,_,u>> xorcy
-    | Muxcy  => liftCava <<_,_,u>> muxcy
-    | UnsignedAdd a b c => liftCava <<_,_,u>> (unsigned_add a b c)
-    | UnsignedAdd1 a b => liftCava <<_,_,u>> (unsigned_add a b _)
-    | UnsignedAdd2 a b => liftCava <<_,_,u>> (unsigned_add a b _)
-    | UnsignedSub a => liftCava <<_,_,u>> (unsigned_sub a)
-    | Lut n f => liftCava <<_,u>> (lut n f)
-
-    | LiftConstant ty x =>
-      match ty, x with
-      | Bit, b => Kappa.Morph (constant b)
-      | Vector Bit n, v => Kappa.Morph (constant_bitvec _ v)
-      | _, H => match H with end
+  Fixpoint interp_combinational {i o: Kind}
+    (expr: kappa (arrow:=Combinational) coq_func i o)
+    : denote_kind i -> option (denote_kind o) :=
+    match expr with
+    | Var x => fun v => Some (x v) 
+    | Abs f => fun '(x,y) => interp_combinational (f (fun _ => x)) y
+    | App f e => fun y => 
+      match (interp_combinational e) tt with
+      | Some x => (interp_combinational f) (x, y)
+      | None => None
       end
-
-    | Morphism m => Kappa.Morph m
-
-    | EmptyVec => liftCava <<u>> (empty_vec _)
-    | Index n => liftCava <<_,_,u>> (index n _)
-    | Cons n => liftCava <<_,_,u>> (cons n _)
-    | Snoc n => liftCava <<_,_,u>> (snoc n _)
-    | Uncons n => liftCava <<_,u>> (uncons n _)
-    | Unsnoc n => liftCava <<_,u>> (unsnoc n _)
-    | Concat n m => liftCava <<_,_,u>> (concat n m _)
-    | Slice n x y H1 H2 => liftCava <<_,u>> (slice n x y _ H1 H2)
-    | Split n m => liftCava <<_,u>> (split n m _)
+    | Comp g f => (interp_combinational f) >==> (interp_combinational g)
+    | Morph m => m
+    | Let v f => fun y => 
+      match (interp_combinational v) tt with
+      | Some x => (interp_combinational (f (fun _ => x))) y
+      | None => None
+      end
+    | LetRec v f => fun _ => None
     end.
-End Vars.
 
-Arguments CavaExpr : clear implicits.
+    Axiom expression_evaluation_is_arrow_evaluation: forall i o (expr: Kappa i o), forall (x: denote_kind i),
+      Closure_conversion (arrow:=Combinational) expr x =
+      interp_combinational (expr _) x.
 
-Definition Desugar {cava: Cava} {i o} (e: forall var, CavaExpr cava var i o) : Kappa i o := fun var => desugar (e var).
-
-Hint Resolve Desugar : core.
-Hint Resolve desugar : core.
-Hint Unfold Desugar : core.
-Hint Unfold desugar : core.
+End combinational_semantics.

--- a/cava/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/cava/Cava/Arrow/CavaNotation.v
@@ -29,7 +29,7 @@ Delimit Scope kappa_scope with kappa.
 
 Module KappaNotation.
   Notation "<[ e ]>" := (
-    fun (cava: Cava) => Closure_conversion (Desugar (fun var => e%kappa))
+    fun (cava: Cava) => Closure_conversion (arrow:=cava) (fun var => e%kappa)
    ) (at level 1, e custom expr at level 1).
 
   (* Notation "<[ e ]>" := (e%kappa) (at level 1, e custom expr at level 1). *)
@@ -49,8 +49,8 @@ Module KappaNotation.
   (* todo: turn into a recursive pattern *)
   Notation "'let' '( x , y ) = e1 'in' e2"
     := (
-    Let (App Fst e1) (fun x =>
-      Let (App Snd e1) (fun y => e2
+    Let (App kappa_fst e1) (fun x =>
+      Let (App kappa_snd e1) (fun y => e2
       )
     )
     )
@@ -58,10 +58,10 @@ Module KappaNotation.
 
   (* Escaping *)
 
-  Notation "! x" := (Morphism (x _))(in custom expr at level 2, x global) : kappa_scope.
-  Notation "!( x )" := (Morphism (x _)) (in custom expr, x constr) : kappa_scope.
+  Notation "! x" := (Morph (x _))(in custom expr at level 2, x global) : kappa_scope.
+  Notation "!( x )" := (Morph (x _)) (in custom expr, x constr) : kappa_scope.
 
-  Notation tupleHelper := (fun x y => App (App Pair x) y).
+  Notation tupleHelper := (fun x y => App (App kappa_pair x) y).
   Notation "( x , .. , y , z )" := (
     (tupleHelper x .. (tupleHelper y z) .. )
     )
@@ -69,65 +69,75 @@ Module KappaNotation.
 
   (* Pre defined functions *)
 
-  Notation "'fst'" := (Fst) (in custom expr at level 4) : kappa_scope.
-  Notation "'snd'" := (Snd) (in custom expr at level 4) : kappa_scope.
+  Notation "'fst'" := (kappa_fst) (in custom expr at level 4) : kappa_scope.
+  Notation "'snd'" := (kappa_snd) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'not'" := (Not) (in custom expr at level 4) : kappa_scope.
-  Notation "'and'" := (And) (in custom expr at level 4) : kappa_scope.
-  Notation "'nand'" := (Nand) (in custom expr at level 4) : kappa_scope.
-  Notation "'or'" := (Or) (in custom expr at level 4) : kappa_scope.
-  Notation "'nor'" := (Nor) (in custom expr at level 4) : kappa_scope.
-  Notation "'xor'" := (Xor) (in custom expr at level 4) : kappa_scope.
-  Notation "'xnor'" := (Xnor) (in custom expr at level 4) : kappa_scope.
-  Notation "'buf'" := (Buf) (in custom expr at level 4) : kappa_scope.
-  Notation "'delay'" := (Delay) (in custom expr at level 4) : kappa_scope.
+  Notation "'not'" := (Morph not_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'and'" := (Morph and_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'nand'" := (Morph nand_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'or'" := (Morph or_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'nor'" := (Morph nor_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'xor'" := (Morph xor_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'xnor'" := (Morph xnor_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'buf'" := (Morph buf_gate) (in custom expr at level 4) : kappa_scope.
+  Notation "'delay'" := (Morph delay_gate) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'xorcy'" := (Xorcy) (in custom expr at level 4) : kappa_scope.
-  Notation "'muxcy'" := (Muxcy) (in custom expr at level 4) : kappa_scope.
+  Notation "'xorcy'" := (Morph xorcy) (in custom expr at level 4) : kappa_scope.
+  Notation "'muxcy'" := (Morph muxcy) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'unsigned_add' a b c" := (UnsignedAdd a b c)
+  Definition unsigned_add2 {cava:Cava} {a b} := unsigned_add a b (S (max a b)).
+  Definition unsigned_add1 {cava:Cava} {a b} := unsigned_add a b (max a b).
+
+  (* Notation "x + y" := (App (App (Morph (UnsignedAdd2 _ _)) x) y) (in custom expr at level 4) : kappa_scope. *)
+  Notation "x + y" := 
+      (App (App (Morph unsigned_add2) x) y) 
+      (in custom expr at level 4) : kappa_scope.
+  Notation "x +% y" := 
+      (App (App (Morph unsigned_add1) x) y) 
+      (in custom expr at level 4) : kappa_scope.
+  Notation "x - y" := (App (App (Morph (unsigned_sub _)) x) y) (in custom expr at level 4) : kappa_scope.
+  Notation "'unsigned_add' a b c" := (Morph (unsigned_add a b c))
     (in custom expr at level 4,
     a constr at level 4,
     b constr at level 4,
     c constr at level 4
     ) : kappa_scope.
-  Notation "'unsigned_sub' a" := (UnsignedSub a)
+  Notation "'unsigned_sub' a" := (Morph (unsigned_sub a))
     (in custom expr at level 4,
     a constr at level 4
     ) : kappa_scope.
-  Notation "x + y" := (App (App (UnsignedAdd2 _ _) x) y) (in custom expr at level 4) : kappa_scope.
-  Notation "x +% y" := (App (App (UnsignedAdd1 _ _) x) y) (in custom expr at level 4) : kappa_scope.
-  Notation "x - y" := (App (App (UnsignedSub _) x) y) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'index'" := (Index _) (in custom expr at level 4) : kappa_scope.
-  Notation "'empty'" := (EmptyVec) (in custom expr at level 4) : kappa_scope.
-  Notation "'cons'" := (Cons _) (in custom expr at level 4) : kappa_scope.
-  Notation "'snoc'" := (Snoc _) (in custom expr at level 4) : kappa_scope.
-  Notation "'concat'" := (Concat _ _) (in custom expr at level 4) : kappa_scope.
-  Notation "'split_at' x" := (Split x _) (in custom expr at level 4, x constr at level 4) : kappa_scope.
-  Notation "'uncons'" := (Uncons _) (in custom expr at level 4) : kappa_scope.
-  Notation "'unsnoc'" := (Unsnoc _) (in custom expr at level 4) : kappa_scope.
+  Notation "'[]'" := (Morph (empty_vec _)) (in custom expr at level 4) : kappa_scope.
+  Notation "x ++ y" := (App (App (Morph (concat _ _)) x) y) (in custom expr at level 4) : kappa_scope.
+  Notation "x :: y" := (App (App (Morph (cons _ _)) x) y) (in custom expr at level 7, right associativity) : kappa_scope.
 
-  Notation "'[]'" := (EmptyVec) (in custom expr at level 4) : kappa_scope.
-  Notation "x ++ y" := (App (App (Concat _ _) x) y) (in custom expr at level 4) : kappa_scope.
-  Notation "x :: y" := (App (App (Cons _) x) y) (in custom expr at level 7, right associativity) : kappa_scope.
+  Notation "'true'" := (Morph (constant true)) (in custom expr at level 2) : kappa_scope.
+  Notation "'false'" := (Morph (constant false)) (in custom expr at level 2) : kappa_scope.
 
-  Notation "'true'" := (LiftConstant Bit true) (in custom expr at level 2) : kappa_scope.
-  Notation "'false'" := (LiftConstant Bit false) (in custom expr at level 2) : kappa_scope.
+  Notation "# x" := (Morph (constant_bitvec _ x))%N (in custom expr at level 2, x constr at level 4) : kappa_scope.
 
-  Notation "# x" := (LiftConstant (Vector Bit _) x)%N (in custom expr at level 2, x constr at level 4) : kappa_scope.
-
-  Notation "v [ x ]" := (App (App (Index _) v) x)
+  Notation "v [ x ]" := (App (App (Morph (index _ _)) v) x)
     ( in custom expr at level 2
     , x at level 7
     ) : kappa_scope.
   Notation "v [: x : y ]" :=
-        (App (Slice _ (x <: nat) (y <: nat) _ _) v)
+        (App (Morph (slice _ (x <: nat) (y <: nat) _ _ _)) v)
     (in custom expr at level 2,
     (* v constr, *)
     x constr at level 7,
     y constr at level 7
     ) : kappa_scope.
+
+  Notation "'index'" := (Morph (index _ _)) (in custom expr at level 4) : kappa_scope.
+  Notation "'empty'" := (Morph empty_vec) (in custom expr at level 4) : kappa_scope.
+  Notation "'cons'" := (Morph (cons _ _)) (in custom expr at level 4) : kappa_scope.
+  Notation "'snoc'" := (Morph (snoc _ _)) (in custom expr at level 4) : kappa_scope.
+  Notation "'concat'" := (Morph (concat _ _ _)) (in custom expr at level 4) : kappa_scope.
+  Notation "'split_at' x" := (Morph (split x _ _)) (in custom expr at level 4, x constr at level 4) : kappa_scope.
+  Notation "'uncons'" := (Morph (uncons _ _)) (in custom expr at level 4) : kappa_scope.
+  Notation "'unsnoc'" := (Morph (unsnoc _ _)) (in custom expr at level 4) : kappa_scope.
+
+
 End KappaNotation.
 
 Definition make_module {i o}

--- a/cava/cava/Cava/Arrow/EvaluationArrow.v
+++ b/cava/cava/Cava/Arrow/EvaluationArrow.v
@@ -23,30 +23,14 @@ Import EqNotations.
 
 Require Import Cava.BitArithmetic.
 
-Fixpoint denote (ty: Kind): Type :=
-  match ty with 
-  | Tuple l r => denote l * denote r
-  | Bit => bool
-  | Vector ty n => Vector.t (denote ty) n
-  | Unit => unit
-  end.
-
-Fixpoint kind_default (ty: Kind): denote ty :=
-  match ty return denote ty with 
-  | Tuple l r => (kind_default l, kind_default r)
-  | Bit => false
-  | Vector ty n => const (kind_default ty) n
-  | Unit => tt
-  end.
-
 Section instance.
 
-(* Coq will infer the evaluated type of 'denote ty', rather than 'denote ty'
+(* Coq will infer the evaluated type of 'denote_kind ty', rather than 'denote_kind ty'
 when giving constant values (e.g. 'tt'), so we define notation to apply the 
 correct type annotation *)
-Notation fun_s ty f := (existT _ _ (f : _ -> denote ty -> (_ * denote ty))).
+Notation fun_s ty f := (existT _ _ (f : _ -> denote_kind ty -> (_ * denote_kind ty))).
 
-Definition evalMorphism X Y := { state: Kind & denote X -> denote state -> (denote Y * denote state) }.
+Definition evalMorphism X Y := { state: Kind & denote_kind X -> denote_kind state -> (denote_kind Y * denote_kind state) }.
 Definition evalProjState {X Y} (m: evalMorphism X Y): Kind := projT1 m. 
 
 Instance EvalCategory : Category Kind := {
@@ -59,13 +43,13 @@ Instance EvalCategory : Category Kind := {
       let (x, r) := (projT2 f) x r in
       (x, (l, r))
     );
-  id X := fun_s Unit (fun x _ => (x, tt : denote Unit));
+  id X := fun_s Unit (fun x _ => (x, tt : denote_kind Unit));
 }.
 
 Instance EvalArrow : Arrow _ EvalCategory Unit Tuple := {
   first _ _ _ f := fun_s (evalProjState f) (fun i s =>
     let (x, s) := (projT2 f) (fst i) s in
-    ((x, snd i), s : denote (evalProjState f))
+    ((x, snd i), s : denote_kind (evalProjState f))
   );
   second _ _ _ f := fun_s (evalProjState f) (fun i s =>
     let (x, s) := (projT2 f) (snd i) s in
@@ -107,28 +91,28 @@ Instance EvalSTKC : ArrowSTKC EvalArrow := { }.
 
   mk_module _ _ _name f := f;
 
-  not_gate := fun_s Unit (fun i _ => (negb i, tt));
-  and_gate := fun_s Unit (fun '(x, y) _ => (andb x y, tt));
-  nand_gate := fun_s Unit (fun '(x, y) _ => (negb (andb x y), tt));
-  or_gate := fun_s Unit (fun '(x, y) _ => (orb x y, tt));
-  nor_gate := fun_s Unit (fun '(x, y) _ => (negb (orb x y), tt));
-  xor_gate := fun_s Unit (fun '(x, y) _ => (xorb x y, tt));
-  xnor_gate := fun_s Unit (fun '(x, y) _ => (negb (xorb x y), tt));
+  not_gate := fun_s Unit (fun i _ => (negb (fst i), tt));
+  and_gate := fun_s Unit (fun '(x, (y, _)) _ => (andb x y, tt));
+  nand_gate := fun_s Unit (fun '(x, (y, _)) _ => (negb (andb x y), tt));
+  or_gate := fun_s Unit (fun '(x, (y, _)) _ => (orb x y, tt));
+  nor_gate := fun_s Unit (fun '(x, (y, _)) _ => (negb (orb x y), tt));
+  xor_gate := fun_s Unit (fun '(x, (y, _)) _ => (xorb x y, tt));
+  xnor_gate := fun_s Unit (fun '(x, (y, _)) _ => (negb (xorb x y), tt));
 
-  buf_gate := fun_s Unit (fun i _ => (i, tt));
-  delay_gate X := fun_s X (fun i s => (s, i));
+  buf_gate := fun_s Unit (fun i _ => (fst i, tt));
+  delay_gate X := fun_s X (fun i s => (s, fst i));
 
-  xorcy := fun_s Unit (fun '(x, y) _ => (xorb x y, tt));
-  muxcy := fun_s Unit (fun (i: (bool*(bool*bool))) _ => (if fst i then fst (snd i) else snd (snd i), tt));
+  xorcy := fun_s Unit (fun '(x, (y, _)) _ => (xorb x y, tt));
+  muxcy := fun_s Unit (fun (i: (bool*((bool*bool)*unit))) _ => (if fst i then fst (fst (snd i)) else snd (fst (snd i)), tt));
 
-  unsigned_add m n s := fun_s Unit (fun '(x, y) _ => 
+  unsigned_add m n s := fun_s Unit (fun '(x, (y,_)) _ => 
     let a := Ndigits.Bv2N x in
     let b := Ndigits.Bv2N y in
     let c := (a + b)%N in
     (Ndigits.N2Bv_sized s c, tt)
   );
 
-  unsigned_sub s := fun_s Unit (fun '(x, y) _ => 
+  unsigned_sub s := fun_s Unit (fun '(x, (y, _)) _ => 
     let a := Ndigits.Bv2N x in
     let b := Ndigits.Bv2N y in
     let c := (a - b)%N in(*todo: This is likely incorrect on underflow *)
@@ -137,38 +121,38 @@ Instance EvalSTKC : ArrowSTKC EvalArrow := { }.
 
   lut n f := fun_s Unit (fun i _ => 
     let f' := NaryFunctions.nuncurry bool bool n f in
-    (f' (vec_to_nprod _ _ i), tt)
+    (f' (vec_to_nprod _ _ (fst i)), tt)
   );
 
-  empty_vec o := fun_s Unit (fun i _ => (Vector.nil (denote o),tt));
-  index n o := fun_s Unit (fun '(array, index) _ => 
+  empty_vec o := fun_s Unit (fun i _ => (Vector.nil (denote_kind o),tt));
+  index n o := fun_s Unit (fun '(array, (index,_)) _ => 
     match Arith.Compare_dec.lt_dec (bitvec_to_nat index) n with
     | left Hlt => (nth_order array Hlt, tt)
     | right Hnlt => (kind_default _, tt)
     end);
 
-  cons n o := fun_s Unit (fun '(x, v) _ => (x :: v, tt));
-  snoc n o := fun_s Unit (fun '(v, x) _ => ( 
+  cons n o := fun_s Unit (fun '(x, (v,_)) _ => (x :: v, tt));
+  snoc n o := fun_s Unit (fun '(v, (x,_)) _ => ( 
     let v' := (v ++ [x]) 
     in match Nat.eq_dec (n + 1) (S n)  with 
-      | left Heq => rew [fun x => denote (Vector o x)] Heq in v'
-      | right Hneq => (ltac:(exfalso;lia))
+      | left Heq => rew [fun x => denote_kind (Vector o x)] Heq in v'
+      | right Hneq => (ltac:(exfalso; lia))
       end, tt));
-  uncons n o := fun_s Unit (fun v _ => ((hd v, tl v), tt));
+  uncons n o := fun_s Unit (fun '(v,_) _ => ((hd v, tl v), tt));
   unsnoc n o := fun_s Unit (fun v _ => (
     let v' := match Arith.Compare_dec.le_dec n (S n)  with 
-      | left Hlt => take n Hlt v
-      | right Hnlt => (ltac:(exfalso;lia))
+      | left Hlt => take n Hlt (fst v)
+      | right Hnlt => (ltac:(exfalso; lia))
       end in
-    (v', last v), tt));
-  concat n m o := fun_s Unit (fun '(x, y) _ => (Vector.append x y, tt));
+    (v', last (fst v)), tt));
+  concat n m o := fun_s Unit (fun '(x, (y, _)) _ => (Vector.append x y, tt));
 
-  split n m o := fun_s Unit (fun x _ => (Vector.splitat n x, tt));
+  split n m o := fun_s Unit (fun x _ => (Vector.splitat n (fst x), tt));
 
   slice n x y o H1 H2 := fun_s Unit (fun v _ => (
     match Nat.eq_dec n (y + (n - y)) with 
       | left Heq =>
-        let '(_, v) := splitat y (rew [fun x => Vector.t (denote o) x] Heq in v)
+        let '(_, v) := splitat y (rew [fun x => Vector.t (denote_kind o) x] Heq in (fst v))
         in 
           match Nat.eq_dec (n-y) ((x - y + 1) + (n - x - 1)) with 
           | left Heq => _
@@ -241,7 +225,7 @@ Defined.
 
 Lemma only_units_is_singular: forall ty,
   kind_only_units ty -> 
-  (forall s:denote ty, s = kind_default ty).
+  (forall s:denote_kind ty, s = kind_default ty).
 Proof.
   intros.
   induction ty; simpl in *.
@@ -268,7 +252,7 @@ Qed.
 Lemma state_is_irrelevant_for_stateless_circuit: forall {x y} 
   (circuit: x ~[EvalCava]~> y) ,
   has_no_state circuit -> 
-  (forall s:denote (evalProjState circuit), s = kind_default (projT1 circuit)).
+  (forall s:denote_kind (evalProjState circuit), s = kind_default (projT1 circuit)).
 Proof.
   intros.
   unfold has_no_state in H.
@@ -277,14 +261,13 @@ Proof.
 Qed.
 
 Definition evaluate {X Y} (circuit: X ~[EvalCava]~> Y)
-  (x: denote X)
-  (state: denote (evalProjState circuit))
-  : (denote Y * denote (evalProjState circuit))
-  :=
+  (x: denote_kind X)
+  (state: denote_kind (evalProjState circuit))
+  : (denote_kind Y * denote_kind (evalProjState circuit)) :=
   ((projT2 circuit) x state).
 
 Definition stateless_evaluation {X Y} (circuit: X ~[EvalCava]~> Y)
-  (H: has_no_state circuit) (x: denote X): denote Y
+  (H: has_no_state circuit) (x: denote_kind X): denote_kind Y
   :=
   fst ((projT2 circuit) x (kind_default _)).
 
@@ -317,11 +300,11 @@ Hint Extern 5 (has_no_state (remove_rightmost_tt _)) =>
 Example not_gate_is_stateless: has_no_state (not_gate).
 Proof. auto with stateless. Qed.
 
-Example evaluate_not_true: evaluate not_gate true tt = (false, tt).
+Example evaluate_not_true: evaluate not_gate (true, tt) tt = (false, tt).
 Proof. reflexivity. Qed.
 
 Example evaluate_not_true_with_stateless: 
-  stateless_evaluation not_gate not_gate_is_stateless true = false.
+  stateless_evaluation not_gate not_gate_is_stateless (true, tt) = false.
 Proof. reflexivity. Qed.
 
 (* The proof is not 'forall x, ~ has_no_state ...' as a delay_gate of a unit type 
@@ -336,5 +319,5 @@ Proof.
   inversion H.
 Qed.
 
-Example evaluate_delay_gate: evaluate (delay_gate (o:=Bit)) true false = (false, true).
+Example evaluate_delay_gate: evaluate (delay_gate (o:=Bit)) (true, tt) false = (false, true).
 Proof. reflexivity. Qed.

--- a/cava/cava/Cava/Arrow/NetlistArrow.v
+++ b/cava/cava/Cava/Arrow/NetlistArrow.v
@@ -188,71 +188,71 @@ Section NetlistEval.
 
     not_gate i :=
       o <- newWire ;;
-      addInstance (Not i o) ;;
+      addInstance (Not (fst i) o) ;;
       ret o;
 
-    and_gate '(i0,i1) :=
+    and_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (And i0 i1 o) ;;
       ret o;
 
-    nand_gate '(i0,i1) :=
+    nand_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (Nand i0 i1 o) ;;
       ret o;
 
-    or_gate '(i0,i1) :=
+    or_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (Or i0 i1 o) ;;
       ret o;
 
-    nor_gate '(i0,i1) :=
+    nor_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (Nor i0 i1 o) ;;
       ret o;
 
-    xor_gate '(i0,i1) :=
+    xor_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (Xor i0 i1 o) ;;
       ret o;
 
-    xnor_gate '(i0,i1) :=
+    xnor_gate '(i0,(i1,_)) :=
       o <- newWire ;;
       addInstance (Xnor i0 i1 o) ;;
       ret o;
 
     buf_gate 'i :=
       o <- newWire ;;
-      addInstance (Buf i o) ;;
+      addInstance (Buf (fst i) o) ;;
       ret o;
 
     delay_gate X x :=
       y <- build X ;;
-      mapMSignals2 (fun x y => DelayBit x y) X x y ;;
+      mapMSignals2 (fun x y => DelayBit x y) X (fst x) y ;;
       ret y;
 
-    xorcy '(i0, i1) :=
+    xorcy '(i0, (i1, _)) :=
       o <- newWire ;;
       addInstance (Component "XORCY" [] [("O", USignal o); ("CI", USignal i0); ("LI", USignal i1)]) ;;
       ret o;
 
-    muxcy '(s,(ci, di)) :=
+    muxcy '(s,((ci, di), _)) :=
       o <- newWire ;;
       addInstance ( Component "MUXCY" [] [("O", USignal o); ("S", USignal s); ("CI", USignal ci); ("DI", USignal di)]) ;;
       ret o;
 
-    unsigned_add m n s '(x, y) :=
+    unsigned_add m n s '(x, (y,_)) :=
       sum <- newVector _ s ;;
       addInstance (UnsignedAdd (VecLit x) (VecLit y) sum) ;;
       ret (Vector.map (IndexConst sum) (vseq 0 s));
 
-    unsigned_sub s '(x, y) :=
+    unsigned_sub s '(x, (y,_)) :=
       sum <- newVector _ s ;;
       (* TODO: add netlist subtraction instance *)
       addInstance (UnsignedAdd (VecLit x) (VecLit y) sum) ;;
       ret (Vector.map (IndexConst sum) (vseq 0 s));
 
-    lut n f is :=
+    lut n f '(is,_) :=
       let seq := seq 0 (2^n) in
       let f' := NaryFunctions.nuncurry bool bool n f in
       let powers := map
@@ -274,17 +274,17 @@ Section NetlistEval.
       ret o;
 
   empty_vec o _ := ret []%vector;
-  index n o '(array, index) := _;
+  index n o '(array, (index, _)) := _;
 
-  cons n o '(x, v) := _;
-  snoc n o '(v, x) := _;
-  uncons n o v := _; 
-  unsnoc n o v := _; 
-  concat n m o '(x, y) := ret (Vector.append x y);
+  cons n o '(x, (v, _)) := _;
+  snoc n o '(v, (x, _)) := _;
+  uncons n o '(v, _) := _; 
+  unsnoc n o '(v, _) := _; 
+  concat n m o '(x, (y,_) ) := ret (Vector.append x y);
 
-  split n m o x := ret (Vector.splitat n x);
+  split n m o x := ret (Vector.splitat n (fst x));
 
-  slice n x y o H1 H2 v := _;
+  slice n x y o H1 H2 '(v,_) := _;
   }.
   Proof.
     (* TODO: clean up *)


### PR DESCRIPTION
- Add evaluation semantics for CavaExpr now `@Kappa Cava` combinational expressions
- Standardise CavaArrow methods to have right most unit (reduces the amount of conversion functions needed).

This moves towards a DSL tower of
1) CavaExpr based on Kappa caluculus
2) CavaArrow circuit DSL design directed by arrows
3) The shared netlist representation

Variables get removed from 1 to 2, types get simplified between 2 to 3.
