### PR TITLE
Add .vo Makefile target

### DIFF
--- a/cava/Makefile
+++ b/cava/Makefile
@@ -21,6 +21,9 @@ all:		coq haskell
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 FixupHaskell:	FixupHaskell.hs
 		ghc --make $^
 


### PR DESCRIPTION
This PR adds a Makefile target for `.vo` files, which simply passes the argument on to `Makefile.coq`. The result is that one can write `make Cava/Netlist.vo` and build *only* the files needed for `Netlist.v`, which comes in handy for development speed.