### PR TITLE
Add Makefile for checking out and building Git submodules

### DIFF
--- a/cava/README.md
+++ b/cava/README.md
@@ -21,17 +21,16 @@ Icarus Verilog will then be available in your `$PATH`.
 Please install the following components:
 
 * The [Coq proof assistant](https://coq.inria.fr/) version 8.11.0.
-* The [coq-ext-lib](https://github.com/coq-community/coq-ext-lib) library for Coq.
 * The [GHC Haskell compiler](https://www.haskell.org/ghc/) version 8.6.5 or later
 * [Verilator](https://www.veripool.org/wiki/verilator) version 4.028 (as specified by the
   [OpenTitan](https://docs.opentitan.org/doc/ug/install_instructions/#verilator) documentation).
 
 ## Building
 
-Type `make` in the directory `cava`:
+To build the Cava system and its examples and run tests, type `make` in the root directory of the repo.
 
 ```console
-$ cd oak-hardware/cava
+$ cd oak-hardware
 $ make
 ```
 

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -14,13 +14,9 @@
 # limitations under the License.
 #
 
-.PHONY: all third_party clean
+.PHONY:	all
 
-all: third_party
-	cd cava && $(MAKE) all
-
-third_party:
-	cd third_party && $(MAKE) 
-
-clean:
-	cd cava && $(MAKE) clean
+all:
+	git submodule update --init
+	cd coqutil && $(MAKE) all && $(MAKE) install
+	cd coq-ext-lib && $(MAKE) theories && $(MAKE) install

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,0 +1,9 @@
+# Project Oak Hardware Git Submodules
+
+The Git submodules are checked out and built by the `Makefile` in the root directory of the repo.
+To manually check out and build the submodules:
+
+```console
+$ cd third_party
+$ make
+```


### PR DESCRIPTION
I propose we have a `Makefile` in `third_party` that will check out and build the Git submodules.
I'll leave it to @blaxill to update the cloud-build YAML to invoke this.