### PR TITLE
Add coq target to top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,15 @@ arrow-examples:
 # Silver Oak re-implementation of some OpenTitan blocks.
 silveroak-opentitan:
 	cd silveroak-opentitan && $(MAKE)
+
+# The coq target builds only the Coq proofs.
+coq:
+	cd third_party && $(MAKE)
+	cd cava && $(MAKE) coq
+	cd arrow-examples && $(MAKE) coq
+	cd monad-examples && $(MAKE) coq
+	cd silveroak-opentitan && $(MAKE) coq
+
 clean:
 	cd third_party && $(MAKE) clean
 	cd cava && $(MAKE) clean


### PR DESCRIPTION
Since we have the Coq-proofs-only target in subdirectories, I found it convenient to add a top-level target that calls them all, in case I want to build the arrow-examples coq proofs and am too lazy to type  `make -C cava coq && make -C arrow-examples coq`!