### PR TITLE
Remove trailing whitespace

### DIFF
--- a/cava/arrow-examples/Aes/mix_columns.v
+++ b/cava/arrow-examples/Aes/mix_columns.v
@@ -30,15 +30,15 @@ Open Scope kind_scope.
   output logic [3:0][3:0][7:0] data_o
 ); *)
 Definition aes_mix_columns
-  :  
-    <<Bit, Vector (Vector (Vector Bit 8) 4) 4, Unit>> ~> 
+  :
+    <<Bit, Vector (Vector (Vector Bit 8) 4) 4, Unit>> ~>
       Vector (Vector (Vector Bit 8) 4) 4 :=
       (* // Transpose to operate on columns
       logic [3:0][3:0][7:0] data_i_transposed;
       logic [3:0][3:0][7:0] data_o_transposed;
-    
+
       assign data_i_transposed = aes_transpose(data_i);
-    
+
       // Individually mix columns
       for (genvar i = 0; i < 4; i++) begin : gen_mix_column
         aes_mix_single_column aes_mix_column_i (
@@ -47,7 +47,7 @@ Definition aes_mix_columns
           .data_o ( data_o_transposed[i] )
         );
       end
-    
+
       assign data_o = aes_transpose(data_o_transposed); *)
   <[\op_i data_i =>
     let transposed = !aes_transpose data_i in

--- a/cava/arrow-examples/Aes/mix_single_column.v
+++ b/cava/arrow-examples/Aes/mix_single_column.v
@@ -25,8 +25,8 @@ Import KappaNotation.
 Open Scope kind_scope.
 
 Definition aes_mix_single_column
-  :  
-    <<Bit, Vector (Vector Bit 8) 4, Unit>> ~> 
+  :
+    <<Bit, Vector (Vector Bit 8) 4, Unit>> ~>
       Vector (Vector Bit 8) 4 :=
   <[\ op_i data_i =>
   (* logic [3:0][7:0] x;
@@ -60,7 +60,7 @@ Definition aes_mix_single_column
   assign y_pre_mul4[0] = data_i[3] ^ data_i[1];
   assign y_pre_mul4[1] = data_i[2] ^ data_i[0];
   *)
-  let y_pre_mul4 = 
+  let y_pre_mul4 =
     data_i[#3] ^ data_i[#1] ::
     data_i[#2] ^ data_i[#0] :: [] in
 (*
@@ -86,7 +86,7 @@ Definition aes_mix_single_column
   (*// Mux z
   assign z_muxed[0] = (op_i == CIPH_FWD) ? 8'b0 : z[0];
   assign z_muxed[1] = (op_i == CIPH_FWD) ? 8'b0 : z[1];*)
-  let z_muxed = 
+  let z_muxed =
     if op_i == !CIPH_FWD then #0 else z[#0] ::
     if op_i == !CIPH_FWD then #0 else z[#1] ::
     [] in

--- a/cava/arrow-examples/Aes/pkg.v
+++ b/cava/arrow-examples/Aes/pkg.v
@@ -72,7 +72,7 @@ function automatic logic [7:0] aes_mul2(logic [7:0] in);
   out[0] = in[7];
   return out;
 endfunction *)
-Definition aes_mul2: 
+Definition aes_mul2:
   <<Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
   <[\ x => x[#7]
         :: (xor x[#0] x[#7])
@@ -89,7 +89,7 @@ Definition aes_mul2:
 function automatic logic [7:0] aes_mul4(logic [7:0] in);
   return aes_mul2(aes_mul2(in));
 endfunction *)
-Definition aes_mul4: 
+Definition aes_mul4:
   <<Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
   <[\ x => !aes_mul2 (!aes_mul2 x) ]>.
 
@@ -108,7 +108,7 @@ function automatic logic [7:0] aes_div2(logic [7:0] in);
   out[0] = in[1] ^ in[0];
   return out;
 endfunction *)
-Definition aes_div2: 
+Definition aes_div2:
   <<Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
   <[\ x => (xor x[#1] x[#0])
         :: x[#2]
@@ -129,16 +129,16 @@ Definition aes_div2:
          in[8*((5-s)%4) +: 8], in[8*((4-s)%4) +: 8]};
   return out;
 endfunction *)
-Definition aes_circ_byte_shift: 
+Definition aes_circ_byte_shift:
   <<Vector (Vector Bit 8) 4, Vector Bit 2, Unit>> ~> (Vector (Vector Bit 8) 4) :=
   <[\input shift =>
       !(map3 <[\input shift seq =>
         let offset = seq - shift in
         input[offset]
       ]>
-      ) 
-      (!replicate input) 
-      (!replicate shift) 
+      )
+      (!replicate input)
+      (!replicate shift)
       !(seq 4)
   ]>.
 
@@ -168,7 +168,7 @@ Definition aes_mvm_acc
   :  <<Vector Bit 8, Vector Bit 8, Bit, Unit>> ~> (Vector Bit 8) :=
   <[\acc mat vec => acc ^ (mat & (!replicate vec)) ]>.
 
-Definition aes_mvm: 
+Definition aes_mvm:
   <<Vector Bit 8, Vector (Vector Bit 8) 8, Unit>> ~> (Vector Bit 8) :=
   <[\ vec_b mat_a =>
   let _1 = !aes_mvm_acc (#0) (mat_a[#0]) (vec_b[#7]) in

--- a/cava/arrow-examples/Aes/sbox_canright_masked_noreuse.v
+++ b/cava/arrow-examples/Aes/sbox_canright_masked_noreuse.v
@@ -29,7 +29,7 @@ Open Scope kind_scope.
                                                         logic [1:0] r,
                                                         logic [3:0] t);*)
 Definition aes_masked_inverse_gf2p4
-  :  
+  :
     << Vector Bit 4 (* b *)
     ,  Vector Bit 4 (* q *)
     ,  Vector Bit 2 (* r *)
@@ -51,8 +51,8 @@ Definition aes_masked_inverse_gf2p4
           ^ aes_mul_gf2p2(b1, b0)
           ^ aes_mul_gf2p2(b1, q0) ^ aes_mul_gf2p2(b0, q1) ^ aes_mul_gf2p2(q1, q0); *)
     let temp1 = !aes_scale_omega2_gf2p2 (!aes_square_gf2p2 (b1 ^ b0)) in
-    let temp2 = !aes_scale_omega2_gf2p2 (!aes_square_gf2p2 (q1 ^ q0)) in 
-    let temp3 = !aes_mul_gf2p2 b1 b0 in 
+    let temp2 = !aes_scale_omega2_gf2p2 (!aes_square_gf2p2 (q1 ^ q0)) in
+    let temp3 = !aes_mul_gf2p2 b1 b0 in
     let temp4 = !aes_mul_gf2p2 b1 q0 ^ !aes_mul_gf2p2 b0 q1 ^ !aes_mul_gf2p2 q1 q0 in
 
     let c = r ^ temp1 ^ temp2 ^ temp3 ^ temp4 in
@@ -84,7 +84,7 @@ Definition aes_masked_inverse_gf2p4
 ]>.
 
 Definition aes_masked_inverse_gf2p8
-  :  
+  :
     << Vector Bit 8 (* a *)
     ,  Vector Bit 8 (* m *)
     ,  Vector Bit 8 (* n *)
@@ -105,7 +105,7 @@ Definition aes_masked_inverse_gf2p8
           ^ aes_square_scale_gf2p4_gf2p2(m1 ^ m0)
           ^ aes_mul_gf2p4(a1, a0)
           ^ aes_mul_gf2p4(a1, m0) ^ aes_mul_gf2p4(a0, m1) ^ aes_mul_gf2p4(m1, m0); *)
-    
+
     let b = q ^ !aes_square_scale_gf2p4_gf2p2 (a1 ^ a0)
               ^ !aes_square_scale_gf2p4_gf2p2 (m1 ^ m0)
               ^ !aes_mul_gf2p4 a1 a0
@@ -163,7 +163,7 @@ Definition aes_masked_inverse_gf2p8
 ]>.
 
 Definition aes_sbox_canright_masked_noreuse
-  :  << 
+  :  <<
     Bit, (* TODO: wrapped type?  aes_pkg::ciph_op_e op_i, *)
 
     Vector Bit 8, (* data_i, // masked, the actual input data is data_i ^ in_mask_i *)
@@ -183,7 +183,7 @@ Definition aes_sbox_canright_masked_noreuse
     assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(in_mask_i, A2X) :
                                                   aes_mvm(in_mask_i, S2X); *)
     let in_mask_basis_x = if op_i == !CIPH_FWD
-                          then !aes_mvm in_mask_i !A2X 
+                          then !aes_mvm in_mask_i !A2X
                           else !aes_mvm in_mask_i !S2X in
 
     (* // The output mask is converted in the opposite direction.

--- a/cava/arrow-examples/Aes/sbox_lut.v
+++ b/cava/arrow-examples/Aes/sbox_lut.v
@@ -43,7 +43,7 @@ verilog hex values were converted from OpenTitan verilog with vim:
 Definition aes_sbox_lut
   :  <<Bit, Vector Bit 8, Unit>> ~> (Vector Bit 8) :=
   <[\ op_i data_i =>
-  let SBOX_FWD = 
+  let SBOX_FWD =
     #99:: #124:: #119:: #123:: #242:: #107:: #111:: #197::
     #48:: #1:: #103:: #43:: #254:: #215:: #171:: #118::
 
@@ -93,7 +93,7 @@ Definition aes_sbox_lut
     #65:: #153:: #45:: #15:: #176:: #84:: #187:: #22
     :: [] in
 
-  let SBOX_INV = 
+  let SBOX_INV =
     #82:: #9:: #106:: #213:: #48:: #54:: #165:: #56::
     #191:: #64:: #163:: #158:: #129:: #243:: #215:: #251::
 

--- a/cava/arrow-examples/Aes/shift_rows.v
+++ b/cava/arrow-examples/Aes/shift_rows.v
@@ -65,7 +65,7 @@ Definition aes_shift_rows
     data_o_0 :: data_o_1 :: data_o_2 :: data_o_3 :: []
   ]>.
 
-Definition shift_rows_composed 
+Definition shift_rows_composed
 :  << Vector _ 4, Unit>> ~> (Vector _ 4) :=
   <[\input =>
   let encoded = !aes_shift_rows !CIPH_FWD input in

--- a/cava/arrow-examples/Aes/sub_bytes.v
+++ b/cava/arrow-examples/Aes/sub_bytes.v
@@ -23,7 +23,7 @@ From ArrowExamples Require Import Combinators Aes.pkg Aes.sbox.
 Import VectorNotations.
 Import KappaNotation.
 Open Scope kind_scope.
-  
+
 (* module aes_sub_bytes #(
   parameter SBoxImpl = "lut"
 ) (
@@ -33,8 +33,8 @@ Open Scope kind_scope.
 ); *)
 Definition aes_sub_bytes
   (sbox_type: SboxImpl)
-  :  
-    <<Bit, Vector (Vector (Vector Bit 8) 4) 4, Unit>> ~> 
+  :
+    <<Bit, Vector (Vector (Vector Bit 8) 4) 4, Unit>> ~>
       Vector (Vector (Vector Bit 8) 4) 4 :=
   (* // Individually substitute bytes
   for (genvar j = 0; j < 4; j++) begin : gen_sbox_j
@@ -50,7 +50,7 @@ Definition aes_sub_bytes
   end *)
   let sbox := curry (aes_sbox sbox_type) in
   let mapped_sbox := <[ !(map sbox) ]> in
-  <[ \op_i data_i => 
+  <[ \op_i data_i =>
     (* duplicate op_i to the same shape of data_i and then zip *)
     let op_i' = !replicate (!replicate op_i) in
     let zipped = !(map2 zipper) op_i' data_i in

--- a/cava/arrow-examples/Aes/unrolled_cipher.v
+++ b/cava/arrow-examples/Aes/unrolled_cipher.v
@@ -212,10 +212,10 @@ Definition unrolled_forward_cipher
     let stage2 = !aes_shift_rows !CIPH_FWD stage1 in
     stage2 ^ round_key
     ]>.
-  
+
 
 Definition unrolled_forward_cipher_flat
-  : 
+  :
     <<
       Vector Bit 128 (* data *)
     , Vector Bit 256 (* key *)

--- a/cava/arrow-examples/ArrowAdderTutorial.v
+++ b/cava/arrow-examples/ArrowAdderTutorial.v
@@ -30,8 +30,8 @@ Section notation.
 
   Definition halfAdder
   : << Bit, Bit, Unit >> ~> <<Bit, Bit>> :=
-    (* The bracket pairing `<[` `]>` opens a circuit expression scope, 
-    see readme.md for more information *) 
+    (* The bracket pairing `<[` `]>` opens a circuit expression scope,
+    see readme.md for more information *)
   <[ \ a b =>
     let part_sum = xor a b in
     let carry = and a b in
@@ -62,13 +62,13 @@ Section notation.
     (f, (d, e))
   ]>.
 
-  (* Replicate is a type created by replicating a type n times, 
+  (* Replicate is a type created by replicating a type n times,
   and connecting them by a right imbalanced tuple structure.
 
-  Since the above formulation of 'below' pairs the inputs and outputs 
-  as a tuple (rather requiring the types are equal and appending as a vector), 
+  Since the above formulation of 'below' pairs the inputs and outputs
+  as a tuple (rather requiring the types are equal and appending as a vector),
   'replicate' allows us to refer to type arrising from multiple
-  applications of 'below'. 
+  applications of 'below'.
   *)
   Fixpoint replicate A n : Kind :=
     match n with
@@ -79,14 +79,14 @@ Section notation.
 
   Fixpoint col {A B C: Kind} n
     (circuit: << A, B, Unit >> ~> <<A, C>>)
-    {struct n}: 
+    {struct n}:
       << A, replicate B (S n), Unit >> ~>
       << A, replicate C (S n)>> :=
     match n with
-    | O => <[ \a b => !circuit a b ]> 
+    | O => <[ \a b => !circuit a b ]>
     | S n' =>
       let column_above := (col n' circuit) in
-      below circuit column_above 
+      below circuit column_above
     end.
 
   Lemma col_cons: forall {A B C}
@@ -105,11 +105,11 @@ Section notation.
   This is done with familiar 'x[_]' syntax, although numeric constants require prepending with '#'.
   The index can be any expression. See readme.md for more information.
   *)
-  | 0 => <[\ x y => (x[#0], y[#0]) ]> 
-  | S n => 
-      <[\ xs ys => 
-      let '(x, xs') = uncons xs in 
-      let '(y, ys') = uncons ys in 
+  | 0 => <[\ x y => (x[#0], y[#0]) ]>
+  | S n =>
+      <[\ xs ys =>
+      let '(x, xs') = uncons xs in
+      let '(y, ys') = uncons ys in
       ((x, y), (!(interleave n) xs' ys'))
     ]>
   end.
@@ -121,10 +121,10 @@ Section notation.
     : << replicate Bit (S n), Unit >> ~>
       << Vector Bit (S n) >> :=
   match n with
-  | 0 => <[\ x => x :: [] ]> 
-  | S n => 
-      <[\ xs => 
-      let '(x, xs') = xs in 
+  | 0 => <[\ x => x :: [] ]>
+  | S n =>
+      <[\ xs =>
+      let '(x, xs') = xs in
       x :: !(productToVec n) xs'
     ]>
   end.

--- a/cava/arrow-examples/Combinators.v
+++ b/cava/arrow-examples/Combinators.v
@@ -29,25 +29,25 @@ Local Open Scope kind_scope.
 (* *************************** *)
 (* Rewrites *)
 
-Definition rewrite_kind {x y} (H: x = y) 
+Definition rewrite_kind {x y} (H: x = y)
   : << x, Unit >> ~[KappaCat]~> y :=
   match eq_kind_dec x y with
   | left Heq =>
-    rew [fun x => << _ >> ~[KappaCat]~> <<x>> ] Heq in <[\x=>x]> 
+    rew [fun x => << _ >> ~[KappaCat]~> <<x>> ] Heq in <[\x=>x]>
   | right Hneq => (ltac:(contradiction))
   end.
 
-Definition rewrite_vector {A x y} (H: x = y) 
+Definition rewrite_vector {A x y} (H: x = y)
   : << Vector A x, Unit >> ~> <<Vector A y>> :=
   match PeanoNat.Nat.eq_dec x y with
   | left Heq =>
-    rew [fun x => << _, _ >> ~[KappaCat]~> <<Vector A x>> ] Heq in <[\x=>x]> 
+    rew [fun x => << _, _ >> ~[KappaCat]~> <<Vector A x>> ] Heq in <[\x=>x]>
   | right Hneq => (ltac:(contradiction))
   end.
 
 Program Definition split_pow2 A n
   :  << Vector A (2^(S n)), Unit >> ~> <<Vector A (2^n), Vector A (2^n)>> :=
-  <[\ x => 
+  <[\ x =>
     let '(l,r) = split_at (2^n) x in
     (l, !(rewrite_vector _) r)
       ]>.
@@ -56,12 +56,12 @@ Program Definition split_pow2 A n
 (* Misc *)
 
 Definition uncurry {A B C args}
-  (f:  << <<A, B>>, args >> ~> C) 
+  (f:  << <<A, B>>, args >> ~> C)
   :  <<A, B, args>> ~> C :=
   <[ \a b => !f (a, b) ]>.
 
 Definition curry {A B C args}
-  (f:  << A, B, args >> ~> C) 
+  (f:  << A, B, args >> ~> C)
   :  << <<A, B>>, args >> ~> C :=
   <[ \ab => let '(a, b) = ab in !f a b ]>.
 
@@ -70,9 +70,9 @@ Fixpoint reshape {n m A}
 match n with
 | 0 => <[\_ => [] ]>
 | S n' =>
-  <[ \vec => 
+  <[ \vec =>
     let '(x, xs) = split_at m vec in
-    x :: !(@reshape n' m A) xs 
+    x :: !(@reshape n' m A) xs
     ]>
 end.
 
@@ -81,7 +81,7 @@ Fixpoint flatten {n m A}
 match n with
 | 0 => <[\_ => [] ]>
 | S n' =>
-  <[ \vec => 
+  <[ \vec =>
     let '(x, xs) = uncons vec in
     concat x (!(@flatten n' m A) xs)
     ]>
@@ -92,7 +92,7 @@ Fixpoint reverse {n A}
 match n with
 | 0 => <[\_ => [] ]>
 | S n' =>
-  <[ \vec => 
+  <[ \vec =>
     let '(x, xs) = uncons vec in
     snoc (!reverse xs) x
     ]>
@@ -123,7 +123,7 @@ Fixpoint tree (A: Kind) (n: nat)
   :  << Vector A (2^n), Unit >> ~> A :=
 match n with
 | O => <[ \ vec => let '(x,_) = uncons vec in x ]>
-| S n' => 
+| S n' =>
   <[\ x =>
       let '(left,right) = !(split_pow2 A n') x in
       let a = !(tree A n' f) left in
@@ -139,7 +139,7 @@ Fixpoint dt_tree_fold'
   :  << Vector (T k) (2^n), Unit >> ~> (T (n + k)) :=
 match n with
 | O => <[ \ vec => let '(x,_) = uncons vec in x ]>
-| S n' =>  
+| S n' =>
   <[\ x =>
       let '(left,right) = !(split_pow2 (T k) n') x in
       let a = !(dt_tree_fold' n' k T f) left in
@@ -154,7 +154,7 @@ Proof. auto. Qed.
 Definition dt_tree_fold
   (n: nat)
   (T: nat -> Kind)
-  (f: forall n,  << T n, T n, Unit >> ~> T (S n)) 
+  (f: forall n,  << T n, T n, Unit >> ~> T (S n))
   :  << Vector (T 0) (2^n), Unit >> ~> T n :=
   <[ \vec => !(rewrite_kind (inj_succ_in_kind _ _)) (!(dt_tree_fold' n 0 T f) vec) ]>.
 
@@ -246,17 +246,17 @@ Definition zipper {n A B}
 
 Fixpoint equality {T}
   :  << T, T, Unit >> ~> <<Bit>> :=
-match T return  << T, T, Unit >> ~[KappaCat]~> <<Bit>> with 
+match T return  << T, T, Unit >> ~[KappaCat]~> <<Bit>> with
 | Unit => <[ \_ _ => true' ]>
 | Bit => <[ \x y => xnor x y ]> (* bit equality is the xnor function *)
-| Tuple l r => <[ 
-    \x y => 
+| Tuple l r => <[
+    \x y =>
       let '(a,b) = x in
       let '(c,d) = y in
       and (!equality a c) (!equality b d)
   ]>
-| Vector ty n => 
-  <[\ x y => 
+| Vector ty n =>
+  <[\ x y =>
     let item_equality = !(map2 equality) x y in
     !(foldl <[\x y => and x y]>) true' item_equality
   ]>
@@ -278,9 +278,9 @@ Definition enable_vec {n}
 
 Fixpoint enable {T}
   :  << Bit, T, Unit >> ~> <<T>> :=
-match T return  << Bit, T, Unit >> ~[KappaCat]~> <<T>> with 
+match T return  << Bit, T, Unit >> ~[KappaCat]~> <<T>> with
 | Unit => <[ \_ x => x ]>
-| Bit => <[ \en x => and en x ]> 
+| Bit => <[ \en x => and en x ]>
 | Tuple l r => <[ \en x => let '(a,b) = x in
                   (!enable en a, !enable en b)
                 ]>
@@ -290,10 +290,10 @@ end.
 Fixpoint bitwise {T}
   (f:  << Bit, Bit, Unit >> ~> <<Bit>>)
   :  << T, T, Unit >> ~> <<T>> :=
-match T return  << T, T, Unit >> ~[KappaCat]~> <<T>> with 
+match T return  << T, T, Unit >> ~[KappaCat]~> <<T>> with
 | Unit => <[ \x _ => x ]>
 | Bit => f
-| Tuple l r => <[ \x y => 
+| Tuple l r => <[ \x y =>
   let '(a,b) = x in
   let '(c,d) = y in
   (!(bitwise f) a c, !(bitwise f) b d)
@@ -318,7 +318,7 @@ Definition mux_item {T}
 Definition below {A B C D E F G: Kind}
   (r:  << A, B, Unit >> ~> << G, D >>)
   (s:  << G, C, Unit >> ~> << F, E >>)
-  :   
+  :
     << A, <<B, C>>, Unit >> ~> << F, <<D, E>> >> :=
 <[ \ a bc =>
   let '(b, c) = bc in
@@ -337,14 +337,14 @@ Fixpoint replicateKind A n : Kind :=
 
 Fixpoint col' {A B C: Kind} n
   (circuit:  << A, B, Unit >> ~> <<A, C>>)
-  {struct n}: 
+  {struct n}:
     << A, replicateKind B (S n), Unit >> ~>
     << A, replicateKind C (S n)>> :=
   match n with
-  | O => <[ \a b => !circuit a b ]> 
+  | O => <[ \a b => !circuit a b ]>
   | S n' =>
     let column_below := (col' n' circuit) in
-    below circuit column_below 
+    below circuit column_below
   end.
 
 Lemma col_cons: forall {A B C}
@@ -355,10 +355,10 @@ Proof. auto. Qed.
 Fixpoint productToVec {n T}
   :  << replicateKind T (S n), Unit >> ~> << Vector T (S n) >> :=
   match n with
-  | 0 => <[\ x => x :: [] ]> 
-  | S n' => 
-      <[\ xs => 
-        let '(x, xs') = xs in 
+  | 0 => <[\ x => x :: [] ]>
+  | S n' =>
+      <[\ xs =>
+        let '(x, xs') = xs in
         x :: !productToVec xs'
       ]>
   end.
@@ -366,34 +366,34 @@ Fixpoint productToVec {n T}
 Fixpoint vecToProduct {n T}
   :  << Vector T (S n), Unit >> ~> << replicateKind T (S n) >> :=
 match n with
-| 0 => <[\ xs => let '(x,_) = uncons xs in x ]> 
-| S n' => 
-    <[\ xs => 
-      let '(x, xs') = uncons xs in 
+| 0 => <[\ xs => let '(x,_) = uncons xs in x ]>
+| S n' =>
+    <[\ xs =>
+      let '(x, xs') = uncons xs in
       (x, !vecToProduct xs')
     ]>
 end.
 
 Fixpoint interleaveVectors n
-  : 
+  :
     << Vector Bit (S n), Vector Bit (S n), Unit >> ~>
     << Vector <<Bit, Bit>> (S n) >> :=
 match n with
-| 0 => <[\ x y => (x[#0], y[#0]) :: [] ]> 
-| S n => 
-    <[\ xs ys => 
-    let '(x, xs') = uncons xs in 
-    let '(y, ys') = uncons ys in 
+| 0 => <[\ x y => (x[#0], y[#0]) :: [] ]>
+| S n =>
+    <[\ xs ys =>
+    let '(x, xs') = uncons xs in
+    let '(y, ys') = uncons ys in
     (x, y) :: (!(interleaveVectors n) xs' ys')
   ]>
 end.
 
 Definition col {A B C: Kind} n
   (circuit:  << A, B, Unit >> ~> <<A, C>>)
-  : 
+  :
     << A, Vector B (S n), Unit >> ~>
     << A, Vector C (S n)>> :=
-  <[ \a b => 
+  <[ \a b =>
     let prod_b = !vecToProduct b in
     let '(a, c) = !(col' n circuit) a prod_b in
     (a, !productToVec c)
@@ -419,13 +419,13 @@ Section regression_tests.
   ]>.
 
   Definition rippleCarryAdder' (width: nat)
-    :  
+    :
       << Bit, Vector <<Bit, Bit>> (S width), Unit >> ~>
       << Bit, Vector Bit (S width) >> :=
   <[ !(col width fullAdder) ]>.
 
   Definition rippleCarryAdder (width: nat)
-    :  
+    :
       << Bit, <<Vector Bit (S width), Vector Bit (S width)>>, Unit >> ~>
       << Bit, Vector Bit (S width) >> :=
   <[ \b xy =>
@@ -434,7 +434,7 @@ Section regression_tests.
     let '(carry, result) = !(rippleCarryAdder' _) b merged in
     (carry, result)
     ]>.
- 
+
   (* Lemma interleave_is_stateless : forall n, has_no_state (interleaveVectors n EvalCava).
   Proof. induction n; auto 20 with stateless. Qed.
 

--- a/cava/arrow-examples/Mux2_1.v
+++ b/cava/arrow-examples/Mux2_1.v
@@ -44,7 +44,7 @@ Open Scope kind_scope.
 
 Lemma mux2_1_is_combinational: is_combinational (closure_conversion mux2_1).
 Proof. simply_combinational. Qed.
-  
+
 Require Import Cava.Types.
 Require Import Cava.Netlist.
 
@@ -57,7 +57,7 @@ Definition mux2_1_Interface :=
 Definition mux2_1_netlist :=
   makeNetlist mux2_1_Interface (build_netlist (closure_conversion mux2_1)).
 
-Definition mux2_1_tb_inputs : list (bool * (bool * bool)) := 
+Definition mux2_1_tb_inputs : list (bool * (bool * bool)) :=
  [(false, (false, true));
   (false, (true, false));
   (false, (false, false));

--- a/cava/arrow-examples/SyntaxExamples.v
+++ b/cava/arrow-examples/SyntaxExamples.v
@@ -24,7 +24,7 @@ From Coq Require Import Lists.List.
 Import ListNotations.
 
 Section notation.
-  Import KappaNotation. 
+  Import KappaNotation.
   Local Open Scope category_scope.
   Local Open Scope kind_scope.
 
@@ -41,5 +41,5 @@ End notation.
 
 Open Scope kind_scope.
 
-Lemma xilinxFullAdder_is_combinational: is_combinational (closure_conversion xilinxFullAdder). 
+Lemma xilinxFullAdder_is_combinational: is_combinational (closure_conversion xilinxFullAdder).
 Proof. simply_combinational. Qed.

--- a/cava/arrow-examples/UnsignedAdder.v
+++ b/cava/arrow-examples/UnsignedAdder.v
@@ -44,7 +44,7 @@ Section notation.
   Lemma max_nn_add_1_is_S_n: forall n, 1 + max n n = S n.
   Proof. intros; rewrite PeanoNat.Nat.max_id; auto. Qed.
 
-  Definition growth_adder n 
+  Definition growth_adder n
   : << Vector Bit n, Vector Bit n, Unit >> ~> Vector Bit (S n) :=
   <[ \ a b => !(rewrite_vector (max_nn_add_1_is_S_n _)) (a + b) ]>.
 
@@ -52,22 +52,22 @@ Section notation.
   : << Vector (Vector Bit a) (2^n), Unit >> ~> Vector Bit (n + a) :=
   <[ \ v => !(dt_tree_fold' n a (Vector Bit) (growth_adder)) v  ]>.
 
-  Definition adder445: << Vector Bit 4, Vector Bit 4, Unit >> ~> (Vector Bit 5) 
+  Definition adder445: << Vector Bit 4, Vector Bit 4, Unit >> ~> (Vector Bit 5)
     := unsigned_adder 4 4 5.
 
-  Definition adder88810: << Vector Bit 8, Vector Bit 8, Vector Bit 8, Unit >> ~> (Vector Bit 10) 
+  Definition adder88810: << Vector Bit 8, Vector Bit 8, Vector Bit 8, Unit >> ~> (Vector Bit 10)
     := adder3 8 8 8.
 
-  Definition adder444_tree_4: << Vector (Vector Bit 4) 4, Unit >> ~> (Vector Bit 4) 
+  Definition adder444_tree_4: << Vector (Vector Bit 4) 4, Unit >> ~> (Vector Bit 4)
     := tree_adder 4 2.
 
-  Definition adder444_tree_8: << Vector (Vector Bit 4) 8, Unit >> ~> (Vector Bit 4) 
+  Definition adder444_tree_8: << Vector (Vector Bit 4) 8, Unit >> ~> (Vector Bit 4)
     := tree_adder 4 3.
 
-  Definition adder444_tree_64: << Vector (Vector Bit 4) 64, Unit >> ~> (Vector Bit 4) 
+  Definition adder444_tree_64: << Vector (Vector Bit 4) 64, Unit >> ~> (Vector Bit 4)
     := tree_adder 4 6.
 
-  Definition growth_tree_8: << Vector (Vector Bit 4) 8, Unit >> ~> (Vector Bit 7) 
+  Definition growth_tree_8: << Vector (Vector Bit 4) 8, Unit >> ~> (Vector Bit 7)
     := growth_tree_adder 4 3.
 End notation.
 
@@ -85,27 +85,27 @@ Definition adder445_interface
      (mkPort "a" (Kind.BitVec Kind.Bit 4), mkPort "b" (Kind.BitVec Kind.Bit 4))
      (mkPort "sum" (Kind.BitVec Kind.Bit 5))
      [].
-Definition adder88810_interface 
+Definition adder88810_interface
   := combinationalInterface "adder88810"
      (mkPort "a" (Kind.BitVec Kind.Bit 8), (mkPort "b" (Kind.BitVec Kind.Bit 8), mkPort "c" (Kind.BitVec Kind.Bit 8)))
      (mkPort "sum" (Kind.BitVec Kind.Bit 10))
      [].
-Definition adder444_tree_4_interface 
+Definition adder444_tree_4_interface
   := combinationalInterface "adder444_tree_4"
      (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 4))
      (mkPort "result" (Kind.BitVec Kind.Bit 4))
      [].
-Definition adder444_tree_8_interface 
+Definition adder444_tree_8_interface
   := combinationalInterface "adder444_tree_8"
      (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 8))
      (mkPort "result" (Kind.BitVec Kind.Bit 4))
      [].
-Definition adder444_tree_64_interface 
+Definition adder444_tree_64_interface
   := combinationalInterface "adder444_tree_64"
      (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 64))
      (mkPort "result" (Kind.BitVec Kind.Bit 4))
      [].
-Definition growth_tree_8_interface 
+Definition growth_tree_8_interface
   := combinationalInterface "growth_tree_8"
      (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 8))
      (mkPort "result" (Kind.BitVec Kind.Bit 7))

--- a/cava/arrow-lib/Arrow.v
+++ b/cava/arrow-lib/Arrow.v
@@ -41,9 +41,9 @@ Delimit Scope arrow_scope with Arrow.
 Notation "x ** y" := (product x y)
   (at level 30, right associativity) : arrow_scope.
 
-Class ArrowLaws 
-  (object: Set) 
-  (category: Category object) (category_laws: CategoryLaws category) 
+Class ArrowLaws
+  (object: Set)
+  (category: Category object) (category_laws: CategoryLaws category)
   (unit: object) (product: object -> object -> object) (A: Arrow object category unit product)
   := {
   (* (un)cance{l,r} and (un)assoc are natural isomorphisms *)
@@ -53,10 +53,10 @@ Class ArrowLaws
   second_cancell   {x y} (f: x ~> y): second f >>> cancell =M= cancell >>> f;
   uncancell_second {x y} (f: x ~> y): uncancell >>> second f =M= f >>> uncancell;
 
-  assoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t): 
+  assoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t):
     assoc >>> bimap _ _ _ _ f (bimap _ _ _ _ g h) =M= bimap _ _ _ _ (bimap _ _ _ _ f g) h >>> assoc;
 
-  unassoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t): 
+  unassoc_iso {x y z w s t} (f: x ~> y) (g: z ~> w) (h: s ~> t):
     unassoc >>> bimap _ _ _ _ (bimap _ _ _ _ f g) h =M= bimap _ _ _ _ f (bimap _ _ _ _ g h) >>> unassoc;
 
   (* triangle and pentagon identities? *)
@@ -118,8 +118,8 @@ Class ArrowLoop `(A: Arrow) := {
 }.
 
 Class ArrowConstant
-  object (category: Category object) 
-  unit prod (A: Arrow object category unit prod) 
+  object (category: Category object)
+  unit prod (A: Arrow object category unit prod)
   (r: object) t
   := {
   constant : t -> (unit ~> r);
@@ -134,8 +134,8 @@ Proof.
 Qed.
 
 Class ArrowSum
-  object (category: Category object) 
-  void either (ASum: Arrow object category void either) 
+  object (category: Category object)
+  void either (ASum: Arrow object category void either)
   := {
   merge {x} : (either x x) ~> x;
   never {x} : void ~> x;
@@ -144,16 +144,16 @@ Class ArrowSum
 (*
 Class ArrowApply := {
   app {x y}: (x~>y)**y ~> x:
-}. 
+}.
 
 Class ArrowProd := {
   prod_copy {x} : x ~> (x<*>x):
   prod_drop {x} : x ~> v;
-}. 
+}.
 *)
 
-Class ArrowSTKC 
-  `(A: Arrow) 
+Class ArrowSTKC
+  `(A: Arrow)
   := {
   stkc_arrow := A;
   stkc_arrow_drop :> ArrowDrop A;
@@ -171,7 +171,7 @@ Section arrowstkc.
   Context {unit: object}.
   Context {product: object -> object -> object}.
 
-  Inductive ArrowStructure := 
+  Inductive ArrowStructure :=
     | Id: object -> ArrowStructure
     | Assoc: object -> object -> object -> ArrowStructure
     | Unassoc: object -> object -> object -> ArrowStructure
@@ -196,7 +196,7 @@ Section arrowstkc.
     | Cancelr x => product x unit
     | Cancell x => product unit x
     | Uncancell x => x
-    | Uncancelr x => x 
+    | Uncancelr x => x
     | Copy x => x
     | Drop x => x
     | Swap x y => product x y
@@ -210,7 +210,7 @@ Section arrowstkc.
     | Cancelr x => x
     | Cancell x => x
     | Uncancell x => product unit x
-    | Uncancelr x => product x unit 
+    | Uncancelr x => product x unit
     | Copy x => product x x
     | Drop x => unit
     | Swap x y => product y x

--- a/cava/arrow-lib/Category.v
+++ b/cava/arrow-lib/Category.v
@@ -12,7 +12,7 @@ Generalizable Variable object category.
   Here we have morphisms between objects of type object.
 *)
 Class Category (object: Type) := {
-  category_object := object; 
+  category_object := object;
   morphism : object -> object -> Type
     where "a ~> b" := (morphism a b);
 

--- a/cava/arrow-lib/Coq.v
+++ b/cava/arrow-lib/Coq.v
@@ -26,44 +26,44 @@ Instance coq_arrow : Arrow Type coq_category unit prod := {
 }.
 
 Instance coq_sum_arrow : Arrow Type coq_category void sum := {
-  first  x y z (f: x ~> y) a := 
-    match a with 
+  first  x y z (f: x ~> y) a :=
+    match a with
     | inl x => inl (f x)
     | inr x => inr x
     end;
 
-  second x y z (f: x ~> y) a := 
-    match a with 
+  second x y z (f: x ~> y) a :=
+    match a with
     | inl x => inl x
     | inr x => inr (f x)
     end;
 
-  assoc x y z a := 
+  assoc x y z a :=
     match a with
-    | inl x => 
-      match x with 
+    | inl x =>
+      match x with
       | inl y => inl y
       | inr y => inr (inl y)
       end
     | inr x => inr (inr x)
     end;
 
-  unassoc x y z a := 
+  unassoc x y z a :=
     match a with
     | inl x => inl (inl x)
-    | inr x => 
-      match x with 
+    | inr x =>
+      match x with
       | inl y => inl (inr y)
       | inr y => inr y
       end
     end;
 
-  cancelr x a := 
+  cancelr x a :=
     match a with
     | inl x => x
     | inr x => match void_is_false x with end
     end;
-  cancell x a := 
+  cancell x a :=
     match a with
     | inl x => match void_is_false x with end
     | inr x => x
@@ -75,8 +75,8 @@ Instance coq_sum_arrow : Arrow Type coq_category void sum := {
 
 Instance coq_arrow_sum : ArrowSum Type coq_category void sum coq_sum_arrow := {
   merge X x := match x with
-    | inl x => x 
-    | inr x => x 
+    | inl x => x
+    | inr x => x
     end;
 
   never X x := match void_is_false x with end;

--- a/cava/arrow-lib/Kleisli.v
+++ b/cava/arrow-lib/Kleisli.v
@@ -14,10 +14,10 @@ Instance kleisli_category m (M: Monad m) : Category Type := {
 }.
 
 Instance kleisli_arrow m (M: Monad m) : Arrow Type (kleisli_category m M) unit prod := {
-  first  x y z (f: x ~> y) a := 
+  first  x y z (f: x ~> y) a :=
     b <- f (fst a) ;;
     ret (b, snd a);
-  second x y z (f: x ~> y) a := 
+  second x y z (f: x ~> y) a :=
     b <- f (snd a) ;;
     ret (fst a, b);
 
@@ -32,48 +32,48 @@ Instance kleisli_arrow m (M: Monad m) : Arrow Type (kleisli_category m M) unit p
 }.
 
 Instance kleisli_sum_arrow m (M: Monad m): Arrow Type (kleisli_category m M) void sum := {
-  first x y z (f: x ~> y) a := 
-    match a with 
-    | inl x => 
+  first x y z (f: x ~> y) a :=
+    match a with
+    | inl x =>
       x' <- f x ;;
       ret (inl x')
     | inr x => ret (inr x)
     end;
 
-  second x y z (f: x ~> y) a := 
-    match a with 
+  second x y z (f: x ~> y) a :=
+    match a with
     | inl x => ret (inl x)
-    | inr x => 
+    | inr x =>
       x' <- f x ;;
       ret (inr x')
     end;
 
-  assoc x y z a := 
+  assoc x y z a :=
     match a with
-    | inl x => 
-      match x with 
+    | inl x =>
+      match x with
       | inl y => ret (inl y)
       | inr y => ret (inr (inl y))
       end
     | inr x => ret (inr (inr x))
     end;
 
-  unassoc x y z a := 
+  unassoc x y z a :=
     match a with
     | inl x => ret (inl (inl x))
-    | inr x => 
-      match x with 
+    | inr x =>
+      match x with
       | inl y => ret (inl (inr y))
       | inr y => ret (inr y)
       end
     end;
 
-  cancelr x a := 
+  cancelr x a :=
     match a with
     | inl x => ret x
     | inr x => match void_is_false x with end
     end;
-  cancell x a := 
+  cancell x a :=
     match a with
     | inl x => match void_is_false x with end
     | inr x => ret x
@@ -83,11 +83,11 @@ Instance kleisli_sum_arrow m (M: Monad m): Arrow Type (kleisli_category m M) voi
   uncancelr x a := ret (inl a);
 }.
 
-Instance kleisli_arrow_sum m (M: Monad m): 
+Instance kleisli_arrow_sum m (M: Monad m):
   ArrowSum Type (kleisli_category m M) void sum (kleisli_sum_arrow m M) := {
   merge X x := match x with
-    | inl x => ret x 
-    | inr x => ret x 
+    | inl x => ret x
+    | inr x => ret x
     end;
 
   never X x := match void_is_false x with end;

--- a/cava/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/cava/Cava/Arrow/ArrowKind.v
@@ -187,7 +187,7 @@ match ty with
 end.
 
 Fixpoint denote_kind (ty: Kind): Type :=
-  match ty with 
+  match ty with
   | Tuple l r => denote_kind l * denote_kind r
   | Bit => bool
   | Vector ty n => Vector.t (denote_kind ty) n
@@ -195,7 +195,7 @@ Fixpoint denote_kind (ty: Kind): Type :=
   end.
 
 Fixpoint kind_default (ty: Kind): denote_kind ty :=
-  match ty return denote_kind ty with 
+  match ty return denote_kind ty with
   | Tuple l r => (kind_default l, kind_default r)
   | Bit => false
   | Vector ty n => const (kind_default ty) n

--- a/cava/cava/Cava/Arrow/CircuitLowering.v
+++ b/cava/cava/Cava/Arrow/CircuitLowering.v
@@ -199,7 +199,7 @@ Fixpoint build_netlist' {i o}
       y <- fresh_wire _ ;;
       map2M (fun x y => DelayBit x y) _ (fst x) y ;;
       ret y
-  | Primitive Primitives.Not => fun i => 
+  | Primitive Primitives.Not => fun i =>
       o <- newWire ;;
       addInstance (Not (fst i) o) ;;
       ret o
@@ -237,11 +237,11 @@ Fixpoint build_netlist' {i o}
   | Primitive (Primitives.Snd _ _) => fun '((x,y),_) => ret y
   | Primitive (Primitives.Pair _ _) => fun '(x,(y,_)) => ret (x,y)
 
-  | Primitive Primitives.And => fun '(x,(y,_)) => 
+  | Primitive Primitives.And => fun '(x,(y,_)) =>
       o <- newWire ;;
       addInstance (And x y o) ;;
       ret o
-  | Primitive Primitives.Nand => fun '(x,(y,_)) => 
+  | Primitive Primitives.Nand => fun '(x,(y,_)) =>
       o <- newWire ;;
       addInstance (Nand x y o) ;;
       ret o

--- a/cava/cava/Cava/Monad/CavaClass.v
+++ b/cava/cava/Cava/Monad/CavaClass.v
@@ -55,7 +55,7 @@ Class Cava m `{Monad m} bit := {
      to the SystemVerilog netlist generation back-end to allow these to me
      functions rather than values in the monad type `m`.
   *)
-  (* Dynamic indexing *)                                   
+  (* Dynamic indexing *)
   indexAt : forall {k: Kind} {sz isz: nat},
             Vector.t (smashTy bit k) sz -> Vector.t bit isz -> smashTy bit k;
   indexBitAt : forall {sz isz: nat}, Vector.t bit sz ->

--- a/cava/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/cava/Cava/Monad/CombinationalMonad.v
@@ -118,16 +118,16 @@ Definition indexConstBool {k: Kind} {sz: nat}
   match lt_dec sel sz with
   | left H => @Vector.nth_order _ _ i sel H
   | right _ => defaultKindBool k
-  end.   
+  end.
 
 Definition sliceBool {k: Kind}
-                     {sz: nat} 
+                     {sz: nat}
                      (startAt len : nat)
                      (v: Vector.t (smashTy bool k) sz)
                      (H: startAt + len <= sz) :
                      Vector.t (smashTy bool k) len :=
   sliceVector v startAt len H.
-                
+
 Definition unsignedAddBool {m n : nat}
                            (av : Bvector m) (bv : Bvector n) :
                            ident (Bvector (1 + max m n)) :=

--- a/cava/cava/Cava/Monad/Combinators.v
+++ b/cava/cava/Cava/Monad/Combinators.v
@@ -58,7 +58,7 @@ Local Open Scope monad_scope.
 --     c ->|  s  |-> e
 --         |     |
 --          -----
---            ^ 
+--            ^
 --            |
 --            g
 --            ^
@@ -68,7 +68,7 @@ Local Open Scope monad_scope.
 --     b ->|  r  |-> d
 --         |     |
 --          -----
---            ^ 
+--            ^
 --            |
 --            a
 -------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ Fixpoint below `{Monad m} {A B C D E F G}
    composing each element in a chain.
 
 -------------------------------------------------------------------------------
--- 4-Sided Tile Combinators 
+-- 4-Sided Tile Combinators
 -------------------------------------------------------------------------------
 -- COL r
 --            a
@@ -111,7 +111,7 @@ Fixpoint below `{Monad m} {A B C D E F G}
 --     b ->|  r  |-> c
 --         |     |
 --          -----
---            ^ 
+--            ^
 --            |
 --            a
 --            ^
@@ -121,7 +121,7 @@ Fixpoint below `{Monad m} {A B C D E F G}
 --     b ->|  r  |-> c
 --         |     |
 --          -----
---            ^ 
+--            ^
 --            |
 --            a
 -------------------------------------------------------------------------------
@@ -202,7 +202,7 @@ Lemma col_cons: forall `{Monad m} {A B C} (r : C * A -> m (B * C)%type)
 Proof.
   intros.
   destruct ca.
-  destruct l. 
+  destruct l.
   - simpl. reflexivity.
   - simpl. reflexivity.
 Qed.
@@ -217,17 +217,17 @@ Proof. lia. Qed.
 Lemma S_add_S_contra: forall x y, x = S y -> S (x - 1) <> S y -> False.
 Proof. lia. Qed.
 
-Definition vec_dec_rewrite1 {A x y} (H: x = S y) (v: Vector.t A y): Vector.t A (x - 1) := 
+Definition vec_dec_rewrite1 {A x y} (H: x = S y) (v: Vector.t A y): Vector.t A (x - 1) :=
   match Nat.eq_dec (x - 1) y with
   | left Heq => rew <- Heq in v
   | right Hneq => match add_S_contra _ _ H Hneq with end
   end.
 
-Definition vec_dec_rewrite2 {A x y} (H: x = S y) (v: Vector.t A (S (x - 1))): Vector.t A (S y) := 
+Definition vec_dec_rewrite2 {A x y} (H: x = S y) (v: Vector.t A (S (x - 1))): Vector.t A (S y) :=
   match Nat.eq_dec (S (x - 1)) (S y) with
   | left Heq => rew Heq in v
   | right Hneq => match S_add_S_contra _ _ H Hneq with end
-  end. 
+  end.
 
 Program Definition below_consV `{Monad m} {A B C} {n: nat}
               (r : C -> A -> m (B * C)%type)
@@ -236,7 +236,7 @@ Program Definition below_consV `{Monad m} {A B C} {n: nat}
   let '(c, a) := ca in
   match a in Vector.t _ z return n=z -> m (Vector.t B z * C)%type with
   | Vector.nil _ => fun _ => ret ([], c)
-  | Vector.cons _ a0 Z ax => fun H => 
+  | Vector.cons _ a0 Z ax => fun H =>
     '(b0, c1) <- r c a0 ;;
     '(bx, cOut) <- s c1 (vec_dec_rewrite1 H ax) ;;
     ret (vec_dec_rewrite2 H (b0 :: bx), cOut)
@@ -251,12 +251,12 @@ Definition circuit_dec_rewrite `{Monad m} {A B C x y} (H: x = S y)
   end.
 
 Fixpoint colV `{Monad m} {A B C} (n: nat)
-              (circuit : C -> A -> m (B * C)%type) 
+              (circuit : C -> A -> m (B * C)%type)
               (c: C) (a: Vector.t A n) :
               m (Vector.t B n * C)%type :=
   match n as n' return n=n' -> m (Vector.t B n' * C)%type with
   | O => fun _ => ret ([], c)
-  | S n0 => fun H => 
+  | S n0 => fun H =>
     let s :=  circuit_dec_rewrite H (colV n0 circuit) in
     '(x,c) <- below_consV circuit s (c, a) ;;
     ret (rew H in x, c)
@@ -293,7 +293,7 @@ Definition halve {A} (l : list A) : list A * list A :=
 (******************************************************************************)
 
 Fixpoint treeList {T: Type} {m bit} `{Cava m bit}
-                  (circuit: T -> T -> m T) (def: T) 
+                  (circuit: T -> T -> m T) (def: T)
                   (n : nat) (v: list T) : m T :=
   match n, v with
   | O, ab => match ab return m T with
@@ -307,13 +307,13 @@ Fixpoint treeList {T: Type} {m bit} `{Cava m bit}
   end.
 
 Fixpoint treeWithList {T: Type} {m bit} `{Cava m bit}
-                      (circuit: T -> T -> m T) (def: T) 
+                      (circuit: T -> T -> m T) (def: T)
                       (n : nat) (v: Vector.t T (2^(n+1))) : m T :=
  treeList circuit def n (to_list v).
 
 (******************************************************************************)
 (* A binary tree combinator, Vector version.                                                  *)
-(******************************************************************************) 
+(******************************************************************************)
 
 Definition halveV {n a} (v : Vector.t a (2*n)) : Vector.t a n * Vector.t a n :=
   match Nat.eq_dec (n + 0) n with

--- a/cava/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/cava/Cava/Monad/NetlistGeneration.v
@@ -98,13 +98,13 @@ Definition lut2Net (f : bool -> bool -> bool) (i : Signal Bit * Signal Bit) :
            state CavaState (Signal Bit) :=
   let config :=     N.b2n (f false false) +
                 2 * N.b2n (f true false) +
-                4 * N.b2n (f false true) + 
+                4 * N.b2n (f false true) +
                 8 * N.b2n (f true true) in
   let (i0, i1) := i in
   o <- newWire ;;
   addInstance (Component "LUT2" [("INIT", HexLiteral 4 config)]
                          [("O", USignal  o); ("I0", USignal i0); ("I1", USignal i1)]) ;;
-  ret o.                       
+  ret o.
 
 Definition f3List (f: bool -> bool -> bool -> bool) (l: list bool) : bool :=
   match l with
@@ -158,7 +158,7 @@ Definition lut5Net (f : bool -> bool -> bool -> bool -> bool -> bool)
   o <- newWire ;;
   addInstance (Component "LUT5" [("INIT", HexLiteral 32 config)]
                           [("O", USignal o); ("I0", USignal i0); ("I1", USignal i1); ("I2", USignal i2); ("I3", USignal i3); ("I4", USignal i4)]) ;;
-  ret o.                        
+  ret o.
 
 Definition f6List (fn: bool -> bool -> bool -> bool -> bool -> bool -> bool)
                   (l: list bool) : bool :=
@@ -172,7 +172,7 @@ Definition lut6Net (f : bool -> bool -> bool -> bool -> bool -> bool -> bool)
   let powers := map (fun p => let bv := nat_to_list_bits_sized 6 (N.of_nat p) in
                      2^(N.of_nat p) * N.b2n (f6List f bv)) (seq 0 64)  in
   let config := fold_left N.add powers 0 in
-  let '(i0, i1, i2, i3, i4, i5) := i in 
+  let '(i0, i1, i2, i3, i4, i5) := i in
   o <- newWire ;;
   addInstance (Component "LUT6" [("INIT", HexLiteral 64 config)]
                           [("O", USignal o); ("I0", USignal i0); ("I1", USignal i1); ("I2", USignal i2); ("I3", USignal i3); ("I4", USignal i4); ("I5", USignal i5)] ) ;;
@@ -191,7 +191,7 @@ Definition muxcyNet (s ci di : Signal Bit) : state CavaState (Signal Bit) :=
   addInstance (Component "MUXCY" [] [("O", USignal o); ("S", USignal s); ("CI", USignal ci); ("DI", USignal di)]) ;;
   ret o.
 
-Definition unsignedAddNet {m n : nat} 
+Definition unsignedAddNet {m n : nat}
                           (a : Vector.t (Signal Bit) m)
                           (b : Vector.t (Signal Bit) n) :
                           state CavaState (Vector.t (Signal Bit) (1 + max m n)) :=
@@ -215,22 +215,22 @@ Definition indexAtNet {k: Kind} {sz isz: nat}
                       (v: Vector.t (smashTy (Signal Bit) k) sz)
                       (i: Vector.t (Signal Bit) isz) :
                       smashTy (Signal Bit) k :=
-  smash (IndexAt (VecLit (Vector.map vecLitS v)) (VecLit i)).            
+  smash (IndexAt (VecLit (Vector.map vecLitS v)) (VecLit i)).
 
 Definition indexConstNet {k: Kind} {sz: nat}
                          (v: Vector.t (smashTy (Signal Bit) k) sz)
                          (i: nat) :
                          smashTy (Signal Bit) k :=
-  smash (IndexConst (VecLit(Vector.map vecLitS v)) i). 
+  smash (IndexConst (VecLit(Vector.map vecLitS v)) i).
 
 Definition sliceNet {k: Kind} {sz: nat}
                     (startAt len: nat)
                     (v: Vector.t (smashTy (Signal Bit) k) sz)
                     (H: startAt + len <= sz) :
                     Vector.t (smashTy (Signal Bit) k) len :=
-  sliceVector v startAt len H.              
+  sliceVector v startAt len H.
 
-Definition greaterThanOrEqualNet {m n : nat} 
+Definition greaterThanOrEqualNet {m n : nat}
                                  (a : Vector.t (Signal Bit) m) (b : Vector.t (Signal Bit) n) :
                                  state CavaState (Signal Bit) :=
   comparison <- newWire ;;

--- a/cava/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/cava/Cava/Monad/UnsignedAdders.v
@@ -35,17 +35,17 @@ Proof.
   induction n.
   - reflexivity.
   - simpl. rewrite IHn. reflexivity.
-Defined.  
+Defined.
 
 Definition deMax {m bit} `{Cava m bit} {n} (v: Vector.t bit (1 + max n n)) :
                  Vector.t (smashTy bit Bit) (1+n).
 Proof.
   rewrite max_n_n in v.
   unfold smashTy. apply v.
-Defined. 
-   
+Defined.
+
 Definition addN {m bit} `{Cava m bit} {n}
-                (a: Vector.t bit n) (b: Vector.t bit n) : m (Vector.t bit n) :=               
+                (a: Vector.t bit n) (b: Vector.t bit n) : m (Vector.t bit n) :=
   s <- unsignedAdd a b ;;
   ret (slice 0 n (deMax s) (n_le_n_plus_1 _)).
 

--- a/cava/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/cava/Cava/Monad/XilinxAdder.v
@@ -13,7 +13,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool. 
+From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import NArith.
 
@@ -68,7 +68,7 @@ Qed.
 
 Definition xilinxAdderWithCarry {m bit} `{Cava m bit} {n: nat}
             (cinab : bit * (Vector.t bit n * Vector.t bit n))
-           : m (Vector.t bit n * bit) 
+           : m (Vector.t bit n * bit)
   := let '(cin, (a, b)) := cinab in
      '(sum, cout) <- colV n xilinxFullAdder cin (vcombine a b) ;;
      ret (sum, cout).
@@ -78,7 +78,7 @@ Example xilinx_add_17_52:
   combinational (xilinxAdderWithCarry
                 (false, (N2Bv_sized 8 17, N2Bv_sized 8 52))) =
                 (N2Bv_sized 8 69, false).
-Proof. reflexivity. Qed.                
+Proof. reflexivity. Qed.
 
 (******************************************************************************)
 (* An unsigned adder with no bit-growth and no carry in                       *)

--- a/cava/cava/Cava/Netlist.v
+++ b/cava/cava/Cava/Netlist.v
@@ -105,7 +105,7 @@ Inductive Instance : Type :=
   | UnsignedSubtract : forall {a b c : nat}, Signal (BitVec Bit a) ->
                                         Signal (BitVec Bit b) ->
                                         Signal (BitVec Bit c) ->
-                                        Instance                                      
+                                        Instance
   (* Relational operations *)
   | GreaterThanOrEqual: forall {a b : nat}, Signal (BitVec Bit a) ->
                                             Signal (BitVec Bit b) ->
@@ -155,17 +155,17 @@ Definition sequentialInterface {ciType coType}
                                (circuitName: string)
                                (clkName: string) (clkEdge: SignalEdge)
                                (rstName: string) (rstEdge: SignalEdge)
-                               (circuitInputs: ciType) 
+                               (circuitInputs: ciType)
                                (circuitOutputs: coType)
                                (attributes: list CircuitAttribute) :=
   mkCircuitInterface circuitName clkName clkEdge rstName rstEdge
-                     (toShape circuitInputs) (toShape circuitOutputs) attributes.                            
+                     (toShape circuitInputs) (toShape circuitOutputs) attributes.
 
 Definition combinationalInterface {ciType coType}
                                   `{@ToShape PortDeclaration ciType}
                                   `{@ToShape PortDeclaration coType}
                                   (circuitName: string)
-                                  (circuitInputs: ciType) 
+                                  (circuitInputs: ciType)
                                   (circuitOutputs: coType)
                                   (attributes: list CircuitAttribute) :=
   sequentialInterface circuitName "" PositiveEdge
@@ -233,7 +233,7 @@ Fixpoint addInstances (insts: list Instance) : state CavaState unit :=
   match insts with
   | [] => ret tt
   | x :: xs =>
-    addInstance x ;; 
+    addInstance x ;;
     addInstances xs
   end.
 
@@ -302,7 +302,7 @@ Definition getClockAndReset : state CavaState ((option (Signal Bit) * SignalEdge
   match cs with
   | mkCavaState _ vecCount vecDefs ext clk clkEdge rst rstEdge _ =>
      ret ((clk, clkEdge), (rst, rstEdge))
-  end.                                       
+  end.
 
 Definition inputBit (name : string) : state CavaState (Signal Bit) :=
   addInputPort (mkPort name Bit) ;;
@@ -330,11 +330,11 @@ Definition initStateFrom (startAt : N) : CavaState
 
 Definition initState : CavaState
   := initStateFrom 0.
-  
+
 (******************************************************************************)
 (* Execute a monadic circuit description and return the generated netlist.    *)
 (******************************************************************************)
-      
+
 Fixpoint instantiateInputPorts (inputs: @shape PortDeclaration) : state CavaState (signalSmashTy (mapShape port_shape inputs)) :=
   match inputs return state CavaState (signalSmashTy (mapShape port_shape inputs)) with
   | Empty => ret tt
@@ -377,7 +377,7 @@ Definition wireUpCircuit (intf : CircuitInterface)
   addInputPort (mkPort (rstName intf) Bit) ;;
   i <- instantiateInputPorts (circuitInputs intf) ;;
   o <- circuit i ;;
-  let outType := circuitOutputs intf in 
+  let outType := circuitOutputs intf in
   instantiateOutputPorts outType o.
 
 Fixpoint driveArguments (inputs: @shape (PortDeclaration * UntypedSignal)) : list (string * UntypedSignal) :=
@@ -428,7 +428,7 @@ Definition blackBox (intf : CircuitInterface)
   addInstance (Component (circuitName intf) [] (clkPort ++ rstPort ++ inputPorts ++ outputPorts)) ;;
   ret outputSignals.
 
-Definition makeNetlist (intf : CircuitInterface)                      
+Definition makeNetlist (intf : CircuitInterface)
                        (circuit : signalSmashTy (mapShape port_shape (circuitInputs intf)) ->
                                   state CavaState (signalSmashTy (mapShape port_shape (circuitOutputs intf)))) : CavaState
   := execState (wireUpCircuit intf circuit) initState.

--- a/cava/cava/Cava/Types.v
+++ b/cava/cava/Cava/Types.v
@@ -103,7 +103,7 @@ Fixpoint flattenShape {A} (s : @shape A) : list A :=
   | Tuple2 t1 t2 =>  flattenShape t1 ++ flattenShape t2
   end.
 
-(* 
+(*
 Drop the rightmost element of a tuple structure if it is Empty. e.g.
 
 withoutRightmostUnit ( Tuple2 x (Tuple2 y (Tuple2 z Empty)) )
@@ -185,8 +185,8 @@ Proof.
   f_equal.
 Defined.
 
-(* 
-Given a signal of some shape 'withoutRightmost S', 
+(*
+Given a signal of some shape 'withoutRightmost S',
 we can extend it with a rightmost value of tt to get a signal of shape 'S'.
 *)
 Fixpoint insertRightmostTt {A t}
@@ -195,10 +195,10 @@ Fixpoint insertRightmostTt {A t}
 Proof.
   induction A; simpl in *.
   exact tt.
-  exact s.  
+  exact s.
   destruct A2.
   - exact (s, tt).
-  - exact s.  
+  - exact s.
   - rewrite signal_tuple_is_tuple in s.
     refine ((fst s, _)).
     apply snd in s.
@@ -208,11 +208,11 @@ Defined.
 
 (*
 Given some function 'f' which takes as input a signal of shape 'A',
-we can return a function performing 'f' that takes an input of 
+we can return a function performing 'f' that takes an input of
 shape 'withoutRightmostUnit A' by first applying 'insertRightmostTt'
 and then performing 'f'.
 *)
-Fixpoint removeRightmostUnit {A B t} 
+Fixpoint removeRightmostUnit {A B t}
   (f: signalTy (Signal t) A -> B)
   : signalTy (Signal t) (withoutRightmostUnit A) -> B :=
   fun a => f (insertRightmostTt a).
@@ -262,7 +262,7 @@ Fixpoint vecLitS {k: Kind} (v: smashTy (Signal Bit) k) : Signal k :=
   | Void, _ => UndefinedSignal
   | ExternalType s, _ => UninterpretedSignal "vecLitS-error"
   end.
-  
+
 Fixpoint signalNetSmashTy (s : @shape Kind) : Type :=
   match s with
   | Empty  => unit

--- a/cava/experiments/timed_experiments/Timed.v
+++ b/cava/experiments/timed_experiments/Timed.v
@@ -50,14 +50,14 @@ Fixpoint runExpr (e: expr) :=
     end.
 
 Definition nand a b := Not (And a b).
-Definition xor a b := 
+Definition xor a b :=
     nand (nand a (nand a b)) (nand b (nand a b)).
 
-(* for combinational expressions, set inputs to singleton lists, 
+(* for combinational expressions, set inputs to singleton lists,
 and take the head of the result trace*)
 Definition combinational2 e a b: _ :=
     hd_error(runExpr (e
-                (Input (a :: nil)) 
+                (Input (a :: nil))
                 (Input (b :: nil))
                 )).
 
@@ -85,7 +85,7 @@ Eval simpl in zipWith xorb
             ( [false;false;true;true])
             ( [false;true;false;true]).
 
-Lemma pipelined_xor_delay_is_2: 
+Lemma pipelined_xor_delay_is_2:
     forall (i : Trace (bool * bool)),
     length (runExpr (pipelined_xor (map fst i) (map snd i))) = length i + 2.
 Proof.
@@ -97,7 +97,7 @@ Proof.
     reflexivity.
 Qed.
 
-Lemma pipelined_xor_is_xorb_delayed2_once: 
+Lemma pipelined_xor_is_xorb_delayed2_once:
     forall x y,
     tl(tl(runExpr (pipelined_xor [x] [y])))  = zipWith xorb [x] [y].
 Proof.
@@ -120,7 +120,7 @@ Lemma pipelined_xor_is_xorb_delayed2:
     forall (x y : Trace bool),
     length x = length y ->
     tl(tl(runExpr (pipelined_xor x y))) = zipWith xorb x y.
-Proof. 
+Proof.
     induction x.
     trivial.
     intros.
@@ -142,16 +142,16 @@ Qed.
 
 
 
-    
-    
 
 
 
 
 
-    
 
-    
+
+
+
+
 
 
 

--- a/cava/experiments/vector/VectorAdd.v
+++ b/cava/experiments/vector/VectorAdd.v
@@ -42,7 +42,7 @@ Definition vectorAddGrowth {width: nat}
   let c : N := aN + bN in
   N2Bv_sized (1 + width) c.
 
-Definition vectorAdd4Growth {width: nat} 
+Definition vectorAdd4Growth {width: nat}
                             (a: Bvector width)
                             (b: Bvector width)
                             (c: Bvector width)
@@ -60,13 +60,13 @@ Definition vectorAddGrowth2 {aWidth bWidth: nat}
   let c : N := aN + bN in
   N2Bv_sized (1 + max aWidth bWidth) c.
 
-Definition vectorAdd3Growth {aWidth bWidth cWidth: nat} 
+Definition vectorAdd3Growth {aWidth bWidth cWidth: nat}
                             (a: Bvector aWidth)
                             (b: Bvector bWidth)
                             (c: Bvector cWidth) :
                             Bvector (1 + max (1 + max aWidth bWidth) cWidth) :=
   let a_plus_b := vectorAddGrowth2 a b in
-  vectorAddGrowth2 a_plus_b c.  
+  vectorAddGrowth2 a_plus_b c.
 
 
 Local Open Scope vector_scope.

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -40,7 +40,7 @@ Require Import Cava.Monad.UnsignedAdders.
 
 Definition adderTree {m bit} `{Cava m bit} {sz: nat}
                      (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
-                     m (Vector.t bit sz) :=              
+                     m (Vector.t bit sz) :=
   tree n addN v.
 
 (******************************************************************************)
@@ -101,7 +101,7 @@ Local Open Scope N_scope.
 Definition adder_tree4_8_tb_inputs
   := map (fun i => Vector.map (N2Bv_sized 8) i)
      [[17;  42;  23;  95];
-      [ 4;  13; 200;  30]; 
+      [ 4;  13; 200;  30];
       [255; 74; 255; 200]
      ].
 

--- a/cava/monad-examples/FullAdderNat.v
+++ b/cava/monad-examples/FullAdderNat.v
@@ -20,7 +20,7 @@
 
 From Coq Require Import ZArith.
 From Coq Require Import ZArith.BinInt.
-From Coq Require Import Bool.Bool. 
+From Coq Require Import Bool.Bool.
 From Coq Require Import Ascii String.
 From Coq Require Import Lists.List.
 Require Import Nat Arith Lia.
@@ -50,7 +50,7 @@ Proof.
   all : simpl.
 Admitted.
 
-  
+
 Lemma fullAdderNat_correct :
   forall (a : N) (b : N) (cin : N), a < 2 -> b < 2 -> cin < 2 ->
   let '(sum, carry_out) := combinational (fullAdder (n2bool cin, (n2bool a, n2bool b))) in

--- a/cava/monad-examples/Multiplexers.v
+++ b/cava/monad-examples/Multiplexers.v
@@ -79,7 +79,7 @@ Definition mux2_1_tb
 
   Definition mux2_1_bit {m bit} `{Cava m bit} {sz isz: nat}
                         (vsel: Vector.t bit sz * Vector.t bit isz) : m bit :=
-  let (v, sel) := vsel in 
+  let (v, sel) := vsel in
   ret (indexBitAt v sel).
 
    Definition v := N2Bv_sized 4  11.
@@ -106,14 +106,14 @@ Definition mux2_1_tb
 
    Example index_bit_3 : combinational (mux2_1_bit (v, i3)) = true.
    Proof. reflexivity. Qed.
- 
+
   Definition mux2_1_bit_Interface
     := combinationalInterface "mux2_1_bit"
        (mkPort "v" (BitVec Bit 4),
         mkPort "sel" (BitVec Bit 2))
        (mkPort "o" Bit)
        [].
-       
+
   Definition mux2_1_bit_Netlist := makeNetlist mux2_1_bit_Interface mux2_1_bit.
 
   Definition mux2_1_bit_tb_inputs :=
@@ -147,7 +147,7 @@ Definition muxBus {m bit} `{Cava m bit} {sz isz dsz: nat}
   let (v, sel) := vsel in
   ret (indexAt v sel).
 
-Definition muxBus4_8 {m bit} `{Cava m bit} 
+Definition muxBus4_8 {m bit} `{Cava m bit}
                      (vsel: Vector.t (smashTy bit (BitVec Bit 8)) 4 *
                             Vector.t bit 2) :
                      m (smashTy bit (BitVec Bit 8)) :=

--- a/cava/monad-examples/Sorter.v
+++ b/cava/monad-examples/Sorter.v
@@ -86,7 +86,7 @@ Definition twoSorterSpec {bw: nat} (ab : Vector.t (Bvector bw) 2) :
   if N.to_nat (Bv2N b) <=? N.to_nat (Bv2N a) then
     [b; a]
   else
-    [a; b].                                      
+    [a; b].
 
 Lemma two_sorter_correct: forall (n m: nat) (a b: Bvector m),
       combinational (twoSorter [a; b]) = twoSorterSpec [a; b].

--- a/cava/monad-examples/UnsignedAdderExamples.v
+++ b/cava/monad-examples/UnsignedAdderExamples.v
@@ -66,7 +66,7 @@ Proof. reflexivity. Qed.
 Definition adderGrowth {m bit} `{Cava m bit} {aSize bSize: nat}
                        (ab: Vector.t bit aSize * Vector.t bit bSize) :
                        m (Vector.t bit (1 + max aSize bSize)) :=
-  let (a, b) := ab in                     
+  let (a, b) := ab in
   unsignedAdd a b.
 
 (* Check 0 + 0 = 0 *)

--- a/cava/monad-examples/bits.v
+++ b/cava/monad-examples/bits.v
@@ -11,7 +11,7 @@ Definition nat_to_pair (n:nat) : bool * bool :=
   | 3 => (true, true)
   | _ => (false, false)
   end.
-  
+
 Definition pair_to_nat (p:bool * bool) : nat :=
   match p with
   | (false, false) => 0
@@ -25,7 +25,7 @@ Proof.
   intros n H.
   repeat (destruct n; [reflexivity |]).
   lia.
-Qed.  
+Qed.
 
 
 (* Option 2: More general, list representation *)
@@ -63,8 +63,8 @@ Qed.
 
 (*
   The list-of-bits representation is not canonical because leading
-  0's don't contribute to the final value.  Therefore we can 
-  put the list of bits into canonical form by trimming leading 
+  0's don't contribute to the final value.  Therefore we can
+  put the list of bits into canonical form by trimming leading
   0's.
 *)
 Fixpoint canonicalize_bits (bits : list bool) : list bool :=
@@ -84,7 +84,7 @@ Eval compute in (low_bit 7).
 (*
   The recursion structure for converting a nat to bits is based on
   division by two / bit-shifting, which isn't purely structural on the
-  Zero + Successor version of nats.  One way around that is to define 
+  Zero + Successor version of nats.  One way around that is to define
   a slightly different recursion principle that folds by div2.
 
   It may be worth checking out BinNat too.
@@ -134,7 +134,7 @@ Proof.
     reflexivity.
     repeat rewrite Nat.shiftl_0_l.
     simpl. reflexivity.
-Qed.   
+Qed.
 
 
 Lemma nat_to_bits'_correct : forall n, bits_to_nat (nat_to_bits' n) = n.
@@ -158,5 +158,5 @@ Proof.
     destruct (le_lt_dec x 0).
     + reflexivity.
     + rewrite H0. reflexivity.
-Qed.      
-      
+Qed.
+

--- a/cava/monad-examples/xilinx/XilinxAdderTree.v
+++ b/cava/monad-examples/xilinx/XilinxAdderTree.v
@@ -39,7 +39,7 @@ Require Import Cava.Monad.XilinxAdder.
 
 Definition adderTree {m bit} `{Cava m bit} {sz: nat}
                      (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
-                     m (Vector.t bit sz) := 
+                     m (Vector.t bit sz) :=
   tree n xilinxAdder v.
 
 (******************************************************************************)

--- a/cava/tests/xilinx/LUTTests.v
+++ b/cava/tests/xilinx/LUTTests.v
@@ -62,7 +62,7 @@ Definition lut2_and_Interface
 Definition lut2_and_nelist := makeNetlist lut2_and_Interface lut2_and.
 
 Definition lut2_and_tb_inputs : list (bool * bool) :=
- [(false, false); (false, true); (true, false); (true, true)].       
+ [(false, false); (false, true); (true, false); (true, true)].
 
  Definition lut2_and_tb_expected_outputs : list bool :=
   map (fun i => combinational (lut2_and i)) lut2_and_tb_inputs.
@@ -207,4 +207,4 @@ Definition lut6_and_tb_expected_outputs : list bool :=
 
 Definition lut6_and_tb :=
   testBench "lut6_and_tb" lut6_and_Interface
-  lut6_and_tb_inputs lut6_and_tb_expected_outputs.   
+  lut6_and_tb_inputs lut6_and_tb_expected_outputs.

--- a/remove-trailing-whitespace.sh
+++ b/remove-trailing-whitespace.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git ls-files $(git rev-parse --show-toplevel) | grep "\.v$" | xargs sed -i -E 's/\s+$//g'


### PR DESCRIPTION
As per https://github.com/project-oak/oak-hardware/pull/209#discussion_r492446055

Removes all trailing whitespace from Coq source files! The only new code here is the script that does the magic, `remove-trailing-whitespace.sh`. 