### PR TITLE
Tree combinator proofs

### DIFF
--- a/cava/cava/Cava/ListUtils.v
+++ b/cava/cava/Cava/ListUtils.v
@@ -1,0 +1,64 @@
+Require Import Coq.Lists.List.
+
+(* Proofs about fold_right and fold_left *)
+Section Folds.
+  Context {A : Type}.
+
+  Lemma fold_left_assoc (f : A -> A -> A) id
+        (right_identity : forall a, f a id = a)
+        (left_identity : forall a, f id a = a)
+        (associative :
+           forall a b c, f a (f b c) = f (f a b) c) :
+    forall l start,
+      fold_left f l start = f start (fold_left f l id).
+  Proof.
+    induction l; cbn [fold_left]; intros.
+    { rewrite right_identity. reflexivity. }
+    { rewrite left_identity.
+      rewrite IHl, <-associative, <-IHl.
+      reflexivity. }
+  Qed.
+End Folds.
+
+Ltac destruct_lists_by_length :=
+  repeat
+    match goal with
+    | H : length ?l = S _ |- _ =>
+      destruct l; cbn [length] in *; [ congruence | apply eq_add_S in H ]
+    | H : length ?l = 0 |- _ =>
+      destruct l; cbn [length] in *; [ | congruence ]
+    end.
+
+Section DestructListsByLengthTests.
+  (* list with length 0 *)
+  Goal (forall (l : list nat),
+           length l = 0 -> l = nil).
+  Proof.
+    intros. destruct_lists_by_length.
+    (* since l should be destructed, [nil=nil] should be left over *)
+    exact (eq_refl nil).
+  Qed.
+
+  (* list with length (S n) *)
+  Goal (forall (l : list nat) (n : nat),
+           length l = S n -> length (tl l) = n).
+  Proof.
+    intros. destruct_lists_by_length.
+    (* we should now have an expression of the form tl (_ :: _) *)
+    progress cbn [tl]. assumption.
+  Qed.
+
+  (* multiple constant-length lists *)
+  Goal (forall (l1 l2 : list nat),
+           length l1 = 1 ->
+           length l2 = 2 ->
+           length (l1 ++ l2) = 3).
+  Proof.
+    intros. destruct_lists_by_length.
+    (* now, we expect l1 and l2 to be fully destructed *)
+    match goal with
+    | |- length ((_ :: nil) ++ (_ :: _ :: nil)) = 3 => idtac
+    end.
+    reflexivity.
+  Qed.
+End DestructListsByLengthTests.

--- a/cava/cava/Cava/VectorUtils.v
+++ b/cava/cava/Cava/VectorUtils.v
@@ -195,3 +195,155 @@ Fixpoint listToAltVector {A: Type} (l: list A) : AltVector A (length l) :=
   | x::xs => vec_cons (consAltVector x (listToAltVector xs))
   end.
 
+Section resize.
+  Context {A:Type}.
+  Local Notation t := (Vector.t). (* for more concise type declarations *)
+
+  Definition resize {n} m (Hlen : n = m) (v : t A n) : t A m.
+    subst; apply v.
+  Defined.
+
+  Fixpoint resize_default {n} default : forall m, t A n -> t A m :=
+    match n as n0 return forall m, t A n0 -> t A m with
+    | O => fun m _ => Vector.const default m
+    | S n' =>
+      fun m v =>
+        match m with
+        | O => Vector.nil _
+        | S m' => (Vector.hd v :: resize_default default m' (Vector.tl v))%vector
+        end
+    end.
+
+  Lemma resize_default_id n d (v : t A n) :
+    resize_default d n v = v.
+  Proof.
+    induction n; intros;
+      [ eapply case0 with (v:=v); reflexivity | ].
+    cbn [resize_default]. rewrite IHn.
+    rewrite <-eta; reflexivity.
+  Qed.
+
+  Lemma resize_default_eq n m d H (v : t A n) :
+    resize m H v = resize_default d m v.
+  Proof.
+    subst. rewrite resize_default_id. reflexivity.
+  Qed.
+
+  Lemma resize_prf_irr n m Hlen1 Hlen2 (v : t A n) :
+    resize m Hlen1 v = resize m Hlen2 v.
+  Proof.
+    subst. rewrite (Eqdep_dec.UIP_refl_nat _ Hlen2).
+    reflexivity.
+  Qed.
+
+  Lemma resize_id n H (v : t A n) : v = resize n H v.
+  Proof. rewrite resize_prf_irr with (Hlen2:=eq_refl). reflexivity. Qed.
+
+  Lemma resize_cons n m Hlen a (v : t A n) :
+    resize (S m) Hlen (a :: v)%vector = (a :: resize m (eq_add_S _ _ Hlen) v)%vector.
+  Proof.
+    intros. assert (n = m) by lia. subst.
+    rewrite <-!resize_id. reflexivity.
+  Qed.
+
+  Lemma resize_resize n m p Hlen1 Hlen2 (v : t A n) :
+    resize p Hlen2 (resize m Hlen1 v) = resize p (eq_trans Hlen1 Hlen2) v.
+  Proof. subst; reflexivity. Qed.
+
+  Lemma fold_left_resize {B} (f : B -> A -> B) n m H b (v : t A n) :
+    Vector.fold_left f b (resize m H v) = Vector.fold_left f b v.
+  Proof. subst. rewrite <-resize_id. reflexivity. Qed.
+End resize.
+
+(* Miscellaneous facts about vectors *)
+Section VectorFacts.
+  Local Notation t := Vector.t.
+
+  Lemma tl_0 {A} (v : t A 1) : Vector.tl v = Vector.nil A.
+  Proof.
+    eapply case0 with (v:=Vector.tl v).
+    reflexivity.
+  Qed.
+
+  Lemma hd_0 {A} (v : t A 1) : Vector.hd v = Vector.last v.
+  Proof.
+    rewrite (eta v).
+    eapply case0 with (v:=Vector.tl v).
+    reflexivity.
+  Qed.
+
+  Lemma last_tl {A} n (v : t A (S (S n))) :
+    Vector.last (Vector.tl v) = Vector.last v.
+  Proof. rewrite (eta v); reflexivity. Qed.
+
+  Lemma fold_left_S {A B : Type} (f : B -> A -> B) b n (v : t A (S n)) :
+      Vector.fold_left f b v = Vector.fold_left
+                                 f (f b (Vector.hd v)) (Vector.tl v).
+  Proof. rewrite (eta v). reflexivity. Qed.
+
+  Lemma fold_left_0 {A B : Type} (f : B -> A -> B) b (v : t A 0) :
+      Vector.fold_left f b v = b.
+  Proof. eapply case0 with (v:=v). reflexivity. Qed.
+
+  Lemma fold_left_append {A B} (f : A -> B -> A) :
+    forall n m start (v1 : t B n) (v2 : t B m),
+      Vector.fold_left f start (v1 ++ v2)%vector
+      = Vector.fold_left f (Vector.fold_left f start v1) v2.
+  Proof.
+    induction n; intros;
+      lazymatch goal with
+      | v' : t _ 0 |- _ =>
+        eapply case0 with (v:=v')
+      | v : t _ (S _) |- _ => rewrite (eta v)
+      end;
+      [ reflexivity | ].
+    rewrite <-append_comm_cons.
+    cbn [Vector.fold_left].
+    rewrite IHn. reflexivity.
+  Qed.
+
+  Lemma fold_left_S_identity {A} (f : A -> A -> A) id
+        (left_identity : forall a, f id a = a) n (v : t A (S n)) :
+    Vector.fold_left f id v = Vector.fold_left f (Vector.hd v) (Vector.tl v).
+  Proof.
+    intros. rewrite (eta v).
+    rewrite !fold_left_S, left_identity.
+    reflexivity.
+  Qed.
+
+  Hint Rewrite @fold_left_S @fold_left_0
+       using solve [eauto] : push_vector_fold vsimpl.
+
+  Lemma fold_left_S_assoc {A} (f : A -> A -> A) id
+        (right_identity : forall a, f a id = a)
+        (left_identity : forall a, f id a = a)
+        (associative :
+           forall a b c, f a (f b c) = f (f a b) c) :
+    forall n start (v : t A n),
+      Vector.fold_left f start v = f start (Vector.fold_left f id v).
+  Proof.
+    induction n; intros; autorewrite with push_vector_fold.
+    { rewrite right_identity. reflexivity. }
+    { rewrite left_identity.
+      erewrite <-fold_left_S_identity by eauto.
+      rewrite IHn, <-associative.
+      rewrite fold_left_S with (b:=id).
+      f_equal. rewrite !left_identity, <-IHn.
+      reflexivity. }
+  Qed.
+End VectorFacts.
+(* These hints create and populate the following autorewrite databases:
+ * - push_vector_fold : simplify using properties of Vector.fold_left
+ * - push_vector_tl_hd_last : simplify using properties of Vector.tl, Vector.hd,
+     and Vector.last
+ * - push_vector_nth_order : simplify expressions containing Vector.nth_order
+ * - vsimpl : generic vector simplification, includes all of the above
+ *
+ * No hint added to one of these databases should leave any subgoals unsolved.
+ *)
+Hint Rewrite @fold_left_S @fold_left_0
+     using solve [eauto] : push_vector_fold vsimpl.
+Hint Rewrite @tl_0 @hd_0 @last_tl
+     using solve [eauto] : push_vector_tl_hd_last vsimpl.
+Hint Rewrite @nth_order_hd @nth_order_last
+     using solve [eauto] : push_vector_nth_order vsimpl.

--- a/cava/cava/_CoqProject
+++ b/cava/cava/_CoqProject
@@ -1,6 +1,7 @@
 -R Cava Cava
 -R ../arrow-lib Arrow
 
+Cava/ListUtils.v
 Cava/VectorUtils.v
 Cava/BitArithmetic.v
 Cava/Cava.v

--- a/cava/monad-examples/AdderTree.v
+++ b/cava/monad-examples/AdderTree.v
@@ -39,9 +39,10 @@ Require Import Cava.Monad.UnsignedAdders.
 (******************************************************************************)
 
 Definition adderTree {m bit} `{Cava m bit} {sz: nat}
-                     (n: nat) (v: Vector.t (Vector.t bit sz) (2^(n+1))) :
+                     (default : bit)
+                     (n: nat) (v: Vector.t (Vector.t bit sz) (2^(S n))) :
                      m (Vector.t bit sz) :=
-  tree n addN v.
+  tree (Vector.const default _) n addN v.
 
 (******************************************************************************)
 (* Some tests.                                                                *)
@@ -60,27 +61,29 @@ Local Open Scope string_scope.
 Local Open Scope nat_scope.
 
 Definition adderTree2 {m bit} `{Cava m bit} {sz: nat}
+                      (default : bit)
                       (v : Vector.t (Vector.t bit sz) 2) : m (Vector.t bit sz)
-  := adderTree 0 v.
+  := adderTree default 0 v.
 
 Local Open Scope vector_scope.
 
 Definition v0_v1 := [v0; v1].
-Definition v0_plus_v1 : Bvector 8 := combinational (adderTree 0 v0_v1).
+Definition v0_plus_v1 : Bvector 8 := combinational (adderTree false 0 v0_v1).
 
-Example sum_vo_v1 : combinational (adderTree2 v0_v1) = N2Bv_sized 8 21.
+Example sum_vo_v1 : combinational (adderTree2 false v0_v1) = N2Bv_sized 8 21.
 Proof. reflexivity. Qed.
 
 (* An adder tree with 4 inputs. *)
 
 Definition adderTree4 {m bit} `{Cava m bit} {sz: nat}
+                      (default : bit)
                       (v : Vector.t (Vector.t bit sz) 4) : m (Vector.t bit sz)
-  := adderTree 1 v.
+  := adderTree default 1 v.
 
 Definition v0_3 := [v0; v1; v2; v3].
-Definition sum_v0_3 : Bvector 8 := combinational (adderTree4 v0_3).
+Definition sum_v0_3 : Bvector 8 := combinational (adderTree4 false v0_3).
 
-Example sum_v0_v1_v2_v3 : combinational (adderTree4 v0_3) = N2Bv_sized 8 30.
+Example sum_v0_v1_v2_v3 : combinational (adderTree4 false v0_3) = N2Bv_sized 8 30.
 Proof. reflexivity. Qed.
 
 Definition adder_tree_Interface name nrInputs bitSize
@@ -94,7 +97,7 @@ Definition adder_tree_Interface name nrInputs bitSize
 Definition adder_tree4_8Interface := adder_tree_Interface "adder_tree4_8" 4 8.
 
 Definition adder_tree4_8Netlist
-  := makeNetlist adder_tree4_8Interface adderTree4.
+  := makeNetlist adder_tree4_8Interface (adderTree4 Gnd).
 
 Local Open Scope N_scope.
 
@@ -106,7 +109,7 @@ Definition adder_tree4_8_tb_inputs
      ].
 
 Definition adder_tree4_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree4 i)) adder_tree4_8_tb_inputs.
+  := map (fun i => combinational (adderTree4 false i)) adder_tree4_8_tb_inputs.
 
 Definition adder_tree4_8_tb :=
   testBench "adder_tree4_8_tb" adder_tree4_8Interface
@@ -118,7 +121,7 @@ Definition adder_tree32_8Interface
   := adder_tree_Interface "adder_tree32_8" 32 8.
 
 Definition adder_tree32_8Netlist
-  := makeNetlist adder_tree32_8Interface (adderTree 4).
+  := makeNetlist adder_tree32_8Interface (adderTree Gnd 4).
 
 (* Create netlist and test-bench for a 64-input adder tree. *)
 
@@ -126,7 +129,7 @@ Definition adder_tree64_8Interface
   := adder_tree_Interface "adder_tree64_8" 64 8.
 
 Definition adder_tree64_8Netlist
-  := makeNetlist adder_tree64_8Interface (adderTree 5).
+  := makeNetlist adder_tree64_8Interface (adderTree Gnd 5).
 
 Definition adder_tree64_8_tb_inputs
   := map (Vector.map (N2Bv_sized 8))
@@ -134,7 +137,7 @@ Definition adder_tree64_8_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_8_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_8_tb_inputs.
+  := map (fun i => combinational (adderTree false 5 i)) adder_tree64_8_tb_inputs.
 
 Definition adder_tree64_8_tb :=
   testBench "adder_tree64_8_tb" adder_tree64_8Interface
@@ -145,7 +148,7 @@ Definition adder_tree64_8_tb :=
 Definition adder_tree64_128Interface := adder_tree_Interface "adder_tree64_128" 64 128.
 
 Definition adder_tree64_128Netlist
-  := makeNetlist adder_tree64_128Interface (adderTree 5).
+  := makeNetlist adder_tree64_128Interface (adderTree Gnd 5).
 
 Definition adder_tree64_128_tb_inputs
   := map (Vector.map (N2Bv_sized 128))
@@ -153,7 +156,7 @@ Definition adder_tree64_128_tb_inputs
      [vseq 0 64; vseq 64 64; vseq 128 64]).
 
 Definition adder_tree64_128_tb_expected_outputs
-  := map (fun i => combinational (adderTree 5 i)) adder_tree64_128_tb_inputs.
+  := map (fun i => combinational (adderTree false 5 i)) adder_tree64_128_tb_inputs.
 
 Definition adder_tree64_128_tb :=
   testBench "adder_tree64_128_tb" adder_tree64_128Interface


### PR DESCRIPTION
Here's the tree combinator proofs I walked through in the last meeting. I'll recap here anyway for archival purposes. The main punchlines are the proofs `tree_equiv` and `treeList_equiv`, both in `Combinators.v`, which serve as the proofs of functional correctness for the preexisting tree combinator operations. In order to prove them, I also needed various proofs about vectors and lists which now live in `VectorUtils.v` and the new file `ListUtils.v`. I created a helper tactic for lists that's pretty generic, so I went ahead and made it exported from `ListUtils.v` and added some tests for it to make it more robust.

### New `resize` definition for vectors

Proving the vector tree combinator as-is was tricky because of vector size coercions, so I created a new definition `resize` that, given a vector and a proof that its is equal to a target size, produces a vector with the target size. For example, it can change a vector of size `2+3` to a vector of size `5`. The `resize` definition pretty much just hides a `rew` behind a definition label, but that makes the `rew` much easier to reason about because I could define a bunch of lemmas about `resize` and use them instead of reasoning about `rew` directly.

### The `resize_default` variant

Although I managed to prove the vector tree combinator proof with that method, I later switched to using `resize_default`, a version of `resize` that uses truncation/default values to coerce a vector to the target size no matter whether the size matches or not. There are two advantages of this strategy. The first is that it actually ends up making proof reasoning easier, because mismatches in the proof arguments don't cause problems. The second is performance.

### Performance comparisons

I used the three versions of tree combinators (list-based, vector-based using `resize`, vector-based using `resize_default`) to make some trees of simple `orb` computations, then tested out fully computing them on different sizes of input. Note that the x-axis here is exponential in number of bits.

![combinator_performance_comparison](https://user-images.githubusercontent.com/6509194/93926681-59b73a00-fd07-11ea-84c2-4e0f3d9cf380.png)
