### PR TITLE
Combinator equivalence proofs

### DIFF
--- a/cava/arrow-examples/Aes/pkg.v
+++ b/cava/arrow-examples/Aes/pkg.v
@@ -26,7 +26,7 @@ Open Scope kind_scope.
 Open Scope category_scope.
 
 Notation "|^ x" :=
-  (App (foldr1 <[\a b => xor a b]> _) x)
+  (App (RemoveContext (foldr1 <[\a b => xor a b]> _)) x)
   (in custom expr at level 5, no associativity) : kappa_scope.
 Notation "x && y" :=
   (App (App (Primitive And) x) y)
@@ -35,16 +35,16 @@ Notation "x || y" :=
   (App (App (Primitive And) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x & y" :=
-  (App (App (bitwise <[and]>  _) x) y)
+  (App (App (RemoveContext (bitwise <[and]>  _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x ^ y" :=
-  (App (App (bitwise <[xor]> _) x) y)
-  (in custom expr at level 6, left associativity) : kappa_scope.
+  (App (App (RemoveContext (bitwise <[xor]> _)) x) y)
+    (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "'if' i 'then' t 'else' e" :=
-  (App (App (App (mux_item _) i) t) e)
+  (App (App (App (RemoveContext (mux_item _)) i) t) e)
   (in custom expr at level 5, left associativity) : kappa_scope.
 Notation "x == y" :=
-  (App (App (equality _) x) y)
+  (App (App (RemoveContext (equality _)) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 
 Inductive SboxImpl :=

--- a/cava/arrow-examples/Aes/sbox_canright.v
+++ b/cava/arrow-examples/Aes/sbox_canright.v
@@ -122,7 +122,7 @@ Proof.
 Qed.
 
 (* This lemma could also be proved the same way as CIPH_FWD *)
-Lemma CIPH_INV_correct : obeys_spec CIPH_INV (fun _ => true).
+Lemma CIPH_INV_correct : obeys_spec CIPH_INV (fun _ : unit => true).
 Proof.
   cbv [obeys_spec CIPH_INV]. circuit_spec. reflexivity.
 Qed.
@@ -143,11 +143,6 @@ Derive canright_composed_spec
        As canright_composed_correct.
 Proof.
   cbv [canright_composed]. circuit_spec.
-  rewrite !resize_default_id, !map_id.
-  (* we need to do this destruct for the instantiation to work; the calls to
-     Datatypes.fst have different types *)
-  match goal with |- _ (Datatypes.fst ?x) = _ =>  destruct x end.
-  cbn [denote_kind combinational_evaluation' Datatypes.fst Datatypes.snd].
   subst canright_composed_spec.
   instantiate_app_by_reflexivity.
 Qed.

--- a/cava/arrow-examples/CombinatorProperties.v
+++ b/cava/arrow-examples/CombinatorProperties.v
@@ -1,0 +1,239 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Arrow Require Import Category Arrow.
+From Cava Require Import Arrow.ArrowExport Arrow.CircuitFunctionalEquivalence
+     BitArithmetic Tactics VectorUtils.
+From ArrowExamples Require Combinators.
+
+(* Functional specifications for circuit combinators *)
+Section Specs.
+  Fixpoint denote_kind_eqb {A : Kind} : denote_kind A -> denote_kind A -> bool :=
+    match A as A0 return denote_kind A0 -> denote_kind A0 -> bool with
+    | Unit => fun _ _ => true
+    | Bit => Bool.eqb
+    | Tuple L R =>
+      fun x y => (denote_kind_eqb (fst x) (fst y)
+               && denote_kind_eqb (snd x) (snd y))%bool
+    | Vector T n =>
+      fun x y =>
+        let eqb_results := Vector.map2 denote_kind_eqb x y in
+        Vector.fold_left andb true eqb_results
+    end.
+
+  Fixpoint enable {A : Kind} (en : bool) : denote_kind A -> denote_kind A :=
+    match A with
+    | Unit => fun x => x
+    | Bit => fun x => andb en x
+    | Tuple L R => fun x => (enable en (fst x), enable en (snd x))
+    | Vector T n => fun x => Vector.map (enable en) x
+    end.
+
+  Fixpoint bitwise {A : Kind} (op : bool -> bool -> bool)
+    : denote_kind A -> denote_kind A -> denote_kind A :=
+    match A as A0 return denote_kind A0 -> denote_kind A0 -> denote_kind A0 with
+    | Unit => fun x _ => x
+    | Bit => op
+    | Tuple L R =>
+      fun x y => (bitwise op (fst x) (fst y), bitwise op (snd x) (snd y))
+    | Vector T n => fun x y => Vector.map2 (bitwise op) x y
+    end.
+End Specs.
+
+(* Miscellaneous helpful proofs for combinator equivalence *)
+Section Misc.
+  Lemma eqb_negb_xor x y : Bool.eqb x y = negb (xorb x y).
+  Proof. destruct x, y; reflexivity. Qed.
+
+  Lemma bitwise_or_enable A en x y :
+    @bitwise A orb (enable en x) (enable (negb en) y) = if en then x else y.
+  Proof.
+    induction A; destruct en; cbn [bitwise enable fst snd];
+      repeat match goal with
+             | IH : context [bitwise _ _ _ = _] |- _ => rewrite IH
+             | x : denote_kind Unit |- _ => destruct x
+             | x : denote_kind Bit |- _ => destruct x
+             | _ => rewrite <-surjective_pairing
+             | _ => rewrite map2_map
+             | _ => reflexivity
+             | _ => progress autorewrite with vsimpl
+             | _ => rewrite map2_ext with (g:=fun x y => x) by auto
+             | _ => rewrite map2_ext with (g:=fun x y => y) by auto
+             | _ => rewrite map2_drop
+             | _ => rewrite map2_swap, map2_drop
+             end.
+  Qed.
+
+  Lemma rewrite_or_default_refl A :
+    circuit_equiv _ _ (rewrite_or_default A A) (fun x => x).
+  Proof.
+    induction A; cbn [rewrite_or_default] in *; arrowsimpl;
+      circuit_spec; autorewrite with vsimpl;
+        try apply surjective_pairing; eauto.
+  Qed.
+End Misc.
+Hint Resolve rewrite_or_default_refl : circuit_spec_correctness.
+
+(* Proofs of equivalence between circuit combinators and functional
+   specifications *)
+Section CombinatorEquivalence.
+  Lemma replicate_correct A n :
+    obeys_spec (@Combinators.replicate n A)
+               (fun x : denote_kind A * unit => Vector.const (fst x) n).
+  Proof.
+    induction n; cbn [Combinators.replicate]; circuit_spec; reflexivity.
+  Qed.
+  Hint Resolve replicate_correct : circuit_spec_correctness.
+
+  Lemma reshape_correct {A} n m :
+    obeys_spec (@Combinators.reshape n m A)
+               (fun x : Vector.t (denote_kind A) _ * unit =>
+                  @reshape (denote_kind A) _ _ (fst x)).
+  Proof.
+    induction n; intros; cbn [Combinators.reshape reshape].
+    { circuit_spec. reflexivity. }
+    { circuit_spec; [ ].  autorewrite with vsimpl.
+      repeat destruct_pair_let. reflexivity. }
+  Qed.
+  Hint Resolve reshape_correct : circuit_spec_correctness.
+
+  Lemma map2_correct A B C n c (f : denote_kind A -> denote_kind B -> denote_kind C) :
+    @obeys_spec (Tuple A (Tuple B Unit)) C c
+                (fun abu : denote_kind A * (denote_kind B * unit) =>
+                   f (fst abu) (fst (snd abu))) ->
+    obeys_spec (@Combinators.map2 n A B C c)
+               (fun v1v2u : Vector.t (denote_kind A) n
+                          * (Vector.t (denote_kind B) n * unit) =>
+                  Vector.map2 f (fst v1v2u) (fst (snd v1v2u))).
+  Proof.
+    induction n; cbn [Combinators.map2]; intros; circuit_spec;
+      autorewrite with vsimpl; rewrite ?map2_cons; reflexivity.
+  Qed.
+  Hint Resolve map2_correct : circuit_spec_correctness.
+  Hint Extern 2 (obeys_spec (Combinators.map2 _) _)
+  => (eapply map2_correct; circuit_spec_crush) : circuit_spec_correctness.
+
+  Lemma map_correct A B n c (f : denote_kind A -> denote_kind B) :
+    @obeys_spec (Tuple A Unit) B c (fun x : denote_kind A * unit => f (fst x)) ->
+    obeys_spec (@Combinators.map n A B c)
+               (fun x : Vector.t (denote_kind A) _ * unit => Vector.map f (fst x)).
+  Proof.
+    induction n; cbn [Combinators.map]; intros; circuit_spec;
+      autorewrite with vsimpl; rewrite ?map_cons; reflexivity.
+  Qed.
+  Hint Resolve map_correct : circuit_spec_correctness.
+  Hint Extern 2 (obeys_spec (Combinators.map _) _)
+  => (eapply map_correct; circuit_spec_crush) : circuit_spec_correctness.
+
+  Lemma flatten_correct A n m :
+    obeys_spec (@Combinators.flatten n m A)
+               (fun x : Vector.t (Vector.t (denote_kind A) _) _ * unit =>
+                  @flatten (denote_kind _) _ _ (fst x)).
+  Proof.
+    revert m; induction n; cbn [Combinators.flatten flatten]; intros.
+    { circuit_spec; reflexivity. }
+    { circuit_spec; [ ]. destruct_pair_let.
+      autorewrite with vsimpl. reflexivity. }
+  Qed.
+  Hint Resolve flatten_correct : circuit_spec_correctness.
+
+  Lemma reverse_correct A n :
+    obeys_spec (@Combinators.reverse n A)
+               (fun x : Vector.t (denote_kind A) _ * unit  =>
+                  @reverse (denote_kind A) _ (fst x)).
+  Proof.
+    induction n; cbn [Combinators.reverse reverse]; circuit_spec;
+      autorewrite with vsimpl; reflexivity.
+  Qed.
+  Hint Resolve reverse_correct : circuit_spec_correctness.
+
+  Lemma foldl_correct A B n c (f : denote_kind B -> denote_kind A -> denote_kind B) :
+    @obeys_spec (Tuple B (Tuple A Unit)) _ c
+                (fun x : denote_kind B * (denote_kind A * unit) => f (fst x) (fst (snd x))) ->
+    obeys_spec (Combinators.foldl (n:=n) c)
+               (fun x : denote_kind B * (Vector.t (denote_kind A) _ * unit) =>
+                  Vector.fold_left f (fst x) (fst (snd x))).
+  Proof.
+    intros; induction n; cbn [Vector.fold_left Combinators.foldl]; circuit_spec.
+    { eapply Vector.case0 with (v:=fst (snd (fst _))). reflexivity. }
+    { autorewrite with push_vector_fold vsimpl. reflexivity. }
+  Qed.
+  Hint Resolve foldl_correct : circuit_spec_correctness.
+  Hint Extern 2 (obeys_spec (Combinators.foldl _) _)
+  => (eapply foldl_correct; circuit_spec_crush) : circuit_spec_correctness.
+
+  Lemma equality_correct A :
+    obeys_spec (@Combinators.equality A)
+               (fun x : denote_kind A * (denote_kind A * unit) =>
+                  denote_kind_eqb (fst x) (fst (snd x))).
+  Proof.
+    induction A; cbn [Combinators.equality denote_kind_eqb];
+      circuit_spec; auto using eqb_negb_xor.
+  Qed.
+  Hint Resolve equality_correct : circuit_spec_correctness.
+
+  Lemma enable_correct A :
+    obeys_spec (@Combinators.enable A)
+               (fun x : bool * (denote_kind A * unit) => enable (fst x) (fst (snd x))).
+  Proof.
+    induction A; cbn [Combinators.enable enable]; circuit_spec;
+      try reflexivity; [ ].
+    rewrite map2_const. autorewrite with vsimpl. reflexivity.
+  Qed.
+  Hint Resolve enable_correct : circuit_spec_correctness.
+
+  Lemma bitwise_correct A c op :
+    @obeys_spec (Tuple Bit (Tuple Bit Unit)) _ c
+                (fun x : bool * (bool * unit) => op (fst x) (fst (snd x))) ->
+    obeys_spec (@Combinators.bitwise A c)
+               (fun x : denote_kind A * (denote_kind A * unit) =>
+                  bitwise op (fst x) (fst (snd x))).
+  Proof.
+    intros.
+    induction A; cbn [Combinators.bitwise bitwise]; circuit_spec;
+      autorewrite with vsimpl; auto.
+  Qed.
+  Hint Resolve bitwise_correct : circuit_spec_correctness.
+  Hint Extern 2 (obeys_spec (Combinators.bitwise _) _)
+  => (eapply bitwise_correct; circuit_spec_crush) : circuit_spec_correctness.
+
+  Lemma mux_item_correct A :
+    obeys_spec (@Combinators.mux_item A)
+               (fun x : bool * (denote_kind A * (denote_kind A * unit)) =>
+                  if (fst x) then (fst (snd x)) else (fst (snd (snd x)))).
+  Proof.
+    cbv [Combinators.mux_item]; circuit_spec; [ ].
+    rewrite bitwise_or_enable. reflexivity.
+  Qed.
+  Hint Resolve mux_item_correct : circuit_spec_correctness.
+End CombinatorEquivalence.
+
+(* Restate all hints so they exist outside the section *)
+Hint Resolve mux_item_correct bitwise_correct enable_correct
+     equality_correct replicate_correct reshape_correct map2_correct
+     map_correct flatten_correct reverse_correct foldl_correct
+  : circuit_spec_correctness.
+
+(* Because the some lemmas produce an [obeys_spec] subgoal, we tell [eauto] it
+   can also try to solve their subgoals using [circuit_spec_crush] *)
+Hint Extern 2 (obeys_spec (Combinators.map _) _)
+=> (eapply map_correct; circuit_spec_crush) : circuit_spec_correctness.
+Hint Extern 2 (obeys_spec (Combinators.map2 _) _)
+=> (eapply map2_correct; circuit_spec_crush) : circuit_spec_correctness.
+  Hint Extern 2 (obeys_spec (Combinators.foldl _) _)
+  => (eapply foldl_correct; circuit_spec_crush) : circuit_spec_correctness.
+Hint Extern 2 (obeys_spec (Combinators.bitwise _) _)
+=> (eapply bitwise_correct; circuit_spec_crush) : circuit_spec_correctness.

--- a/cava/arrow-examples/_CoqProject
+++ b/cava/arrow-examples/_CoqProject
@@ -3,6 +3,7 @@
 -R . ArrowExamples
 
 Combinators.v
+CombinatorProperties.v
 
 Mux2_1.v
 SyntaxExamples.v

--- a/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -192,6 +192,8 @@ Ltac lower1 :=
       first [ rewrite (@lower_remove_context x y e ctxt)
             | change x with t1; change y with t2;
               rewrite (@lower_remove_context t1 t2 e ctxt) ]
+    | @Comp _ ?x ?y ?z ?e1 ?e2 =>
+      rewrite (@lower_comp x y z e2 e1 ctxt)
     | @Primitive _ ?p => cbv [closure_conversion']
     | @Var _ _ _ _ => cbv [closure_conversion']
     end; arrowsimpl

--- a/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -24,7 +24,7 @@ Inductive circuit_equiv: forall i o, Circuit i o -> (denote_kind i -> denote_kin
   | Composition_equiv: forall x y z c1 c2 r1 r2 r,
     circuit_equiv x y c1 r1 ->
     circuit_equiv y z c2 r2 ->
-    (forall a:denote_kind x, r a = r2 (r1 a) ) ->
+    (forall a:denote_kind x, r a = r2 (r1 a)) ->
     circuit_equiv x z (Composition _ _ _ c1 c2) r
 
   | Uncancell_equiv: forall x r,
@@ -85,13 +85,10 @@ Inductive circuit_equiv: forall i o, Circuit i o -> (denote_kind i -> denote_kin
     (forall v, r v = resize_default (kind_default _) nn v) ->
     circuit_equiv (Vector x n) (Vector x nn) (Resize x n nn) r
 
-  | Primtive_equiv: forall p r,
+  | Primitive_equiv: forall p r,
     (forall a, r a = combinational_evaluation' (CircuitArrow.Primitive p) a) ->
-    circuit_equiv (primitive_input p) (primitive_output p)
+    circuit_equiv _ _
                   (CircuitArrow.Primitive p) r
-
-  (* | Any_equiv: forall i o c, *)
-  (*   circuit_equiv i o c (combinational_evaluation' c) *)
 .
 
 Lemma circuit_equiv_ext {i o} c spec1 spec2 :
@@ -140,7 +137,7 @@ Definition obeys_spec {i o}
            (c : @morphism Kind KappaCat i o)
            (spec : denote_kind i -> denote_kind o) :=
   circuit_equiv _ _ (closure_conversion' Datatypes.nil (c natvar))
-                (fun (x : denote_kind (i ** as_kind Datatypes.nil)%Arrow) =>
+                (fun (x : denote_kind i * unit) =>
                    spec (Datatypes.fst x)).
 
 (* this lemma helps get a subcircuit goal into the [obeys_spec] form so eauto
@@ -161,22 +158,77 @@ Ltac arrowsimpl :=
    them *)
 Create HintDb circuit_spec_correctness discriminated.
 
+Ltac circuit_spec_instantiate :=
+  lazymatch goal with
+  | |- _ = _ =>
+    cbn [fst snd denote_kind product primitive_output];
+    lazymatch goal with
+    | |- context [combinational_evaluation' (CircuitArrow.Primitive _)] =>
+      (* simplify combinational_evaluation' if there's a primitive *)
+      cbv [combinational_evaluation']
+    | |- _ = @resize_default _ ?n ?d ?n ?v =>
+      (* change resize_default to identity function if it appears *)
+      transitivity v; [ | rewrite resize_default_id; reflexivity ]
+    | |- _ = Vector.map (fun x => x) ?v =>
+      (* change Vector.map id to identity function if it appears *)
+      transitivity v; [ | rewrite Vector.map_id; reflexivity ]
+    | _ => idtac
+    end; cbn[fst snd denote_kind product primitive_output];
+    instantiate_app_by_reflexivity
+  end.
+
+Ltac lower1 :=
+  lazymatch goal with
+  | |- circuit_equiv _ _ (@closure_conversion' ?t1 ?t2 ?ctxt ?k) _ =>
+    lazymatch k with
+    | @Abs _ ?x ?y ?z ?f =>
+      (* sometimes the types need to be coerced for Abs *)
+      first [ rewrite (@lower_abs x y z f ctxt)
+            | change t1 with (Tuple x y); change t2 with z;
+              rewrite (@lower_abs x y z f ctxt) ]
+    | @App _ ?x ?y ?z ?f ?e => rewrite (@lower_app x y z f e ctxt)
+    | @Let _ ?x ?y ?z ?v ?f => rewrite (@lower_let x y z f v ctxt)
+    | @RemoveContext _ ?x ?y ?e =>
+      first [ rewrite (@lower_remove_context x y e ctxt)
+            | change x with t1; change y with t2;
+              rewrite (@lower_remove_context t1 t2 e ctxt) ]
+    | @Primitive _ ?p => cbv [closure_conversion']
+    | @Var _ _ _ _ => cbv [closure_conversion']
+    end; arrowsimpl
+  end.
+
+Ltac primitive_equiv :=
+  lazymatch goal with
+  | |- circuit_equiv ?x ?y (CircuitArrow.Primitive ?p) _ =>
+    change x with (primitive_input p);
+    change y with (primitive_output p);
+    eapply Primitive_equiv; intros
+  end.
+
 Ltac circuit_spec_step :=
   lazymatch goal with
-  | |- ?lhs = ?rhs =>
-    cbn [Datatypes.fst Datatypes.snd];
-    instantiate_app_by_reflexivity
-  | |- circuit_equiv _ _ ?c _ =>
-    lazymatch c with
-    | closure_conversion' _ _ =>
-      apply obeys_spec_to_circuit_equiv;
-      solve [eauto with circuit_spec_correctness]
-    | _ => first [ econstructor; intros
-                | solve [eauto with circuit_spec_correctness] ]
-    end
+  | |- circuit_equiv _ _ (closure_conversion' _ ?c) _ =>
+    first [ lower1
+          | apply obeys_spec_to_circuit_equiv;
+            solve [eauto with circuit_spec_correctness ] ]
+  | |- circuit_equiv _ _ _ _ =>
+    first [ econstructor; intros
+          | solve [ eauto with circuit_spec_correctness ]
+          | primitive_equiv ]
+  | |- ?lhs = ?rhs => circuit_spec_instantiate
   | |- ?x => fail "Stuck at" x
   end.
-Ltac circuit_spec :=
-  cbv [obeys_spec]; cbn [closure_conversion']; arrowsimpl;
-  repeat circuit_spec_step; cbn [denote_kind combinational_evaluation' fst snd].
 
+Ltac circuit_spec :=
+  cbv [obeys_spec]; cbn [primitive_input primitive_output as_kind];
+  repeat circuit_spec_step; cbn [denote_kind product fst snd]; fold denote_kind.
+
+(* Version of [circuit_spec] that expects to solve the goal *)
+Ltac circuit_spec_crush :=
+  circuit_spec; autorewrite with vsimpl; repeat destruct_pair_let;
+  repeat match goal with
+         | u : unit |- _ => destruct u
+         | |- context [@snd _ unit ?x] => destruct (snd x)
+         | |- context [@fst unit _ ?x] => destruct (fst x)
+         end;
+  (reflexivity || instantiate_app_by_reflexivity).


### PR DESCRIPTION
This PR includes some changes to the `circuit_spec` tactic that use the lemmas in #229 to unfold `closure_conversion'` one constructor at a time, which speeds it up considerably. I then used the sped-up tactic to prove functional equivalence for most of the circuit combinators (I had these proofs lying around already because I needed them for the AES top-level proof I'm working on, but they were due to be separated out and merged and also good test cases!)