### PR TITLE
Add continuation expression to arrow laws

### DIFF
--- a/cava/arrow-lib/Arrow.v
+++ b/cava/arrow-lib/Arrow.v
@@ -47,17 +47,23 @@ Class ArrowLaws
   (unit: object) (product: object -> object -> object) (A: Arrow object category unit product)
   := {
   (* (un)cance{l,r} and (un)assoc are natural isomorphisms *)
-  first_cancelr   {x y} (f: x ~> y): first f >>> cancelr =M= cancelr >>> f;
-  uncancelr_first {x y} (f: x ~> y): uncancelr >>> first f =M= f >>> uncancelr;
+  first_cancelr   {x y z} (f: x ~> y) (k: _ ~> z):
+    first f >>> cancelr >>> k =M= cancelr >>> f >>> k;
+  uncancelr_first {x y z} (f: x ~> y) (k: _ ~> z):
+    uncancelr >>> first f >>> k =M= f >>> uncancelr >>> k;
 
-  second_cancell   {x y} (f: x ~> y): second f >>> cancell =M= cancell >>> f;
-  uncancell_second {x y} (f: x ~> y): uncancell >>> second f =M= f >>> uncancell;
+  second_cancell   {x y z} (f: x ~> y) (k: _ ~> z):
+    second f >>> cancell >>> k =M= cancell >>> f >>> k;
+  uncancell_second {x y z} (f: x ~> y) (k: _ ~> z):
+    uncancell >>> second f >>> k =M= f >>> uncancell >>> k;
 
-  assoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t): 
-    assoc >>> bimap _ _ _ _ f (bimap _ _ _ _ g h) =M= bimap _ _ _ _ (bimap _ _ _ _ f g) h >>> assoc;
+  assoc_iso {x y z w s t v} (f: x ~> y) (g: z ~> w) (h: s ~> t) (k: _ ~> v):
+    assoc >>> bimap _ _ _ _ f (bimap _ _ _ _ g h) >>> k
+    =M= bimap _ _ _ _ (bimap _ _ _ _ f g) h >>> assoc >>> k;
 
-  unassoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t): 
-    unassoc >>> bimap _ _ _ _ (bimap _ _ _ _ f g) h =M= bimap _ _ _ _ f (bimap _ _ _ _ g h) >>> unassoc;
+  unassoc_iso {x y z w s t v} (f: x ~> y) (g: z ~> w) (h: s ~> t) (k: _ ~> v):
+    unassoc >>> bimap _ _ _ _ (bimap _ _ _ _ f g) h >>> k
+    =M= bimap _ _ _ _ f (bimap _ _ _ _ g h) >>> unassoc >>> k;
 
   (* triangle and pentagon identities? *)
 }.


### PR DESCRIPTION
This is a change that helps arrow laws work for manipulating expressions. Because the compose operator `>>>` is right-associative, Coq interprets `(A >>> B >>> C >>> D)` as `(A >>> (B >>> (C >>> D))`. Therefore, despite initial appearances, `B >>> C` is not a subexpression. In order to change the example to `A >>> E >>> D`, you need a lemma with a continuation argument, e.g. `forall K, (B >>> C >>> K)`, on the left-hand side.

We'll need to prove an alternate version of the lemma for the case when we want to rewrite the very innermost `compose` (`C >>> D` in the example), because that one doesn't have a continuation. But the non-continuation version should be implied by the continuation-included version as long as there's an identity morphism we can insert. Do we?