### PR TITLE
Proof that closure conversion preserves semantics

### DIFF
--- a/arrow-examples/CombinatorProperties.v
+++ b/arrow-examples/CombinatorProperties.v
@@ -75,16 +75,7 @@ Section Misc.
              | _ => rewrite map2_swap, map2_drop
              end.
   Qed.
-
-  Lemma rewrite_or_default_refl A :
-    circuit_equiv _ _ (rewrite_or_default A A) (fun x => x).
-  Proof.
-    induction A; cbn [rewrite_or_default] in *; arrowsimpl;
-      circuit_spec; autorewrite with vsimpl;
-        try apply surjective_pairing; eauto.
-  Qed.
 End Misc.
-Hint Resolve rewrite_or_default_refl : circuit_spec_correctness.
 
 (* TODO: move *)
 Ltac kappa_spec_begin :=

--- a/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -197,7 +197,7 @@ Ltac lower1 :=
     | @Comp _ ?x ?y ?z ?e1 ?e2 =>
       rewrite (@lower_comp x y z e2 e1 ctxt)
     | @Primitive _ ?p => cbv [closure_conversion']
-    | @Var _ _ _ _ => cbv [closure_conversion']
+    | @Var _ _ _ => cbv [closure_conversion']
     end; arrowsimpl
   end.
 

--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -7,25 +7,24 @@ Set Implicit Arguments.
 Set Asymmetric Patterns.
 
   Section Equivalence.
-    Inductive obj_tup : Type := obj_pair : Kind -> Kind -> obj_tup.
-    Variables var1 var2 : Kind -> Kind -> Type.
+    Variables var1 var2 : Kind -> Type.
 
-    Definition vars := existT (fun '(obj_pair x y) => (var1 x y * var2 x y)%type).
-    Definition ctxt := list { '(obj_pair x y) : obj_tup & (var1 x y * var2 x y)%type }.
+    Definition vars := existT (fun t => (var1 t * var2 t)%type).
+    Definition ctxt := list { t : Kind & (var1 t * var2 t)%type }.
 
     Inductive kappa_equivalence:
       forall i o, ctxt
       -> kappa var1 i o -> kappa var2 i o
       -> Prop :=
-    | Var_equiv : forall i o (n1: var1 i o) (n2: var2 i o) E,
-      In (vars (obj_pair i o) (pair n1 n2)) E
+    | Var_equiv : forall x (n1: var1 x) (n2: var2 x) E,
+      In (vars (pair n1 n2)) E
       -> kappa_equivalence E (Var n1) (Var n2)
 
     | Abs_equiv : forall x y z
-      (f1: var1 Unit x -> kappa var1 y z)
-      (f2: var2 Unit x -> kappa var2 y z)
+      (f1: var1 x -> kappa var1 y z)
+      (f2: var2 x -> kappa var2 y z)
       (E: ctxt),
-      (forall n1 n2, kappa_equivalence (vars (obj_pair Unit x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
+      (forall n1 n2, kappa_equivalence (vars (pair n1 n2) :: E) (f1 n1) (f2 n2))
       -> kappa_equivalence E (Abs f1) (Abs f2)
 
     | App_equiv : forall E x y z
@@ -46,14 +45,14 @@ Set Asymmetric Patterns.
     | Prim_equiv : forall E p, kappa_equivalence E (ExprSyntax.Primitive p) (ExprSyntax.Primitive p)
 
     | Letrec_equiv : forall x y z
-      (v1: var1 Unit x -> kappa var1 Unit x)
-      (v2: var2 Unit x -> kappa var2 Unit x)
-      (f1: var1 Unit x -> kappa var1 y z)
-      (f2: var2 Unit x -> kappa var2 y z)
+      (v1: var1 x -> kappa var1 Unit x)
+      (v2: var2 x -> kappa var2 Unit x)
+      (f1: var1 x -> kappa var1 y z)
+      (f2: var2 x -> kappa var2 y z)
       (E: ctxt),
-      (forall n1 n2, kappa_equivalence (vars (obj_pair Unit x) (pair n1 n2) :: E) (v1 n1) (v2 n2))
+      (forall n1 n2, kappa_equivalence (vars (pair n1 n2) :: E) (v1 n1) (v2 n2))
       ->
-      (forall n1 n2, kappa_equivalence (vars (obj_pair Unit x) (pair n1 n2) :: E) (f1 n1) (f2 n2))
+      (forall n1 n2, kappa_equivalence (vars (pair n1 n2) :: E) (f1 n1) (f2 n2))
       ->
       kappa_equivalence E (LetRec v1 f1) (LetRec v2 f2)
 

--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -62,6 +62,3 @@ Set Asymmetric Patterns.
   End Equivalence.
 
   Definition Wf {i o} (e: Kappa i o) := forall var1 var2, kappa_equivalence [] (e var1) (e var2).
-
-  Axiom Kappa_equivalence : forall {i o} (expr: forall var, kappa var i o), Wf expr.
-(* End Arrow. *)

--- a/cava/Cava/Arrow/ExprLowering.v
+++ b/cava/Cava/Arrow/ExprLowering.v
@@ -211,7 +211,6 @@ new list Kind variable in to place*)
   2. 'assoc': move the argument to the front of the list Kind via reassociation
       assoc:      y*(x*list Kind_variables) ~> o
 
-
   3. call f'
       f':         y*new_list Kind_variables ~> o
   *)

--- a/cava/Cava/Arrow/ExprLowering.v
+++ b/cava/Cava/Arrow/ExprLowering.v
@@ -440,10 +440,10 @@ Qed.
 
 Hint Resolve kappa_wf : kappa_cc.
 
-Theorem Kappa_wf: forall {i o} (expr: forall var, kappa var i o), wf_phoas_context [] (expr _).
+Theorem Kappa_wf: forall {i o} (expr: forall var, kappa var i o),
+    Wf expr -> wf_phoas_context [] (expr _).
 Proof.
-  Hint Extern 5 (kappa_equivalence _ _ _) => apply Kappa_equivalence : kappa_cc.
-  eauto with kappa_cc.
+  cbv [Wf]; eauto with kappa_cc.
 Qed.
 
 Definition closure_conversion {i o} (expr: Kappa i o) : i ~> o

--- a/cava/Cava/Arrow/ExprLoweringPreservation.v
+++ b/cava/Cava/Arrow/ExprLoweringPreservation.v
@@ -1,0 +1,168 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Init.Nat.
+Require Import Coq.Lists.List.
+Require Import coqutil.Tactics.Tactics.
+Require Import Arrow.Arrow.
+Require Import Arrow.Category.
+Require Import Arrow.CircuitArrow.
+Require Import Cava.Arrow.ArrowKind.
+Require Import Cava.Arrow.CircuitProp.
+Require Import Cava.Arrow.CircuitSemantics.
+Require Import Cava.Arrow.ExprEquiv.
+Require Import Cava.Arrow.ExprLowering.
+Require Import Cava.Arrow.ExprSemantics.
+Require Import Cava.Arrow.ExprSyntax.
+
+(* TODO: this is copied from CircuitFunctionalEquivalence and extended; it
+   should be moved to a more general location *)
+Local Ltac arrowsimpl :=
+  cbn [cancell cancelr uncancell uncancelr assoc unassoc first second copy drop
+               loopr loopl swap compose id
+               CircuitCat CircuitArrow CircuitArrowSwap CircuitArrowLoop
+               CircuitArrowDrop CircuitArrowCopy arrow_category as_kind
+               Datatypes.length Nat.eqb extract_nth ].
+
+Lemma rewrite_or_default_refl A x :
+  combinational_evaluation' (rewrite_or_default A A) x = x.
+Proof.
+  induction A; cbn [rewrite_or_default] in *; arrowsimpl;
+    cbn [combinational_evaluation' fst snd]; autorewrite with vsimpl;
+      try reflexivity; [ ].
+  rewrite IHA1, IHA2; eauto using surjective_pairing.
+Qed.
+
+Definition context_entry_ok
+           (ctxt_types : list Kind)
+           (ctxt_values : denote_kind (as_kind ctxt_types))
+           (e : { t : Kind & (coq_func t * natvar t)%type})
+  : Prop :=
+  let value := fst (projT2 e) in
+  let index := snd (projT2 e) in
+  reverse_nth ctxt_types index = Some (projT1 e) /\
+  combinational_evaluation' (extract_nth ctxt_types _ index) ctxt_values = value.
+
+Lemma extend_context_entry_ok_tl ctxt_types ctxt t (x : denote_kind t) e :
+  context_entry_ok ctxt_types ctxt e ->
+  context_entry_ok (t :: ctxt_types) (x, ctxt) e.
+Proof.
+  cbv [context_entry_ok]; intros.
+  repeat match goal with
+         | x : { _ & _ } |- _ => destruct x
+         | x : _ * _ |- _ => destruct x
+         | H : _ /\ _ |- _ => destruct H
+         | _ => progress cbn [projT1 projT2 fst snd rev] in *
+         end.
+  erewrite split_lookup by eauto.
+  split; [ reflexivity | ].
+  cbn [extract_nth].
+  destruct_one_match; arrowsimpl; cbn [combinational_evaluation' fst snd];
+    subst; [ | tauto ].
+  match goal with
+  | H : reverse_nth _ (length _) = Some _ |- _ =>
+    apply lookup_upper_contra in H
+  end.
+  tauto.
+Qed.
+
+Lemma extend_context_entry_ok_hd ctxt_types ctxt t (x : denote_kind t) :
+  context_entry_ok (t :: ctxt_types) (x, ctxt) (vars _ _ (x, length ctxt_types)).
+Proof.
+  cbv [context_entry_ok]. fold as_kind denote_kind in *.
+  cbn [rev projT1 projT2 fst snd vars].
+  erewrite split_lookup by eauto.
+  split; [ reflexivity | ]. cbn [extract_nth].
+  destruct_one_match; arrowsimpl; cbn [combinational_evaluation']; [ | tauto ].
+  cbn [fst snd]. apply rewrite_or_default_refl.
+Qed.
+
+Fixpoint no_letrec {var i o} (e : kappa var i o) : Prop :=
+  match e with
+  | Var _ => True
+  | Abs f => forall v, no_letrec (f v)
+  | App f x => no_letrec f /\ no_letrec x
+  | Comp e1 e2 => no_letrec e1 /\ no_letrec e2
+  | Primitive _ => True
+  | Let x f => no_letrec x /\ forall v, no_letrec (f v)
+  | LetRec _ _ => False
+  | Id => True
+  | RemoveContext e => no_letrec e
+  end.
+Definition NoLetRec {i o} (e : Kappa i o) : Prop := no_letrec (e unitvar).
+
+Lemma no_letrec_unitvar_equiv
+      i o var (expr1 : kappa unitvar i o) (expr2 : kappa var i o) G :
+  kappa_equivalence G expr1 expr2 ->
+  no_letrec expr1 ->
+  no_letrec expr2.
+Proof.
+  induction 1; intros; cbn [no_letrec] in *; destruct_products; solve [eauto].
+  Unshelve. apply tt.
+Qed.
+
+Lemma closure_conversion'_preserves_semantics i o :
+  forall (expr1 : kappa coq_func i o) (expr2 : kappa natvar i o) G,
+    kappa_equivalence G expr1 expr2 ->
+    no_letrec expr1 ->
+    forall (ctxt_types : list Kind) (ctxt : denote_kind (as_kind ctxt_types))
+      (x : denote_kind i),
+      Forall (context_entry_ok ctxt_types ctxt) G ->
+      interp_combinational' expr1 x
+      = combinational_evaluation'
+          (closure_conversion' ctxt_types expr2) (x, ctxt).
+Proof.
+  induction 1; intros.
+  all:cbn [interp_combinational' closure_conversion'].
+  all:cbn [denote_kind no_letrec] in *; destruct_products.
+  all:arrowsimpl; cbn [combinational_evaluation' fst snd].
+  { (* Var *)
+    match goal with
+    | HForall : Forall ?P ?l, HIn : In ?x ?l |- _ =>
+      let H := fresh in
+      assert (H : P x) by (eapply Forall_forall; eauto);
+        destruct H as [? ?]
+    end.
+    cbn [vars projT1 projT2 fst snd] in *.
+    congruence. }
+  { (* Abs *)
+    match goal with
+    | IH : _ |- _ => erewrite IH with (ctxt_types:=_ :: ctxt_types)
+    end; [ reflexivity | solve [eauto] | ].
+    apply Forall_cons; [ solve [apply extend_context_entry_ok_hd] | ].
+    eapply Forall_impl; [ | eassumption].
+    apply extend_context_entry_ok_tl. }
+  { (* App *)
+    erewrite IHkappa_equivalence1, IHkappa_equivalence2 by eauto.
+    reflexivity. }
+  { (* Comp *)
+    erewrite IHkappa_equivalence1, IHkappa_equivalence2 by eauto.
+    reflexivity. }
+  { (* Primitive *) reflexivity. }
+  { (* LetRec *) tauto. }
+  { (* Id *) reflexivity. }
+Qed.
+
+Theorem closure_conversion_preserves_semantics i o (expr : Kappa i o) x :
+  Wf expr -> NoLetRec expr ->
+  interp_combinational (expr coq_func) x = combinational_evaluation
+                                             (closure_conversion expr) x.
+Proof.
+  cbv [Wf interp_combinational combinational_evaluation closure_conversion].
+  intros; arrowsimpl; cbn [combinational_evaluation'].
+  eapply closure_conversion'_preserves_semantics with (ctxt_types:=nil) (G:=nil);
+    eauto using Forall_nil, no_letrec_unitvar_equiv.
+Qed.

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -31,21 +31,21 @@ Local Open Scope category_scope.
 Local Open Scope arrow_scope.
 
 Section combinational_semantics.
-  Definition coq_func i o := denote_kind i -> denote_kind o.
+  Definition coq_func t := denote_kind t.
 
   Fixpoint interp_combinational' {i o: Kind}
     (expr: kappa coq_func i o)
     : denote_kind i -> (denote_kind o) :=
-    match expr with
-    | Var x => fun v => (x v)
-    | Abs f => fun '(x,y) => interp_combinational' (f (fun _ => x)) y
+    match expr in kappa _ i0 o0 return denote_kind i0 -> denote_kind o0 with
+    | Var x => fun v : unit => x
+    | Abs f => fun '(x,y) => interp_combinational' (f x) y
     | App f e => fun y =>
       (interp_combinational' f) (interp_combinational' e tt, y)
     | Comp g f => fun x => interp_combinational' g (interp_combinational' f x)
     | Primitive p => combinational_evaluation' (CircuitArrow.Primitive p)
     | Id => fun x => x
     | Let v f => fun y =>
-      interp_combinational' (f (fun _ => interp_combinational' v tt)) y
+      interp_combinational' (f (interp_combinational' v tt)) y
     | LetRec v f => fun _ => kind_default _
     | RemoveContext f => interp_combinational' f
     end.

--- a/cava/Cava/Arrow/ExprSyntax.v
+++ b/cava/Cava/Arrow/ExprSyntax.v
@@ -10,20 +10,20 @@ Set Implicit Arguments.
 Set Asymmetric Patterns.
 
 Section vars.
-  Definition natvar : Kind -> Kind -> Type := fun _ _ => nat.
-  Definition unitvar : Kind -> Kind -> Type := fun _ _ => unit.
+  Definition natvar : Kind -> Type := fun _ => nat.
+  Definition unitvar : Kind -> Type := fun _ => unit.
 
   Section Vars.
-    Variable (var: Kind -> Kind -> Type).
+    Variable (var: Kind -> Type).
 
     Inductive kappa : Kind -> Kind -> Type :=
-    | Var : forall {x y},   var x y -> kappa x y
-    | Abs : forall {x y z}, (var Unit x -> kappa y z) -> kappa (Tuple x y) z
+    | Var : forall {x},     var x -> kappa Unit x
+    | Abs : forall {x y z}, (var x -> kappa y z) -> kappa (Tuple x y) z
     | App : forall {x y z}, kappa (Tuple x y) z -> kappa Unit x -> kappa y z
     | Comp: forall {x y z}, kappa y z -> kappa x y -> kappa x z
     | Primitive : forall prim, kappa (primitive_input prim) (primitive_output prim)
-    | Let: forall {x y z}, kappa Unit x -> (var Unit x -> kappa y z) -> kappa y z
-    | LetRec : forall {x y z}, (var Unit x -> kappa Unit x) -> (var Unit x -> kappa y z) -> kappa y z
+    | Let: forall {x y z}, kappa Unit x -> (var x -> kappa y z) -> kappa y z
+    | LetRec : forall {x y z}, (var x -> kappa Unit x) -> (var x -> kappa y z) -> kappa y z
     | Id : forall {x}, kappa x x
     | RemoveContext: forall {x y}, kappa x y -> kappa x y
     .
@@ -46,7 +46,7 @@ Section vars.
     (expr: kappa natvar i o) {struct expr}
     : Prop :=
     match expr with
-    | Var _ _ n  => ok_lookup ctxt n o
+    | Var _ n  => ok_lookup ctxt n o
     | Abs x _ _ f => wf_phoas_context (x :: ctxt) (f (length ctxt))
     | App _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2
     | Comp _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2
@@ -61,7 +61,7 @@ Section vars.
 
 End vars.
 
-Arguments Var {var _ _}.
+Arguments Var {var _}.
 Arguments Abs {var _ _ _}.
 Arguments App {var _ _ _}.
 Arguments Comp {var _ _ _}.


### PR DESCRIPTION
This proof went...much easier than I expected! The punchline is this theorem from `ExprLoweringPreservation.v`:
```
Theorem closure_conversion_preserves_semantics i o (expr : Kappa i o) x :
  Wf expr -> NoLetRec expr ->
  interp_combinational (expr coq_func) x = combinational_evaluation
                                             (closure_conversion expr) x.
```
The restrictions are that a) the Kappa expression must be `Wf`, meaning that it doesn't change its structure based on the `var` you pass in, and b) that there can't be `LetRec` constructors in the expression (because otherwise it wouldn't be combinational).

Other changes included here are:
- change `var` type to `Kind -> Type` instead of `Kind -> Kind -> Type`. The first (input/source) type was always `Unit`, so the argument provided no useful information or generality, and would have required bookkeeping in the proofs to prove that everything in the context was `var Unit ?`
- removed the `Kappa_equivalence` axiom because it was untrue as stated (something of type `forall var, kappa var i o` could do something silly like branch on the type of `var`, so quantifying over everything of that type is too strong); added a `Wf` precondition to the one place the axiom was used
- move `rewrite_or_default_refl` proof to the new file, because it was actually unused there but was necessary for the semantics-preservation proof