### PR TITLE
Add OpenTitan at commit 783edaf444eb0d9eaf9df71c785089bffcda574e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/coq-ext-lib"]
 	path = third_party/coq-ext-lib
 	url = https://github.com/coq-community/coq-ext-lib
+[submodule "third_party/opentitan"]
+	path = third_party/opentitan
+	url = https://github.com/lowRISC/opentitan/


### PR DESCRIPTION
Adds OpenTitan to `third_party/opentitan` as a submodule, the opentitan directory is currently not used in any build scripts.