### PR TITLE
Add .nia.cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ work-obj93.cf
 */xsim.dir/*
 *~
 *.lia.cache
+*.nia.cache
 *\#*


### PR DESCRIPTION
The autogenerated file `.nia.cache` showed up in my `git status`. This PR prevents it from doing that again!