### PR TITLE
Ignore dirty coq-ext-lib submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "third_party/coq-ext-lib"]
 	path = third_party/coq-ext-lib
 	url = https://github.com/coq-community/coq-ext-lib
+	ignore = dirty
 [submodule "third_party/opentitan"]
 	path = third_party/opentitan
 	url = https://github.com/lowRISC/opentitan


### PR DESCRIPTION
I think building coq-ext-lib modifies files in its directory causing git to mention it during staging. This just removes the git notification that `coq-ext-lib` directory is dirty.