### PR TITLE
Remove outdated import

### DIFF
--- a/arrow-examples/Aes/CipherProperties.v
+++ b/arrow-examples/Aes/CipherProperties.v
@@ -16,7 +16,6 @@
 
 Require Import Coq.Strings.String.
 From Coq Require Import Derive.
-From Arrow Require Import Category Arrow.
 From Cava Require Import Arrow.ArrowExport Arrow.CircuitFunctionalEquivalence
      BitArithmetic Tactics VectorUtils.
 


### PR DESCRIPTION
Caused by #269 and #271 being merged at about the same time, so the new file created in #271 had an import that #269 invalidated. This commit removes the bad import (which is now subsumed by `Arrow.ArrowExport`, so no further imports needed to be added).