### PR TITLE
Prove facts about identity monad and combinational

### DIFF
--- a/cava/cava/Cava/Monad/MonadFacts.v
+++ b/cava/cava/Cava/Monad/MonadFacts.v
@@ -1,0 +1,96 @@
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import ExtLib.Structures.MonadLaws.
+Require Import ExtLib.Structures.Monad.
+
+Require Import Cava.Monad.CavaMonad.
+
+Local Open Scope monad_scope.
+
+(* This instance allows the use of functional extensionality on identity-monad
+   bind *)
+Lemma ident_bind_Proper_ext : forall A B (x : ident A) (f : A -> ident B)
+                                                       (g : A -> ident B),
+  (forall a, f a = g a) -> (x >>= f) = (x >>= g).
+Proof.
+  intros. (* Introduce quantified variables.
+    t: Type
+    u: Type
+    x: ident t
+    f, g: t -> ident u
+    H: forall a : t, f a = g a
+    ---------------------------
+    ` x : _ <- x;; f x = ` x : _ <- x;; g x   *)
+  simpl. (* Simplify to boil down to applications of unIdent
+    f (unIdent x) = g (unIdent x) *)
+  auto. (* auto can use H in our context to discharge the proof. *)
+Qed.
+
+(* Right identity monad law specialized to the identity monad:
+  x >>= ret = x  *)
+Lemma ident_bind_ret A (x : ident A) : x >>= ret = x.
+Proof.
+  (* Desugared:
+       x : _ <- x;; ret x = x *)
+  destruct x. (* Take apart on x
+      x : _ <- {| unIdent := unIdent |};;
+      ret x = {| unIdent := unIdent |} *)
+  simpl. (* Perform unfolding simplifications:
+    {| unIdent := unIdent |} = {| unIdent := unIdent |}   *)
+  reflexivity.
+Qed.
+
+(* Recognize a bind of bind *)
+Lemma ident_bind_lift_app {A B C} (f : A -> B) (g : B -> C) 
+                          (x : ident A) :
+  x >>= (fun y => ret (g (f y))) =
+  x >>= (fun y => ret (f y)) >>= (fun y => ret (g y)).
+Proof.
+  destruct x. (* Take apart on x
+    y : A <- {| unIdent := unIdent |};;
+    ret (g (f y)) =
+    (y : A <- {| unIdent := unIdent |};;
+      ret (f y)
+    ) ;;
+    ret (g y)  *)
+  reflexivity.
+Qed.
+
+Hint Rewrite @bind_of_return @bind_associativity
+     using solve [typeclasses eauto] : monadlaws.
+
+(* Prove that Monad_ident is an instance of MonadLaw.
+   Should this really be in coq-ext-lib? *)
+Instance MonadLaws_ident : MonadLaws Monad_ident.
+Proof. constructor; intros; reflexivity. Qed.
+
+(* Decompose a serial composition of circuits f and g into
+   two separate combinational interpretations. *)
+Lemma combinational_bind {A B} (f : ident A) (g : A -> ident B) :
+  combinational (f >>= g) = combinational (g (combinational f)).
+Proof.
+  destruct f. (* Take apart on the circuit f.
+    combinational (` x : _ <- {| unIdent := unIdent |};; g x) =
+    combinational (g (combinational {| unIdent := unIdent |}))   *)
+  reflexivity. (* Both sides boil down to computing x as the result of
+                  circuit f which is passed as an argument to circuit g *)
+Qed.
+
+(* The combinational interpretation of the `return` of any value is
+   just the same value. *)
+Lemma combinational_ret {A} (x : A) : combinational (ret x) = x.
+Proof. reflexivity. Qed.
+

--- a/cava/cava/_CoqProject
+++ b/cava/cava/_CoqProject
@@ -15,6 +15,7 @@ Cava/Monad/CavaMonad.v
 Cava/Monad/CavaClass.v
 Cava/Monad/CombinationalMonad.v
 Cava/Monad/Combinators.v
+Cava/Monad/MonadFacts.v
 Cava/Monad/UnsignedAdders.v
 Cava/Monad/NetlistGeneration.v
 Cava/Monad/XilinxAdder.v


### PR DESCRIPTION
This PR ports over some of the proofs about monads that @jadephilipoom wrote in https://github.com/project-oak/oak-hardware/commit/b7364dc5923cac09dbc1281a1f6099b5b278cc65 which I have tried to simplify a bit for my comprehension. I've checked that these definitions allow the ripple-carry adder correctness to still be proved (with minor adaption).

I've added comments that show the goals as they develop. I appreciate this may be poor form? Especially since we can't expect these to be stable from one release of Coq to another?

