### PR TITLE
Add license header to AES spec

### DIFF
--- a/cava/cava/Cava/Spec/Aes.v
+++ b/cava/cava/Cava/Spec/Aes.v
@@ -1,3 +1,18 @@
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
 Require Import Coq.Lists.List.
 
 Hint Rewrite @map_app @fold_left_app : listsimpl.


### PR DESCRIPTION
We should be sure to have license headers on all our source files. Sorry, I should I have mentioned this for the original PR.