### PR TITLE
Remove trailing slash from submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "third_party/coqutil"]
 	path = third_party/coqutil
-	url = https://github.com/mit-plv/coqutil/
+	url = https://github.com/mit-plv/coqutil
 [submodule "third_party/coq-ext-lib"]
 	path = third_party/coq-ext-lib
 	url = https://github.com/coq-community/coq-ext-lib
 [submodule "third_party/opentitan"]
 	path = third_party/opentitan
-	url = https://github.com/lowRISC/opentitan/
+	url = https://github.com/lowRISC/opentitan


### PR DESCRIPTION
When I tried to do a fresh clone from my new corp laptop, I was getting "repository not found" errors during submodule initialization. This change fixed the issue.