### PR TITLE
Proofs about circuit_equiv

### DIFF
--- a/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -14,6 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+From coqutil Require Import Tactics.Tactics.
 From Arrow Require Import Category Arrow.
 From Cava.Arrow Require Import ArrowKind CircuitArrow CircuitSemantics
      ExprSyntax ExprLowering.
@@ -26,58 +27,106 @@ Inductive circuit_equiv: forall i o, Circuit i o -> (denote_kind i -> denote_kin
     (forall a:denote_kind x, r a = r2 (r1 a) ) ->
     circuit_equiv x z (Composition _ _ _ c1 c2) r
 
-  | Uncancell_equiv: forall x,
-    circuit_equiv x (Tuple Unit x) (Structural (Uncancell x)) (fun a => (tt, a))
-  | Uncancelr_equiv: forall x,
-    circuit_equiv x (Tuple x Unit) (Structural (Uncancelr x)) (fun a => (a, tt))
+  | Uncancell_equiv: forall x r,
+    (forall a, r a = (tt, a)) ->
+    circuit_equiv x (Tuple Unit x) (Structural (Uncancell x)) r
+  | Uncancelr_equiv: forall x r,
+    (forall a, r a = (a, tt)) ->
+    circuit_equiv x (Tuple x Unit) (Structural (Uncancelr x)) r
 
-  | Cancell_equiv: forall x,
-    circuit_equiv (Tuple Unit x) x (Structural (Cancell x)) (fun a => snd a)
-  | Cancelr_equiv: forall x,
-    circuit_equiv (Tuple x Unit) x (Structural (Cancelr x)) (fun a => fst a)
+  | Cancell_equiv: forall x r,
+    (forall a, r a = @snd _ (denote_kind x) a) ->
+    circuit_equiv (Tuple Unit x) x (Structural (Cancell x)) r
+  | Cancelr_equiv: forall x r,
+    (forall a, r a = @fst (denote_kind x) _ a) ->
+    circuit_equiv (Tuple x Unit) x (Structural (Cancelr x)) r
 
   | First_equiv: forall x y z c r r1,
     circuit_equiv x y c r1 ->
-    (forall a, r a = (r1 (fst a), snd a)) ->
+    (forall a : denote_kind x * denote_kind z, r a = (r1 (fst a), snd a)) ->
     circuit_equiv (Tuple x z) (Tuple y z) (First x y z c) r
 
   | Second_equiv: forall x y z c r r1,
     circuit_equiv x y c r1 ->
-    (forall a, r a = (fst a, r1 (snd a))) ->
+    (forall a : denote_kind z * denote_kind x, r a = (fst a, r1 (snd a))) ->
     circuit_equiv (Tuple z x) (Tuple z y) (Second x y z c) r
 
-  | Swap_equiv: forall x y,
-    circuit_equiv (Tuple x y) (Tuple y x) (Structural (Swap x y)) (fun a => (snd a, fst a))
-  | Drop_equiv: forall x,
-    circuit_equiv x Unit (Structural (Drop x)) (fun a => tt)
-  | Copy_equiv: forall x,
-    circuit_equiv x (Tuple x x) (Structural (Copy x)) (fun a => (a,a))
+  | Swap_equiv: forall x y r,
+    (forall a : denote_kind x * denote_kind y, r a = (snd a, fst a)) ->
+    circuit_equiv (Tuple x y) (Tuple y x) (Structural (Swap x y)) r
+  | Drop_equiv: forall x r,
+    (forall a, r a = tt) ->
+    circuit_equiv x Unit (Structural (Drop x)) r
+  | Copy_equiv: forall x r,
+    (forall a, r a = (a,a)) ->
+    circuit_equiv x (Tuple x x) (Structural (Copy x)) r
 
-  | Assoc_equiv: forall x y z,
+  | Assoc_equiv: forall x y z r,
+    (forall i : denote_kind x * denote_kind y * denote_kind z,
+      r i = (fst (fst i), (snd (fst i), snd i))) ->
     circuit_equiv (Tuple (Tuple x y) z) (Tuple x (Tuple y z))
-    (Structural (Assoc x y z)) (fun i => (fst (fst i), (snd (fst i), snd i)))
-  | Unassoc_equiv: forall x y z,
+    (Structural (Assoc x y z)) r
+  | Unassoc_equiv: forall x y z r,
+    (forall i : denote_kind x * (denote_kind y * denote_kind z),
+      r i = ((fst i, fst (snd i)), snd (snd i))) ->
     circuit_equiv (Tuple x (Tuple y z)) (Tuple (Tuple x y) z)
-    (Structural (Unassoc x y z)) (fun i => ((fst i, fst (snd i)), snd (snd i)))
+    (Structural (Unassoc x y z)) r
 
-  | Id_equiv: forall x,
-    circuit_equiv x x (Structural (Arrow.Id x)) (fun a => a)
+  | Id_equiv: forall x r,
+    (forall a, r a = a) ->
+    circuit_equiv x x (Structural (Arrow.Id x)) r
 
   | Map_equiv: forall x y n c r r1,
     circuit_equiv x y c r1 ->
     (forall v, r v = Vector.map r1 v) ->
     circuit_equiv (Vector x n) (Vector y n) (Map x y n c) r
 
-  | Resize_equiv: forall x n nn,
-    circuit_equiv (Vector x n) (Vector x nn) (Resize x n nn)
-      (fun v => resize_default (kind_default _) nn v)
+  | Resize_equiv: forall x n nn r,
+    (forall v, r v = resize_default (kind_default _) nn v) ->
+    circuit_equiv (Vector x n) (Vector x nn) (Resize x n nn) r
 
-  | Primtive_equiv: forall p,
-    circuit_equiv (primitive_input p) (primitive_output p) (CircuitArrow.Primitive p) (combinational_evaluation' (CircuitArrow.Primitive p))
+  | Primtive_equiv: forall p r,
+    (forall a, r a = combinational_evaluation' (CircuitArrow.Primitive p) a) ->
+    circuit_equiv (primitive_input p) (primitive_output p)
+                  (CircuitArrow.Primitive p) r
 
   (* | Any_equiv: forall i o c, *)
   (*   circuit_equiv i o c (combinational_evaluation' c) *)
 .
+
+Lemma circuit_equiv_ext {i o} c spec1 spec2 :
+  (forall x, spec1 x = spec2 x) -> circuit_equiv i o c spec1 ->
+  circuit_equiv i o c spec2.
+Proof.
+  intro Hspec; induction 1.
+  all:(econstructor; eauto; [ ]).
+  all:intros; rewrite <-Hspec; eauto.
+Qed.
+
+Lemma circuit_equiv_implies_combinational_evaluation' {i o} c spec :
+  circuit_equiv i o c spec ->
+  (forall input : denote_kind i, spec input = combinational_evaluation' c input).
+Proof.
+  induction 1; cbn [combinational_evaluation' denote_kind]; intros.
+  all: repeat match goal with
+              | Hr : forall a, ?r a = _ |- _ => rewrite Hr
+              end.
+  all:destruct_products; cbn [fst snd].
+  all:eauto using Vector.map_ext.
+Qed.
+
+Lemma circuit_equiv_combinational_evaluation' {i o} c :
+  circuit_equiv i o c (combinational_evaluation' c).
+Proof.
+  induction c; cbn [combinational_evaluation']; intros.
+  all:try match goal with
+          | x : ArrowStructure |- _ => destruct x
+          | x : CircuitPrimitive |- _ => destruct x
+          end.
+  all:try econstructor; eauto.
+  all:intros; destruct_products; eauto.
+  (* TODO: loop cases missing *)
+Abort.
 
 (* wrapper for circuit_equiv that keeps goals in standard, recursion-friendly form *)
 Definition obeys_spec {i o}
@@ -95,12 +144,11 @@ Lemma obeys_spec_to_circuit_equiv i o c spec :
                 (fun x => spec (Datatypes.fst x)).
 Proof. intro H; exact H. Qed.
 
-Hint Unfold cancell cancelr uncancell uncancelr assoc unassoc first second
-     copy drop swap compose
-     CircuitCat CircuitArrow CircuitArrowSwap CircuitArrowDrop CircuitArrowCopy
-     arrow_category as_kind Datatypes.length Nat.eqb extract_nth
-     rewrite_or_default
-  : arrowunfold.
+Ltac arrowsimpl :=
+  cbn [cancell cancelr uncancell uncancelr assoc unassoc first second copy drop
+               swap compose CircuitCat CircuitArrow CircuitArrowSwap
+               CircuitArrowDrop CircuitArrowCopy arrow_category as_kind
+               Datatypes.length Nat.eqb extract_nth rewrite_or_default ].
 
 (* Add [obeys_spec] proofs to this hint database, and circuit_spec will use
    them *)
@@ -114,14 +162,14 @@ Ltac circuit_spec_step :=
   | |- circuit_equiv _ _ ?c _ =>
     lazymatch c with
     | closure_conversion' _ _ =>
-      (* subcircuit *)
       apply obeys_spec_to_circuit_equiv;
       solve [eauto with circuit_spec_correctness]
-    | _ => econstructor; intros
+    | _ => first [ econstructor; intros
+                | solve [eauto with circuit_spec_correctness] ]
     end
   | |- ?x => fail "Stuck at" x
   end.
 Ltac circuit_spec :=
-  cbv [obeys_spec]; cbn [closure_conversion']; autounfold with arrowunfold;
+  cbv [obeys_spec]; cbn [closure_conversion']; arrowsimpl;
   repeat circuit_spec_step; cbn [denote_kind combinational_evaluation' fst snd].
 

--- a/cava/cava/Cava/Arrow/CircuitProp.v
+++ b/cava/cava/Cava/Arrow/CircuitProp.v
@@ -28,6 +28,7 @@ Fixpoint no_delays {i o} (c: Circuit i o): bool :=
   | Second _ _ _ f => no_delays f
   | Loopr _ _ _ f => no_delays f
   | Loopl _ _ _ f => no_delays f
+  | Map _ _ _ f => no_delays f
   | _ => true
   end.
 
@@ -38,6 +39,7 @@ Fixpoint no_loops {i o} (c: Circuit i o): bool :=
   | Second _ _ _ f => no_loops f
   | Loopr _ _ _ f => false
   | Loopl _ _ _ f => false
+  | Map _ _ _ f => no_loops f
   | _ => true
   end.
 


### PR DESCRIPTION
I've been working on getting an AES top-level proof (top-level circuit proven assuming its subroutines are correct) put together, and in the process I found it useful to:
- change the definition of `circuit_equiv` so it obeys functional extensionality (i.e. if a circuit `c` matches the behavior of a function `s`, and the spec `s'` produces the same result as `s` for all inputs, then `c` matches the behavior of `s'` as well)
- prove that `circuit_equiv` now obeys functional extensionality
- make the `circuit_spec` tactic use `cbn` instead of `unfold`

Then, kind of unrelatedly, I decided to take a stab at proving that `circuit_equiv` between a circuit and a spec (function) implies that the spec is equivalent to `combinational_evaluation'` of the circuit, which is a proof we eventually need for the full chain of reasoning. Turns out it was surprisingly simple and "just worked", so it's here too!

I started writing a proof that all circuits are related by `circuit_equiv` to their evaluation, but there are a couple leftover goals for loops because `circuit_equiv` doesn't have cases for those yet. I left the proof `Abort`ed so we can fill it in later; that property isn't directly needed but might come in handy, and serves as a good sanity check.

CC: @satnam6502 (who probably doesn't have time to review!)