### PR TITLE
Port of OpenTitan to the Xilinx XCV104 FPGA board

### DIFF
--- a/fpga/zcu104/opentitan/Makefile
+++ b/fpga/zcu104/opentitan/Makefile
@@ -1,0 +1,25 @@
+#
+# Copyright 2019 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ZCU104=../../../../zcu104
+
+install:
+		cp pins_zcu104.xdc $(ZCU104)/opentitan/hw/top_earlgrey/data/
+		cp clkgen_zcu104.sv $(ZCU104)/opentitan/hw/top_earlgrey/rtl/
+		cp top_earlgrey_zcu104.sv $(ZCU104)/opentitan/hw/top_earlgrey/rtl/
+		cp top_earlgrey_zcu104.core $(ZCU104)/opentitan/hw/top_earlgrey
+		cp vivado_hook_opt_design_post.tcl $(ZCU104)/opentitan/hw/top_earlgrey/util/
+		cp vivado_hook_write_bitstream_pre.tcl $(ZCU104)/opentitan/hw/top_earlgrey/util/

--- a/fpga/zcu104/opentitan/clkgen_zcu104.sv
+++ b/fpga/zcu104/opentitan/clkgen_zcu104.sv
@@ -1,0 +1,92 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module clkgen_zcu104 (
+  input IO_CLK,
+  input IO_RST_N,
+  output clk_sys,
+  output clk_48MHz,
+  output rst_sys_n
+);
+  logic locked_pll;
+  logic io_clk_buf;
+  logic clk_50_buf;
+  logic clk_50_unbuf;
+  logic clk_fb_buf;
+  logic clk_fb_unbuf;
+  logic clk_48_buf;
+  logic clk_48_unbuf;
+
+  // input buffer
+  IBUF io_clk_ibuf (
+    .I (IO_CLK),
+    .O (io_clk_buf)
+  );
+
+  PLLE2_ADV #(
+    .BANDWIDTH            ("OPTIMIZED"),
+    .COMPENSATION         ("ZHOLD"),
+    .STARTUP_WAIT         ("FALSE"),
+    .DIVCLK_DIVIDE        (1),
+    .CLKFBOUT_MULT        (10),
+    .CLKFBOUT_PHASE       (0.000),
+    .CLKOUT0_DIVIDE       (25),
+    .CLKOUT0_PHASE        (0.000),
+    .CLKOUT0_DUTY_CYCLE   (0.500),
+    .CLKOUT1_DIVIDE       (25),
+    .CLKOUT1_PHASE        (0.000),
+    .CLKOUT1_DUTY_CYCLE   (0.500),
+    .CLKIN1_PERIOD        (8.000)
+  ) pll (
+    .CLKFBOUT            (clk_fb_unbuf),
+    .CLKOUT0             (clk_50_unbuf),
+    .CLKOUT1             (clk_48_unbuf),
+    .CLKOUT2             (),
+    .CLKOUT3             (),
+    .CLKOUT4             (),
+    .CLKOUT5             (),
+     // Input clock control
+    .CLKFBIN             (clk_fb_buf),
+    .CLKIN1              (io_clk_buf),
+    .CLKIN2              (1'b0),
+     // Tied to always select the primary input clock
+    .CLKINSEL            (1'b1),
+    // Ports for dynamic reconfiguration
+    .DADDR               (7'h0),
+    .DCLK                (1'b0),
+    .DEN                 (1'b0),
+    .DI                  (16'h0),
+    .DO                  (),
+    .DRDY                (),
+    .DWE                 (1'b0),
+    // Other control and status signals
+    .LOCKED              (locked_pll),
+    .PWRDWN              (1'b0),
+    // Do not reset PLL on external reset, otherwise ILA disconnects at a reset
+    .RST                 (1'b0));
+
+  // output buffering
+  BUFG clk_fb_bufg (
+    .I (clk_fb_unbuf),
+    .O (clk_fb_buf)
+  );
+
+  BUFG clk_50_bufg (
+    .I (clk_50_unbuf),
+    .O (clk_50_buf)
+  );
+
+  BUFG clk_48_bufg (
+    .I (clk_48_unbuf),
+    .O (clk_48_buf)
+  );
+
+  // outputs
+  // clock
+  assign clk_sys = clk_50_buf; // TODO: choose 50 MHz clock as sysclock for now
+  assign clk_48MHz = clk_48_buf;
+
+  // reset
+  assign rst_sys_n = locked_pll & IO_RST_N;
+endmodule

--- a/fpga/zcu104/opentitan/pins_zcu104.xdc
+++ b/fpga/zcu104/opentitan/pins_zcu104.xdc
@@ -1,0 +1,23 @@
+## Clock Signal using differential 125MHz input
+create_clock -period 8.000 -name CLK_125_P -waveform {0.000 4.000} -add [get_ports CLK_125_P]
+set_property PACKAGE_PIN F23 [get_ports CLK_125_P]
+set_property IOSTANDARD LVDS [get_ports CLK_125_P]
+
+create_generated_clock -name clk_50_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT0]
+create_generated_clock -name clk_48_unbuf -source [get_pin clkgen/pll/CLKIN1] [get_pin clkgen/pll/CLKOUT1]
+set_clock_groups -group clk_50_unbuf -group clk_48_unbuf -asynchronous
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+
+
+# Reset with SW18
+set_property -dict { PACKAGE_PIN C3 IOSTANDARD LVCMOS33 } [get_ports { IO_RST }];
+
+## UART
+set_property -dict { PACKAGE_PIN A20 IOSTANDARD LVCMOS18 } [get_ports { IO_URX }];
+set_property -dict { PACKAGE_PIN C19 IOSTANDARD LVCMOS18 } [get_ports { IO_UTX }];
+
+set_property SEVERITY {Warning} [get_drc_checks UCIO-1]
+set_property SEVERITY {Warning} [get_drc_checks NSTD-1]
+
+

--- a/fpga/zcu104/opentitan/top_earlgrey_zcu104.core
+++ b/fpga/zcu104/opentitan/top_earlgrey_zcu104.core
@@ -1,0 +1,62 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:systems:top_earlgrey_zcu104:0.1"
+description: "Earl Grey toplevel for the Xilinx ZCU104 FPGA Reference Board"
+filesets:
+  files_rtl_zcu104:
+    depend:
+      - lowrisc:systems:top_earlgrey:0.1
+    files:
+      - rtl/clkgen_zcu104.sv
+      - rtl/top_earlgrey_zcu104.sv
+    file_type: systemVerilogSource
+
+  files_constraints:
+    files:
+      - data/pins_zcu104.xdc
+      - data/placement.xdc
+    file_type: xdc
+
+  files_tcl:
+    files:
+      - util/vivado_setup_hooks.tcl: { file_type: tclSource }
+      # File copied by fusesoc into the workroot (the file containing the
+      # .eda.yml file), and referenced from vivado_setup_hooks.tcl
+      - util/vivado_hook_write_bitstream_pre.tcl: { file_type: user, copyto: vivado_hook_write_bitstream_pre.tcl }
+      - util/vivado_hook_opt_design_post.tcl: { file_type: user, copyto: vivado_hook_opt_design_post.tcl }
+
+parameters:
+  # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
+  # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
+  # --SRAM_INIT_FILE=$PWD/sw/device/examples/hello_world/hello_world.vmem
+  # XXX: The VMEM file should be added to the sources of the Vivado project to
+  # make the Vivado dependency tracking work. However this requires changes to
+  # fusesoc first.
+  ROM_INIT_FILE:
+    datatype: str
+    description: SRAM initialization file in vmem hex format
+    default: "/home/satnam/zcu104/opentitan/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.32.vmem"
+    paramtype: vlogdefine
+  # For value definition, please see ip/prim/rtl/prim_pkg.sv
+  PRIM_DEFAULT_IMPL:
+    datatype: str
+    paramtype: vlogdefine
+    description: Primitives implementation to use, e.g. "prim_pkg::ImplGeneric".
+
+targets:
+  synth:
+    default_tool: vivado
+    filesets:
+      - files_rtl_zcu104
+      - files_constraints
+      - files_tcl
+    toplevel: top_earlgrey_zcu104
+    parameters:
+      - ROM_INIT_FILE
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+    tools:
+      vivado:
+        part: "xczu7ev-ffvc1156-2-e" # ZCU104
+

--- a/fpga/zcu104/opentitan/top_earlgrey_zcu104.sv
+++ b/fpga/zcu104/opentitan/top_earlgrey_zcu104.sv
@@ -1,0 +1,205 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module top_earlgrey_zcu104 (
+  // Clock and Reset
+  input               CLK_125_P,
+  input               CLK_125_N,
+  input               IO_RST,
+
+  // JTAG interface
+  input               IO_DPS0, // IO_JTCK,    IO_SDCK
+  input               IO_DPS3, // IO_JTMS,    IO_SDCSB
+  input               IO_DPS1, // IO_JTDI,    IO_SDMOSI
+  input               IO_DPS4, // IO_JTRST_N,
+  input               IO_DPS5, // IO_JSRST_N,
+  output              IO_DPS2, // IO_JTDO,    IO_MISO
+  input               IO_DPS6, // JTAG=0,     SPI=1
+  input               IO_DPS7, // BOOTSTRAP=1
+  // UART interface
+  input               IO_URX,
+  output              IO_UTX,
+  // USB interface
+  inout               IO_USB_DP0,
+  inout               IO_USB_DN0,
+  input               IO_USB_SENSE0,
+  output              IO_USB_PULLUP0,
+  // GPIO x 16 interface
+  inout               IO_GP0,
+  inout               IO_GP1,
+  inout               IO_GP2,
+  inout               IO_GP3,
+  inout               IO_GP4,
+  inout               IO_GP5,
+  inout               IO_GP6,
+  inout               IO_GP7,
+  inout               IO_GP8,
+  inout               IO_GP9,
+  inout               IO_GP10,
+  inout               IO_GP11,
+  inout               IO_GP12,
+  inout               IO_GP13,
+  inout               IO_GP14,
+  inout               IO_GP15
+);
+
+  logic clk_sys, clk_48mhz, rst_sys_n;
+  logic [31:0] cio_gpio_p2d, cio_gpio_d2p, cio_gpio_en_d2p;
+  logic cio_uart_rx_p2d, cio_uart_tx_d2p, cio_uart_tx_en_d2p;
+  logic cio_spi_device_sck_p2d, cio_spi_device_csb_p2d, cio_spi_device_mosi_p2d,
+        cio_spi_device_miso_d2p, cio_spi_device_miso_en_d2p;
+  logic cio_jtag_tck_p2d, cio_jtag_tms_p2d, cio_jtag_tdi_p2d, cio_jtag_tdo_d2p;
+  logic cio_jtag_trst_n_p2d, cio_jtag_srst_n_p2d;
+  logic cio_usbdev_sense_p2d;
+  logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
+  logic cio_usbdev_pullup_d2p, cio_usbdev_pullup_en_d2p;
+  logic cio_usbdev_tx_mode_se_d2p, cio_usbdev_tx_mode_se_en_d2p;
+  logic cio_usbdev_supsend_d2p, cio_usbdev_supsend_en_d2p;
+  logic cio_usbdev_d_p2d, cio_usbdev_d_d2p, cio_usbdev_d_en_d2p;
+  logic cio_usbdev_dp_p2d, cio_usbdev_dp_d2p, cio_usbdev_dp_en_d2p;
+  logic cio_usbdev_dn_p2d, cio_usbdev_dn_d2p, cio_usbdev_dn_en_d2p;
+
+  // Top-level design
+  top_earlgrey #(
+    .IbexPipeLine(1)
+  ) top_earlgrey (
+    .clk_i                      (clk_sys),
+    .rst_ni                     (rst_sys_n),
+    .clk_fixed_i                (clk_sys),
+    .clk_usb_48mhz_i            (clk_48mhz),
+
+    .jtag_tck_i                 (cio_jtag_tck_p2d),
+    .jtag_tms_i                 (cio_jtag_tms_p2d),
+    .jtag_trst_ni               (cio_jtag_trst_n_p2d),
+    .jtag_td_i                  (cio_jtag_tdi_p2d),
+    .jtag_td_o                  (cio_jtag_tdo_d2p),
+
+    .mio_in_i                   (cio_gpio_p2d),
+    .mio_out_o                  (cio_gpio_d2p),
+    .mio_oe_o                   (cio_gpio_en_d2p),
+
+    .dio_uart_rx_i              (cio_uart_rx_p2d),
+    .dio_uart_tx_o              (cio_uart_tx_d2p),
+    .dio_uart_tx_en_o           (cio_uart_tx_en_d2p),
+
+    .dio_spi_device_sck_i       (cio_spi_device_sck_p2d),
+    .dio_spi_device_csb_i       (cio_spi_device_csb_p2d),
+    .dio_spi_device_mosi_i      (cio_spi_device_mosi_p2d),
+    .dio_spi_device_miso_o      (cio_spi_device_miso_d2p),
+    .dio_spi_device_miso_en_o   (cio_spi_device_miso_en_d2p),
+
+    .dio_usbdev_sense_i         (cio_usbdev_sense_p2d),
+    .dio_usbdev_se0_o           (cio_usbdev_se0_d2p),
+    .dio_usbdev_se0_en_o        (cio_usbdev_se0_en_d2p),
+    .dio_usbdev_pullup_o        (cio_usbdev_pullup_d2p),
+    .dio_usbdev_pullup_en_o     (cio_usbdev_pullup_en_d2p),
+    .dio_usbdev_tx_mode_se_o    (cio_usbdev_tx_mode_se_d2p),
+    .dio_usbdev_tx_mode_se_en_o (cio_usbdev_tx_mode_se_en_d2p),
+    .dio_usbdev_suspend_o       (cio_usbdev_suspend_d2p),
+    .dio_usbdev_suspend_en_o    (cio_usbdev_suspend_en_d2p),
+    .dio_usbdev_d_i             (cio_usbdev_d_p2d),
+    .dio_usbdev_d_o             (cio_usbdev_d_d2p),
+    .dio_usbdev_d_en_o          (cio_usbdev_d_en_d2p),
+    .dio_usbdev_dp_i            (cio_usbdev_dp_p2d),
+    .dio_usbdev_dp_o            (cio_usbdev_dp_d2p),
+    .dio_usbdev_dp_en_o         (cio_usbdev_dp_en_d2p),
+    .dio_usbdev_dn_i            (cio_usbdev_dn_p2d),
+    .dio_usbdev_dn_o            (cio_usbdev_dn_d2p),
+    .dio_usbdev_dn_en_o         (cio_usbdev_dn_en_d2p),
+
+    .scanmode_i                 (1'b0) // 1 for Scan
+  );
+
+  logic IO_CLK;
+  logic IO_RST_N;
+  assign IO_RST_N = !IO_RST; 
+
+  IBUFDS diffClkIn (.O(IO_CLK),
+                    .I(CLK_125_P),
+                    .IB(CLK_125_N)
+                   );
+
+
+  clkgen_zcu104 clkgen (
+    .IO_CLK(IO_CLK),
+    .IO_RST_N(IO_RST_N),
+    .clk_sys(clk_sys),
+    .rst_sys_n(rst_sys_n)
+  );
+
+  // pad control
+  padctl padctl (
+    // UART
+    .cio_uart_rx_p2d,
+    .cio_uart_tx_d2p,
+    .cio_uart_tx_en_d2p,
+    // USB
+    .cio_usbdev_sense_p2d(cio_usbdev_sense_p2d),
+    .cio_usbdev_se0_d2p(cio_usbdev_se0_d2p),
+    .cio_usbdev_se0_en_d2p(cio_usbdev_se0_en_d2p),
+    .cio_usbdev_pullup_d2p(cio_usbdev_pullup_d2p),
+    .cio_usbdev_pullup_en_d2p(cio_usbdev_pullup_en_d2p),
+    .cio_usbdev_tx_mode_se_d2p(cio_usbdev_tx_mode_se_d2p),
+    .cio_usbdev_tx_mode_se_en_d2p(cio_usbdev_tx_mode_se_en_d2p),
+    .cio_usbdev_suspend_d2p(cio_usbdev_suspend_d2p),
+    .cio_usbdev_suspend_en_d2p(cio_usbdev_suspend_en_d2p),
+    .cio_usbdev_d_p2d(cio_usbdev_d_p2d),
+    .cio_usbdev_d_d2p(cio_usbdev_d_d2p),
+    .cio_usbdev_d_en_d2p(cio_usbdev_d_en_d2p),
+    .cio_usbdev_dp_p2d(cio_usbdev_dp_p2d),
+    .cio_usbdev_dp_d2p(cio_usbdev_dp_d2p),
+    .cio_usbdev_dp_en_d2p(cio_usbdev_dp_en_d2p),
+    .cio_usbdev_dn_p2d(cio_usbdev_dn_p2d),
+    .cio_usbdev_dn_d2p(cio_usbdev_dn_d2p),
+    .cio_usbdev_dn_en_d2p(cio_usbdev_dn_en_d2p),
+    // GPIO
+    .cio_gpio_p2d,
+    .cio_gpio_d2p,
+    .cio_gpio_en_d2p,
+    // pads
+    .IO_URX,
+    .IO_UTX,
+    .IO_USB_DP0,
+    .IO_USB_DN0,
+    .IO_USB_SENSE0,
+    .IO_USB_PULLUP0,
+    .IO_GP0,
+    .IO_GP1,
+    .IO_GP2,
+    .IO_GP3,
+    .IO_GP4,
+    .IO_GP5,
+    .IO_GP6,
+    .IO_GP7,
+    .IO_GP8,
+    .IO_GP9,
+    .IO_GP10,
+    .IO_GP11,
+    .IO_GP12,
+    .IO_GP13,
+    .IO_GP14,
+    .IO_GP15,
+
+    .cio_spi_device_sck_p2d,
+    .cio_spi_device_csb_p2d,
+    .cio_spi_device_mosi_p2d,
+    .cio_spi_device_miso_d2p,
+    .cio_spi_device_miso_en_d2p,
+    .cio_jtag_tck_p2d,
+    .cio_jtag_tms_p2d,
+    .cio_jtag_trst_n_p2d,
+    .cio_jtag_srst_n_p2d,
+    .cio_jtag_tdi_p2d,
+    .cio_jtag_tdo_d2p,
+    .IO_DPS0,
+    .IO_DPS1,
+    .IO_DPS2,
+    .IO_DPS3,
+    .IO_DPS4,
+    .IO_DPS5,
+    .IO_DPS6,
+    .IO_DPS7
+  );
+
+endmodule

--- a/fpga/zcu104/opentitan/vivado_hook_opt_design_post.tcl
+++ b/fpga/zcu104/opentitan/vivado_hook_opt_design_post.tcl
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Any change in ROM instances path should be updated in following two files
+# 1. hw/top_earlgrey/data/placement.xdc and
+# 2. hw/top_earlgrey/util/vivado_hook_opt_design_post.tcl
+
+send_msg "Designcheck 2-1" INFO "Checking if ROM memory is mapped to BRAM memory."
+
+if {[catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_0" && PRIMITIVE_TYPE =~ BMEM.*.* }]]\
+&& [catch [get_cells -hierarchical -filter { NAME =~  "*rom_rom*dout_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]] } {
+  send_msg "Designcheck 2-2" INFO "BRAM implementation found for ROM memory."
+} else {
+  send_msg "Designcheck 2-3" INFO "BRAM implementation not found for ROM memory."
+}

--- a/fpga/zcu104/opentitan/vivado_hook_write_bitstream_pre.tcl
+++ b/fpga/zcu104/opentitan/vivado_hook_write_bitstream_pre.tcl
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Bypass this for now for the ZCU104 board.
+#
+# set workroot [file dirname [info script]]
+
+# send_msg "Designcheck 1-1" INFO "Checking design"
+
+# Ensure the design meets timing
+# set slack_ns [get_property SLACK [get_timing_paths -delay_type min_max]]
+# send_msg "Designcheck 1-2" INFO "Slack is ${slack_ns} ns."
+
+# if [expr {$slack_ns < 0}] {
+#  send_msg "Designcheck 1-3" INFO "Timing failed. Slack is ${slack_ns} ns."
+# }
+


### PR DESCRIPTION
The Makefile overwrites the currently checked out OpenTitan design is target the Xilinx ZCU104 FPGA board.
```console
$ make
```
copies the files over. The design is build with:
```console
$ fusesoc --cores-root . run --target=synth lowrisc:systems:top_earlgrey_zcu104
```
and programmed with
```console
$ fusesoc --cores-root . pgm lowrisc:systems:top_earlgrey_zcu104:0.1
```
Which should display a message like this on the UART:

[opentitan-oldpinxver-zcu104](https://user-images.githubusercontent.com/6164339/90307692-87e66600-de8d-11ea-8211-49386d45bd45.png)

Current work at commit 783edaf444eb0d9eaf9df71c785089bffcda574e (but not later commits yet).