### PR TITLE
Simplify combinational evaluator

### DIFF
--- a/cava/arrow-examples/Aes/sbox_canright_pkg.v
+++ b/cava/arrow-examples/Aes/sbox_canright_pkg.v
@@ -47,9 +47,9 @@ Definition aes_mul_gf2p2
 
 Section regression_checks.
   Notation aes_mul_gf2p2_eval x y := 
-    (bitvec_to_nat (combinational_evaluation aes_mul_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x, N2Bv_sized 2 y))).
+    (bitvec_to_nat (combinational_evaluation aes_mul_gf2p2 (ltac:(simply_combinational)) (N2Bv_sized 2 x, N2Bv_sized 2 y))).
   Notation aes_mul_gf2p2_test x y o := 
-    (forall (wf: wf_combinational (aes_mul_gf2p2 _)), 
+    (forall (wf: is_combinational aes_mul_gf2p2), 
     combinational_evaluation aes_mul_gf2p2 wf (N2Bv_sized 2 x, N2Bv_sized 2 y) = N2Bv_sized 2 o).
 
   Goal aes_mul_gf2p2_test 0 0 0. auto. Qed.
@@ -75,9 +75,9 @@ Definition aes_scale_omega2_gf2p2
 
 Section regression_checks.
   Notation aes_scale_omega2_gf2p2_eval x := 
-    (bitvec_to_nat (combinational_evaluation aes_scale_omega2_gf2p2 (ltac:(combinational_obvious)) (N2Bv_sized 2 x))).
+    (bitvec_to_nat (combinational_evaluation aes_scale_omega2_gf2p2 (ltac:(simply_combinational)) (N2Bv_sized 2 x))).
   Notation aes_scale_omega2_gf2p2_test x o := 
-    (forall (wf: wf_combinational (aes_scale_omega2_gf2p2 _)), 
+    (forall (wf: is_combinational aes_scale_omega2_gf2p2), 
     combinational_evaluation aes_scale_omega2_gf2p2 wf (N2Bv_sized 2 x) = N2Bv_sized 2 o).
 
   Goal aes_scale_omega2_gf2p2_test 0 0. auto. Qed.
@@ -175,11 +175,11 @@ Section regression_checks.
   Definition S2X_indexer: forall cava:Cava, <<Vector Bit 3, Unit>> ~> <<Vector Bit 8>> := 
     <[\x => let vec = !S2X in vec[x] ]>.
   Goal
-    (forall wf: wf_combinational (S2X_indexer _), 
+    (forall wf: is_combinational S2X_indexer, 
       combinational_evaluation S2X_indexer wf (N2Bv_sized 3 2) = N2Bv_sized 8 5). 
     auto. Qed.
   Goal
-    (forall wf: wf_combinational (S2X_indexer _), 
+    (forall wf: is_combinational S2X_indexer, 
       combinational_evaluation S2X_indexer wf (N2Bv_sized 3 4) = N2Bv_sized 8 18). 
     auto. Qed.
 End regression_checks.

--- a/cava/arrow-examples/ArrowAdderTutorial.v
+++ b/cava/arrow-examples/ArrowAdderTutorial.v
@@ -150,8 +150,8 @@ Section notation.
 
 End notation.
 
-Lemma fullAdder_is_combinational: wf_combinational (fullAdder _).
-Proof. combinational_obvious. Qed.
+Lemma fullAdder_is_combinational: is_combinational fullAdder.
+Proof. simply_combinational. Qed.
 
 Require Import Cava.Types.
 Require Import Cava.Netlist.

--- a/cava/arrow-examples/Mux2_1.v
+++ b/cava/arrow-examples/Mux2_1.v
@@ -41,9 +41,9 @@ End notation.
 
 Open Scope kind_scope.
 
-Lemma mux2_1_is_combinational: wf_combinational (mux2_1 _).
-Proof. combinational_obvious. Qed.
-
+Lemma mux2_1_is_combinational: is_combinational mux2_1.
+Proof. simply_combinational. Qed.
+  
 Require Import Cava.Types.
 Require Import Cava.Netlist.
 

--- a/cava/arrow-examples/SyntaxExamples.v
+++ b/cava/arrow-examples/SyntaxExamples.v
@@ -40,5 +40,5 @@ End notation.
 
 Open Scope kind_scope.
 
-Lemma xilinxFullAdder_is_combinational: wf_combinational (xilinxFullAdder _).
-Proof. combinational_obvious. Qed.
+Lemma xilinxFullAdder_is_combinational: is_combinational xilinxFullAdder. 
+Proof. simply_combinational. Qed.

--- a/cava/arrow-examples/UnsignedAdder.v
+++ b/cava/arrow-examples/UnsignedAdder.v
@@ -57,15 +57,15 @@ Definition adder445: forall cava: Cava,
     << Vector Bit 4, Vector Bit 4, Unit >> ~[cava]~> (Vector Bit 5) 
   := unsigned_adder 4 4 5.
 
-Lemma adder445_is_combinational: wf_combinational (adder445 _).
-Proof. combinational_obvious. Qed.
+Lemma adder445_is_combinational: is_combinational adder445.
+Proof. simply_combinational. Qed.
 
 Definition adder88810: forall cava: Cava,
     << Vector Bit 8, Vector Bit 8, Vector Bit 8, Unit >> ~[cava]~> (Vector Bit 10) 
   := adder3 8 8 8.
 
-Lemma adder88810_is_combinational: wf_combinational (adder88810 _).
-Proof. combinational_obvious. Qed.
+Lemma adder88810_is_combinational: is_combinational adder88810.
+Proof. simply_combinational. Qed.
 
 Definition adder444_tree_4: forall cava: Cava, 
   << Vector (Vector Bit 4) 4, Unit >> ~[cava]~> (Vector Bit 4) 
@@ -158,8 +158,8 @@ Definition adder444_tree_4_inputs :=
   map (fun '(x, y, z, w) => [N2Bv_sized 4 x; N2Bv_sized 4 y; N2Bv_sized 4 z; N2Bv_sized 4 w]%vector)
   [(0, 0, 0, 1); (1, 1, 1, 1); (1, 3, 5, 2); (15, 1, 1, 1)]%N.
 
-Lemma adder444_tree_4_is_combinational: wf_combinational (adder444_tree_4 _).
-Proof. combinational_obvious. Qed.
+Lemma adder444_tree_4_is_combinational: is_combinational adder444_tree_4.
+Proof. simply_combinational. Qed.
 
 Definition adder444_tree_4_tb_expected_outputs
   := map (fun i => combinational_evaluation adder444_tree_4 adder444_tree_4_is_combinational i) adder444_tree_4_inputs.
@@ -179,8 +179,8 @@ Definition growth_tree_8_inputs :=
   ;[15; 15; 15; 15; 15; 15; 15; 15]%vector %N
   ].
 
-Lemma growth_tree_8_is_combinational: wf_combinational (growth_tree_8 _).
-Proof. combinational_obvious. Qed.
+Lemma growth_tree_8_is_combinational: is_combinational growth_tree_8.
+Proof. simply_combinational. Qed.
 
 Definition growth_tree_8_tb_expected_outputs
   := map (fun i => combinational_evaluation growth_tree_8 growth_tree_8_is_combinational i) growth_tree_8_inputs.

--- a/cava/cava/Cava/Arrow/CavaExpression.v
+++ b/cava/cava/Cava/Arrow/CavaExpression.v
@@ -34,23 +34,17 @@ Section combinational_semantics.
 
   Fixpoint interp_combinational {i o: Kind}
     (expr: kappa (arrow:=Combinational) coq_func i o)
-    : denote_kind i -> option (denote_kind o) :=
+    : denote_kind i -> (denote_kind o) :=
     match expr with
-    | Var x => fun v => Some (x v) 
+    | Var x => fun v => (x v) 
     | Abs f => fun '(x,y) => interp_combinational (f (fun _ => x)) y
     | App f e => fun y => 
-      match (interp_combinational e) tt with
-      | Some x => (interp_combinational f) (x, y)
-      | None => None
-      end
-    | Comp g f => (interp_combinational f) >==> (interp_combinational g)
+      (interp_combinational f) (interp_combinational e tt, y)
+    | Comp g f => fun x => interp_combinational g (interp_combinational f x)
     | Morph m => m
     | Let v f => fun y => 
-      match (interp_combinational v) tt with
-      | Some x => (interp_combinational (f (fun _ => x))) y
-      | None => None
-      end
-    | LetRec v f => fun _ => None
+      interp_combinational (f (fun _ => interp_combinational v tt)) y
+    | LetRec v f => fun _ => kind_default _
     end.
     
     Axiom expression_evaluation_is_arrow_evaluation: forall i o (expr: Kappa i o), forall (x: denote_kind i),

--- a/cava/cava/Cava/Arrow/CombinationalArrow.v
+++ b/cava/cava/Cava/Arrow/CombinationalArrow.v
@@ -27,103 +27,105 @@ Require Import Cava.BitArithmetic.
 (* Evaluation as function evaluation, no delay elements or loops              *)
 (******************************************************************************)
 
-(* TODO: switch to coq ext lib's option monad*)
-Notation "f >==> g" :=
-  (fun x =>
-  match f x with
-  | Some y => g y
-  | _ => None
-  end)(at level 1).
-
 Section instance.
 
 Instance CoqKindMaybeCategory : Category Kind := {
-  morphism X Y := denote_kind X -> option (denote_kind Y);
-  compose _ _ _ f g := g >==> f;
-  id X x := Some x;
+  morphism X Y := denote_kind X -> denote_kind Y;
+  compose _ _ _ f g x := f (g x);
+  id X x := x;
 }.
 
 Instance CoqKindMaybeArrow : Arrow _ CoqKindMaybeCategory Unit Tuple := {
-  first _ _ _ f i := match f (fst i) with | Some x => Some (x, snd i) | _ => None end;
-  second _ _ _ f i := match f (snd i) with | Some y => Some (fst i, y) | _ => None end;
+  first _ _ _ f i := (f (fst i), snd i);
+  second _ _ _ f i := (fst i, f (snd i));
 
-  cancelr X x := Some (fst x);
-  cancell X x := Some (snd x);
+  cancelr X x := (fst x);
+  cancell X x := (snd x);
 
-  uncancell _ x := Some (tt, x);
-  uncancelr _ x := Some (x, tt);
+  uncancell _ x := (tt, x);
+  uncancelr _ x := (x, tt);
 
-  assoc _ _ _ i := Some (fst (fst i), (snd (fst i), snd i));
-  unassoc _ _ _ i := Some ((fst i, fst (snd i)), snd (snd i));
+  assoc _ _ _ i := (fst (fst i), (snd (fst i), snd i));
+  unassoc _ _ _ i := ((fst i, fst (snd i)), snd (snd i));
 }.
 
-Instance CombinationalDrop : ArrowDrop CoqKindMaybeArrow := { drop _ x := Some tt }.
-Instance CombinationalCopy : ArrowCopy CoqKindMaybeArrow := { copy _ x := Some (pair x x) }.
-Instance CombinationalSwap : ArrowSwap CoqKindMaybeArrow := { swap _ _ x := Some (snd x, fst x) }.
-Instance CombinationalLoop : ArrowLoop CoqKindMaybeArrow := { loopl _ _ _ _ _ := None; loopr _ _ _ _ _ := None }.
+Instance CombinationalDrop : ArrowDrop CoqKindMaybeArrow := { drop _ x := tt }.
+Instance CombinationalCopy : ArrowCopy CoqKindMaybeArrow := { copy _ x := (pair x x) }.
+Instance CombinationalSwap : ArrowSwap CoqKindMaybeArrow := { swap _ _ x := (snd x, fst x) }.
+Instance CombinationalLoop : ArrowLoop CoqKindMaybeArrow := 
+  { loopl _ _ _ _ _ := kind_default _; loopr _ _ _ _ _ := kind_default _; }.
 Instance CombinationalSTKC : ArrowSTKC CoqKindMaybeArrow := { }.
+
+Definition vec_head {n o} (v: t o (S n)): o := 
+  match v with
+  | x::_ => x
+  end.
+Definition vec_tail {n o} (v: t o (S n)): t o n := 
+  match v with
+  | _::x => x
+  end.
 
 #[refine] Instance Combinational : Cava := {
   cava_arrow := CoqKindMaybeArrow;
-  constant b _ := Some b;
-  constant_bitvec n v _ := Some (N2Bv_sized n v);
+  constant b _ := b;
+  constant_bitvec n v _ := (N2Bv_sized n v);
 
   mk_module _ _ _name f := f;
 
-  not_gate b := Some (negb (fst b));
-  and_gate '(x, y) := Some (andb x (fst y));
-  nand_gate '(x, y) := Some (negb (andb x (fst y)));
-  or_gate '(x, y) := Some (orb x (fst y));
-  nor_gate '(x, y) := Some (negb (orb x (fst y)));
-  xor_gate '(x, y) := Some (xorb x (fst y));
-  xnor_gate '(x, y) := Some (negb (xorb x (fst y)));
-  buf_gate x := Some (fst x);
-  delay_gate _ _ := None;
+  not_gate b := (negb (fst b));
+  and_gate '(x, y) := (andb x (fst y));
+  nand_gate '(x, y) := (negb (andb x (fst y)));
+  or_gate '(x, y) := (orb x (fst y));
+  nor_gate '(x, y) := (negb (orb x (fst y)));
+  xor_gate '(x, y) := (xorb x (fst y));
+  xnor_gate '(x, y) := (negb (xorb x (fst y)));
+  buf_gate x := (fst x);
+  delay_gate _ _ := kind_default _;
 
-  xorcy '(x, y) := Some (xorb x (fst y));
-  muxcy i := Some (if fst i then fst (fst (snd i)) else snd (fst (snd i)));
+  xorcy '(x, y) := (xorb x (fst y));
+  muxcy i := (if fst i then fst (fst (snd i)) else snd (fst (snd i)));
 
   unsigned_add m n s '(av, (bv, _)) :=
     let a := Ndigits.Bv2N av in
     let b := Ndigits.Bv2N bv in
     let c := (a + b)%N in
-    Some (Ndigits.N2Bv_sized s c);
+    (Ndigits.N2Bv_sized s c);
 
   unsigned_sub s '(av, (bv, _)) :=
     let a := Ndigits.Bv2N av in
     let b := Ndigits.Bv2N bv in
     let c := (a - b)%N in (*todo: This is likely incorrect on underflow *)
-    Some (Ndigits.N2Bv_sized s c);
+    (Ndigits.N2Bv_sized s c);
 
   lut n f '(i,_) :=
     let f' := NaryFunctions.nuncurry bool bool n f in
-    Some (f' (vec_to_nprod _ _ i));
+    (f' (vec_to_nprod _ _ i));
 
-  empty_vec o _ := Some (Vector.nil (denote_kind o));
-  index n o '(array, (index, _)) := 
-    match Arith.Compare_dec.lt_dec (bitvec_to_nat index) n with
-    | left Hlt => Some (nth_order array Hlt)
-    | right Hnlt => None
+  empty_vec o _ := (Vector.nil (denote_kind o));
+  index n o x := 
+    match Arith.Compare_dec.lt_dec (bitvec_to_nat (fst (snd x))) n with
+    | left Hlt => (nth_order (fst x) Hlt)
+    | right Hnlt => kind_default _
     end;
 
-  cons n o '(x, (v,_)) := Some (x :: v);
+  cons n o '(x, (v,_)) := (x :: v);
   snoc n o '(v, (x,_)) := 
-    let v' := Some (v ++ [x]) 
+    let v' := (v ++ [x]) 
     in match Nat.eq_dec (n + 1) (S n)  with 
-      | left Heq => rew [fun x => option (denote_kind (Vector o x))] Heq in v'
+      | left Heq => rew [fun x => (denote_kind (Vector o x))] Heq in v'
       | right Hneq => (ltac:(exfalso;lia))
       end;
-  uncons n o v := Some (hd (fst v), tl (fst v));
+  uncons n o v := (vec_head (fst v), vec_tail (fst v));
   unsnoc n o v :=
     let v' := match Arith.Compare_dec.le_dec n (S n)  with 
       | left Hlt => take n Hlt (fst v)
       | right Hnlt => (ltac:(exfalso; abstract lia))
       end in
-    Some (v', last (fst v));
-  concat n m o '(x, (y, _)) := Some (Vector.append x y);
+    (v', last (fst v));
+  concat n m o '(x, (y, _)) := (Vector.append x y);
 
   split n m o x :=
-    Some (Vector.splitat n (fst x));
+    (Vector.splitat n (fst x));
 
   slice n x y o H1 H2 v := 
     match Nat.eq_dec n (y + (n - y)) with 
@@ -143,147 +145,16 @@ Proof.
     intros.
     rewrite Heq in v.
     apply (splitat (x-y+1)) in v.
-    apply (fst) in v.
-    exact (Some v).
+    exact (fst v).
 Defined.
 
 End instance.
 
 Local Open Scope category_scope.
 
-Definition wf_combinational {x y} (circuit: x ~[Combinational]~> y)
-  := forall i, exists o, circuit i = Some o.
-
-Lemma split_combinational {x y z}
-  (circuit1: x ~[Combinational]~> y)
-  (circuit2: y ~[Combinational]~> z)
-  i
-  : (circuit1 >>> circuit2 ) i
-  = match circuit1 i with 
-  | Some i' => circuit2 i'
-  | None => None
-  end.
-Proof. auto. Qed.
-
-Lemma wf_combinational_split {x y z}
-  (circuit1: x ~[Combinational]~> y)
-  (circuit2: y ~[Combinational]~> z)
-  : wf_combinational circuit1 /\ wf_combinational circuit2
-  -> wf_combinational (circuit1 >>> circuit2).
-Proof.
-  unfold wf_combinational in *; intros.
-  - inversion H.
-    specialize (H0 i).
-    destruct H0.
-    specialize (H1 x0).
-    inversion H1.
-    rewrite split_combinational.
-    rewrite H0.
-    eexists.
-    rewrite H2.
-    auto.
-Qed.
-
-Lemma second_is_combinational {x y z}:
-  forall (circuit1: x ~[Combinational]~> y),
-  wf_combinational circuit1 ->
-  wf_combinational (second (z:=z) circuit1).
-Proof.
-  unfold wf_combinational.
-  intros.
-  cbn.
-  specialize (H (snd i)).
-  destruct (circuit1 (snd i)).
-  eauto.
-  inversion H.
-  inversion H0.
-Qed.
-
-Lemma uncancelr_is_combinational {x}:
-  wf_combinational (uncancelr (Arrow:=@cava_arrow Combinational) (x:=x)).
-Proof.
-  unfold wf_combinational.
-  cbn.
-  eauto.
-Qed.
-
-Lemma insert_rightmost_tt1_is_combinational: forall x,
-  wf_combinational (insert_rightmost_tt1 x).
-Proof.
-  apply (well_founded_ind arg_length_order_wf _).
-  intros.
-  destruct x; [| cbn; unfold wf_combinational; eauto ..].
-  unfold insert_rightmost_tt1.
-  rewrite Fix_eq.
-  destruct x2.
-  * apply (second_is_combinational _).
-    fold (@insert_rightmost_tt1 Combinational (Tuple x2_1 x2_2)).
-    apply (H (Tuple x2_1 x2_2)).
-    unfold arg_length_order; auto.
-  * apply uncancelr_is_combinational.
-  * apply (second_is_combinational _).
-    fold (@insert_rightmost_tt1 Combinational Bit).
-    apply (H Bit).
-    unfold arg_length_order; auto.
-  * apply (second_is_combinational _).
-    fold (@insert_rightmost_tt1 Combinational (Vector x2 n)).
-    apply (H (Vector x2 n)).
-    unfold arg_length_order; auto.
-  * intros.
-    cbn.
-    destruct x; auto.
-    destruct x4; try rewrite (H0 _ _); auto.
-Qed.
-
-Lemma remove_right_unit_is_combinational {x y} (circuit: forall cava: Cava, x ~[cava]~> y)
-  : wf_combinational (circuit Combinational) -> wf_combinational (insert_rightmost_tt1 _ >>> (circuit _)).
-Proof.
-  intros.
-  apply (wf_combinational_split (insert_rightmost_tt1 x) (circuit _)).
-  split.
-  apply insert_rightmost_tt1_is_combinational.
-  apply H.
-Qed.
-
-Lemma unsat_kind_false: forall y, (exists o : denote_kind y, None = Some o) -> False.
-Proof.
-  intros.
-  induction y; inversion H; inversion H0.
-Qed.
-
 Definition combinational_evaluation {x y: Kind}
   (circuit: forall cava: Cava, x ~> y)
-  (wf: wf_combinational (circuit Combinational)) 
+  (ok: is_combinational circuit)
   (i: denote_kind (remove_rightmost_unit x))
-  : denote_kind y.
-Proof.
-  apply remove_right_unit_is_combinational in wf.
-  pose ((insert_rightmost_tt1 _ >>> circuit Combinational) i) as c'.
-  specialize (wf i).
-  set (v := (insert_rightmost_tt1 x >>> circuit Combinational) i) in *.
-  destruct v.
-  exact d.
-
-  apply unsat_kind_false in wf.
-  inversion wf.
-Defined.
-
-Lemma not_gate_wf: wf_combinational (not_gate).
-Proof.
-  cbv [wf_combinational not_gate Combinational].
-  eauto.
-Defined.
-
-Ltac combinational_obvious :=
-  cbv [wf_combinational];
-  compute;
-  eauto.
-
-Example not_true: @not_gate Combinational (true, tt) = Some false.
-Proof. reflexivity. Qed.
-
-Example not_true_with_wf: combinational_evaluation (@not_gate) not_gate_wf true = false.
-Proof. compute. reflexivity. Qed.
-
-Example not_false: @not_gate Combinational (false, tt) = Some true.
-Proof. reflexivity. Qed.
+  : denote_kind y :=
+  (insert_rightmost_tt1 x >>> circuit Combinational) i.


### PR DESCRIPTION
This is a cleanup of an avenue I was testing for faster execution. Uses default values instead of working within an option monad. I don't think it actually is faster but the representations should be equivalent and this one is simpler. 