### PR TITLE
Add pinmux build to the system build

### DIFF
--- a/cava/opentitan/Makefile
+++ b/cava/opentitan/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 The Project Oak Authors
+# Copyright 2020 The Project Oak Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +14,9 @@
 # limitations under the License.
 #
 
-.PHONY: all clean
+all:	
+	cd pinmux && $(MAKE) all
 
-all:
-	cd arrow-lib && $(MAKE)
-	cd cava && $(MAKE)
-	cd monad-examples && $(MAKE)
-	cd monad-examples/xilinx && $(MAKE) extraction
-	cd tests/xilinx && $(MAKE) extraction
-	cd arrow-examples && $(MAKE)
-	cd opentitan && $(MAKE) all
+clean:	
+	cd pinmux && $(MAKE) clean
 
-clean:
-	cd arrow-lib && $(MAKE) clean
-	cd cava && $(MAKE) clean
-	cd monad-examples && $(MAKE) clean
-	cd monad-examples/xilinx && $(MAKE) clean
-	cd tests/xilinx && $(MAKE) clean
-	cd arrow-examples && $(MAKE) clean
-	cd opentitan && $(MAKE) clean
-	rm -rf .DS_Store

--- a/cava/opentitan/pinmux/Makefile
+++ b/cava/opentitan/pinmux/Makefile
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-.PHONY: all coq clean
+.PHONY: all coq clean compile_pinmux
 
-all:		coq pinmux.sv
+all:		coq pinmux.sv compile_pinmux
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
 VLINT = $(VERILATOR) --lint-only
@@ -32,6 +32,9 @@ PinmuxSV:	PinmuxSV.hs
 
 pinmux.sv:	coq PinmuxSV
 		./PinmuxSV
+
+compile_pinmux:	pinmux.sv
+		cd snapshot && $(MAKE)
 
 clean:		
 		-@$(MAKE) -f Makefile.coq clean

--- a/cava/opentitan/pinmux/snapshot/Makefile
+++ b/cava/opentitan/pinmux/snapshot/Makefile
@@ -19,7 +19,9 @@
 # needed for the pinmux of OpenTitan.
 ################################################################################
 
-OPENTITAN = ../../../../../opentitan
+OPENTITAN = ../../../../third_party/opentitan
+
+.PHONY:	all clean check_oldpinmux
 
 all:	vlint
 


### PR DESCRIPTION
Add the generation of the Silver Oak to the system build (and pre-submit) and also check the generated SystemVerilog for our pinmux by linting it with Verilator in situ with the dependent SystemVerilog files.