### PR TITLE
Many, many useful proofs about vectors

### DIFF
--- a/cava/cava/Cava/Monad/Combinators.v
+++ b/cava/cava/Cava/Monad/Combinators.v
@@ -403,7 +403,7 @@ Lemma tree_equiv
 Proof.
   induction n; intros.
   { change (2 ^ 1) with 2 in *.
-    cbn [tree]. autorewrite with vsimpl.
+    cbn [tree]. autorewrite with push_vector_fold vsimpl.
     rewrite circuit_equiv, op_id_left. reflexivity. }
   { cbn [tree]. destruct_pair_let.
     rewrite !IHn by eauto.


### PR DESCRIPTION
In the course of proving specifications for various arrow combinators, I accumulated a whole bunch of general `Vector.t` proofs. This PR adds those to `VectorUtils.v`. In order to make the proofs easier, I changed some of the custom vector functions (`vreverse`, `vsnoc`, and `vunsnoc`) to recurse on the *length* of the vector, instead of on the vector itself.

The one other change here is that I took `fold_left_S` out of the `vsimpl` set of rewrite hints. The problem is that it triggers any time it sees `fold_left` with a length that matches `S _` -- and `4` is just a notation for `S (S (S (S 0)))`, so if you have a `fold_left` with length 8 it'll apply itself 8 times and make your goal huge. It's still added to the `push_vector_fold` set of hints, so you can get the same behavior as before by writing `autorewrite with push_vector_fold vsimpl` instead of just `autorewrite with vsimpl`, but you have more control over whether that particular lemma gets used.