### PR TITLE
Update converted OpenTitan AES

### DIFF
--- a/cava/arrow-examples/.gitignore
+++ b/cava/arrow-examples/.gitignore
@@ -16,6 +16,7 @@ Makefile.coq
 # Haskell files except the manually created ones
 *.hs
 !ArrowExamplesSV.hs
+!Main.hs
 
 # Binaries
 ArrowExamplesSV

--- a/cava/arrow-examples/Aes/pkg.v
+++ b/cava/arrow-examples/Aes/pkg.v
@@ -42,8 +42,8 @@ Notation "x == y" :=
   (App (App (Morph (equality _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 
-Inductive SboxImpl := 
-| SboxLut
+Inductive SboxImpl :=
+(* | SboxLut *)
 | SboxCanright
 (* | SboxCanrightMasked *)
 | SboxCanrightMaskedNoReuse.
@@ -72,7 +72,7 @@ function automatic logic [7:0] aes_mul2(logic [7:0] in);
 endfunction *)
 Definition aes_mul2: forall cava: Cava,
   <<Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
-  <[\ x => x[#7] 
+  <[\ x => x[#7]
         :: (xor x[#0] x[#7])
         :: x[#1]
         :: (xor x[#2] x[#7])
@@ -109,7 +109,7 @@ endfunction *)
 Definition aes_div2: forall cava: Cava,
   <<Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
   <[\ x => (xor x[#1] x[#0])
-        :: x[#2] 
+        :: x[#2]
         :: (xor x[#3] x[#0])
         :: (xor x[#4] x[#0])
         :: x[#5]
@@ -130,7 +130,7 @@ endfunction *)
 Definition aes_circ_byte_shift: forall cava: Cava,
   <<Vector (Vector Bit 8) 4, Vector Bit 2, Unit>> ~> (Vector (Vector Bit 8) 4) :=
   <[\input shift =>
-      !(map3 <[\input shift seq => 
+      !(map3 <[\input shift seq =>
         let offset = seq - shift in
         input[offset]
       ]>
@@ -148,13 +148,13 @@ Definition aes_circ_byte_shift: forall cava: Cava,
   return transpose;
 endfunction *)
 Fixpoint aes_transpose {n m}
-  : forall cava: Cava, 
-    <<Vector (Vector (Vector Bit 8) m) n, Unit>> ~> 
-      Vector (Vector (Vector Bit 8) n) m := 
+  : forall cava: Cava,
+    <<Vector (Vector (Vector Bit 8) m) n, Unit>> ~>
+      Vector (Vector (Vector Bit 8) n) m :=
 match n with
 | O => <[\_ => !replicate ([]) ]>
 | S n' =>
-  <[\mat => 
+  <[\mat =>
     let '(mat', vec) = unsnoc mat in
     !(map2 <[\vec x => snoc vec x ]>) (!aes_transpose mat') vec
     ]>

--- a/cava/arrow-examples/Aes/unrolled_cipher.v
+++ b/cava/arrow-examples/Aes/unrolled_cipher.v
@@ -26,33 +26,33 @@ Open Scope kind_scope.
 
 Definition cipher_round
   (sbox_impl: SboxImpl)
-  : forall cava: Cava, 
+  : forall cava: Cava,
     << Bit                               (* cipher mode: CIPH_FWD/CIPH_INV *)
     , Vector (Vector (Vector Bit 8) 4) 4 (* data input *)
     , Vector (Vector (Vector Bit 8) 4) 4 (* round key *)
-    , Unit>> ~> 
+    , Unit>> ~>
       Vector (Vector (Vector Bit 8) 4) 4 :=
   <[\op_i data_i stage_key =>
     let stage1 = !(aes_sub_bytes sbox_impl) op_i data_i in
     let stage2 = !aes_shift_rows op_i stage1 in
     let stage3 = !aes_mix_columns op_i stage2 in
-    !(map2 <[ !(map2 <[\x y => x ^ y]>) ]> ) stage3 stage_key 
+    !(map2 <[ !(map2 <[\x y => x ^ y]>) ]> ) stage3 stage_key
     ]>.
 
 (* Note: aes_key_expand in OpenTitan is stateful, this version is not *)
 Program Definition aes_key_expand
   (sbox_impl: SboxImpl)
-  : forall cava: Cava, 
+  : forall cava: Cava,
     << Bit (* op_i *)
     , Vector Bit 3 (* round id *)
     , Vector Bit 8 (* rcon input *)
     , Vector (Vector (Vector Bit 8) 4) 8 (* input key *)
     , Unit
-    >> ~> 
+    >> ~>
       << Vector Bit 8, Vector (Vector (Vector Bit 8) 4) 8>> :=
   let sbox := curry (aes_sbox sbox_impl) in
   let mapped_sbox := <[ !(map sbox) ]> in
-  <[\op_i round_id rcon key_i => 
+  <[\op_i round_id rcon key_i =>
     (* if (key_len_i == AES_256 && rnd[0] == 1'b0) begin
     use_rcon = 1'b0;
     end *)
@@ -60,13 +60,13 @@ Program Definition aes_key_expand
 
     (* rcon_d = (op_i == CIPH_FWD) ? aes_mul2(rcon_q) :
                 (op_i == CIPH_INV) ? aes_div2(rcon_q) : 8'h01; *)
-    let rcon = 
+    let rcon =
       if round_id == #0
-      then 
+      then
         if op_i == !CIPH_FWD
         then #1
         else #64
-      else 
+      else
         if op_i == !CIPH_FWD
         then !aes_mul2 rcon
         else !aes_div2 rcon in
@@ -76,7 +76,7 @@ Program Definition aes_key_expand
         CIPH_FWD: rot_word_in = key_i[7];
         CIPH_INV: rot_word_in = key_i[3];
         default:  rot_word_in = key_i[7]; *)
-    let rot_word_in = 
+    let rot_word_in =
       if op_i == !CIPH_FWD
       then key_i[#7]
       else key_i[#3] in
@@ -85,7 +85,7 @@ Program Definition aes_key_expand
     let rot_word_out = !aes_circ_byte_shift rot_word_in #3 in
 
     (* assign sub_word_in = use_rot_word ? rot_word_out : rot_word_in; *)
-    let sub_word_in = 
+    let sub_word_in =
       if use_rcon (* for AES_256 use_rcon == use_rot_word *)
       then rot_word_out
       else rot_word_in in
@@ -126,10 +126,10 @@ Program Definition aes_key_expand
       end *)
     let regular =
       if round_id == #0
-      then concat key_i[:7:4] key_i[:3:0] 
-      else 
+      then concat key_i[:7:4] key_i[:3:0]
+      else
         if op_i == !CIPH_FWD
-        then 
+        then
           (* todo: this is a "scan" op *)
           let regular_4 = (!reshape irregular) ^ key_i[#0] in
           let regular_5 = regular_4 ^ key_i[#1] in
@@ -152,7 +152,7 @@ Program Definition aes_key_expand
               end
             end // rnd == 0
           end *)
-        else 
+        else
           let regular_0 = (!reshape irregular) ^ key_i[#4] in
           let regular_1 = key_i[#4] ^ key_i[#5] in
           let regular_2 = key_i[#5] ^ key_i[#6] in
@@ -162,39 +162,105 @@ Program Definition aes_key_expand
     (rcon, regular)
     ]>.
 Next Obligation. lia. Defined.
-Next Obligation. lia. Defined. 
+Next Obligation. lia. Defined.
 Next Obligation. lia. Defined.
 Next Obligation. lia. Defined.
 Next Obligation. lia. Defined.
 
-(* stateless *)
-Program Definition unrolled_foward_cipher
+Program Definition key_expand_and_round
   (sbox_impl: SboxImpl)
-  : forall cava: Cava, 
+  : forall cava: Cava,
+    <<
+      <<
+        Vector Bit 8 (* rcon *)
+      , Vector (Vector (Vector Bit 8) 4) 4 (* data *)
+      , Vector (Vector (Vector Bit 8) 4) 8 (* key *)
+      (* , Unit *)
+      >>,
+      Vector Bit 3, (* round *)
+      Unit
+    >> ~>
     <<
       Vector Bit 8 (* rcon *)
     , Vector (Vector (Vector Bit 8) 4) 4 (* data *)
     , Vector (Vector (Vector Bit 8) 4) 8 (* key *)
-    , Unit
-    >> ~> 
-    << 
-      Vector Bit 8 (* rcon *)
-    , Vector (Vector (Vector Bit 8) 4) 4 (* data *)
-    , Vector (Vector (Vector Bit 8) 4) 8 (* key state *)
-    >>
-      :=
-  let cipher_round := cipher_round sbox_impl in  
-  let aes_key_expand := aes_key_expand sbox_impl in  
-  <[\rcon data_i key => 
-    let round = #0 in
-    let rcon = #1 in
+    (* , Unit *)
+    >> :=
+  <[\state round =>
+    let '(rcon, state') = state in
+    let '(data_i, key) = state' in
 
     let key_words_0 = key[:3:0] in
     let key_bytes_0 = !aes_transpose key_words_0 in
     let round_key = key_bytes_0 in
 
-    let '(rcon, new_key) = !aes_key_expand !CIPH_FWD round rcon key in
+    let '(rcon', new_key) = !(aes_key_expand sbox_impl) !CIPH_FWD round rcon key in
+    let data_o = !(cipher_round sbox_impl) !CIPH_FWD data_i round_key in
+    (rcon', data_o, new_key)
+  ]>.
+Next Obligation. lia. Qed.
 
-    (rcon, !cipher_round !CIPH_FWD data_i round_key, new_key)
+(* stateless *)
+Program Definition unrolled_forward_cipher
+  (sbox_impl: SboxImpl)
+  : forall cava: Cava,
+    <<
+      (* Vector Bit 8 *)
+      Vector (Vector (Vector Bit 8) 4) 4 (* data *)
+    , Vector (Vector (Vector Bit 8) 4) 8 (* key *)
+    , Unit
+    >> ~>
+    <<
+      (* Vector Bit 8 rcon *)
+      Vector (Vector (Vector Bit 8) 4) 4 (* data *)
+    (* , Vector (Vector (Vector Bit 8) 4) 8 *)
+    >>
+      :=
+  let cipher_round := cipher_round sbox_impl in
+  let aes_key_expand := aes_key_expand sbox_impl in
+  <[\data_i key =>
+    let rcon = #1 in
+
+    let '(rcon, end_state) = !(foldl (n:=13) (key_expand_and_round sbox_impl)) (rcon, data_i, key) !(seq (n:=13) 0) in
+    let '(data_i, key) = end_state in
+
+
+    (* final round has no mix_columns *)
+    let '(_, key) = !aes_key_expand !CIPH_FWD #13 rcon key in
+
+    let key_words_0 = key[:3:0] in
+    let key_bytes_0 = !aes_transpose key_words_0 in
+    let round_key = key_bytes_0 in
+
+    let stage1 = !(aes_sub_bytes sbox_impl) !CIPH_FWD data_i in
+    let stage2 = !aes_shift_rows !CIPH_FWD stage1 in
+    !(map2 <[ !(map2 <[\x y => x ^ y]>) ]> ) stage2 round_key
     ]>.
-Next Obligation. lia. Defined.
+Next Obligation. lia. Qed.
+
+Definition unrolled_forward_cipher_flat
+  : forall cava: Cava,
+    <<
+      Vector Bit 128 (* data *)
+    , Vector Bit 256 (* key *)
+    , Unit
+    >> ~>
+    <<
+      Vector Bit 128 (* data *)
+    (* , Vector Bit 256 *)
+    >>
+      :=
+  <[\data key =>
+    let data_o = !(unrolled_forward_cipher SboxCanright) (!reshape (!reshape data)) (!reshape (!reshape key)) in
+    !flatten (!flatten data_o)
+    ]>.
+
+Definition test_key := N2Bv_sized 256 0.
+
+(* 0x80000000000000000000000000000000 *)
+Definition test_data := N2Bv_sized 128 170141183460469231731687303715884105728.
+
+(* 0xddc6bf790c15760d8d9aeb6f9a75fd4e *)
+Definition test_encrypted := N2Bv_sized 128 294791345377038030526550647723007540558.
+
+Definition eval_unrolled : nat := bitvec_to_nat (unrolled_forward_cipher_flat Combinational (test_data, (test_key, tt))).

--- a/cava/arrow-examples/ArrowExtraction.v
+++ b/cava/arrow-examples/ArrowExtraction.v
@@ -20,6 +20,8 @@ From Coq Require Import extraction.ExtrHaskellString.
 From Coq Require Import ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
+Set Extraction Optimize.
+
 Extraction Language Haskell.
 
 Require Import Combinators.
@@ -39,11 +41,28 @@ Extraction Library ArrowAdderTutorial.
 From Cava Require Import Arrow.ArrowExport.
 (* From Cava Require Import Cava.pkg. *)
 Extraction Library CavaNotation.
-Require Import Aes.pkg.
-Extraction Library pkg.
-Require Import Aes.sbox.
+
+Require Import
+  Aes.sbox
+  Aes.mix_single_column
+  Aes.sub_bytes
+  Aes.shift_rows
+  Aes.mix_columns
+  Aes.sbox_canright_masked_noreuse
+  (* Aes.sbox_lut *)
+  Aes.sbox_canright
+  Aes.pkg
+  Aes.unrolled_cipher
+  Aes.sbox_canright_pkg.
+
 Extraction Library sbox.
-Require Import Aes.sbox_canright_pkg.
-Extraction Library sbox_canright_pkg.
-Require Import Aes.sbox_canright.
+Extraction Library mix_single_column.
+Extraction Library sub_bytes.
+Extraction Library shift_rows.
+Extraction Library mix_columns.
+Extraction Library sbox_canright_masked_noreuse.
+(* Extraction Library sbox_lut. *)
 Extraction Library sbox_canright.
+Extraction Library pkg.
+Extraction Library unrolled_cipher.
+Extraction Library sbox_canright_pkg.

--- a/cava/arrow-examples/Combinators.v
+++ b/cava/arrow-examples/Combinators.v
@@ -162,30 +162,30 @@ Definition dt_tree_fold
 
 Fixpoint foldl {n A B}
   (f: forall cava: Cava, <<B, A, Unit>> ~> B)
-  (initial: forall cava: Cava, <<Unit>> ~> B)
+  (* (initial: forall cava: Cava, <<Unit>> ~> B) *)
   {struct n}
-  : forall cava: Cava, << Vector A n, Unit >> ~> <<B>> :=
+  : forall cava: Cava, <<B, Vector A n, Unit >> ~> <<B>> :=
 match n with
-| 0 => <[ \_ => !initial ]>
+| 0 => <[ \initial _ => initial ]>
 | S n' =>
-  <[ \xs =>
+  <[ \initial xs =>
       let '(x, xs') = uncons xs in
-      let acc = !(foldl f initial) xs' in
+      let acc = !(foldl f) initial xs' in
       !f acc x
   ]>
 end.
 
 Fixpoint foldr {n A B}
   (f: forall cava: Cava, <<A, B, Unit>> ~> B)
-  (initial: forall cava: Cava, <<Unit>> ~> B)
+  (* (initial: forall cava: Cava, <<Unit>> ~> B) *)
   {struct n}
-  : forall cava: Cava, << Vector A n, Unit >> ~> <<B>> :=
+  : forall cava: Cava, <<B, Vector A n, Unit >> ~> <<B>> :=
 match n with
-| 0 => <[ \_ => !initial ]>
+| 0 => <[ \initial _ => initial ]>
 | S n' =>
-  <[ \xs =>
+  <[ \initial xs =>
       let '(xs', x) = unsnoc xs in
-      let acc = !(foldr f initial) xs' in
+      let acc = !(foldr f) initial xs' in
       !f x acc
   ]>
 end.
@@ -262,7 +262,7 @@ match T return forall cava: Cava, << T, T, Unit >> ~> <<Bit>> with
 | Vector ty n => 
   <[\ x y => 
     let item_equality = !(map2 equality) x y in
-    !(foldl <[\x y => and x y]> <[ true ]>) item_equality
+    !(foldl <[\x y => and x y]>) true item_equality
   ]>
 end.
 

--- a/cava/arrow-examples/Main.hs
+++ b/cava/arrow-examples/Main.hs
@@ -1,0 +1,21 @@
+--
+-- Copyright 2020 The Project Oak Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License")
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+module Main where
+
+import Unrolled_cipher
+
+main = print eval_unrolled

--- a/cava/arrow-examples/_CoqProject
+++ b/cava/arrow-examples/_CoqProject
@@ -2,11 +2,10 @@
 -R ../arrow-lib Arrow
 -R . ArrowExamples
 
-Combinators.v 
+Combinators.v
 
 Mux2_1.v
 SyntaxExamples.v
-ArrowExtraction.v
 UnsignedAdder.v
 
 ArrowAdderTutorial.v
@@ -22,3 +21,5 @@ Aes/shift_rows.v
 Aes/mix_single_column.v
 Aes/mix_columns.v
 Aes/unrolled_cipher.v
+
+ArrowExtraction.v


### PR DESCRIPTION
- Currently incorrect result, key expansion is likely wrong as code was converted from stateful to stateless. A separate PR will add a naive direct implementation of key expansion.
- Sbox_lut is temporarily disabled to make Haskell extraction and evaluation easier
