### PR TITLE
Add Let and RemoveContext cases to kappa_equivalence

### DIFF
--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -44,6 +44,18 @@ Set Asymmetric Patterns.
 
     | Prim_equiv : forall E p, kappa_equivalence E (ExprSyntax.Primitive p) (ExprSyntax.Primitive p)
 
+    | Let_equiv : forall x y z
+      (v1: kappa var1 Unit x)
+      (v2: kappa var2 Unit x)
+      (f1: var1 x -> kappa var1 y z)
+      (f2: var2 x -> kappa var2 y z)
+      (E: ctxt),
+      kappa_equivalence E v1 v2
+      ->
+      (forall n1 n2, kappa_equivalence (vars (pair n1 n2) :: E) (f1 n1) (f2 n2))
+      ->
+      kappa_equivalence E (Let v1 f1) (Let v2 f2)
+
     | Letrec_equiv : forall x y z
       (v1: var1 x -> kappa var1 Unit x)
       (v2: var2 x -> kappa var2 Unit x)
@@ -57,6 +69,13 @@ Set Asymmetric Patterns.
       kappa_equivalence E (LetRec v1 f1) (LetRec v2 f2)
 
     | Id_equiv : forall x E, kappa_equivalence E (@Id var1 x) Id
+
+    | RemoveContext_equiv : forall x y E
+      (f1 : kappa var1 x y)
+      (f2 : kappa var2 x y),
+      kappa_equivalence nil f1 f2
+      ->
+      kappa_equivalence E (RemoveContext f1) (RemoveContext f2)
     .
 
   End Equivalence.

--- a/cava/Cava/Arrow/ExprLoweringPreservation.v
+++ b/cava/Cava/Arrow/ExprLoweringPreservation.v
@@ -17,8 +17,8 @@
 Require Import Coq.Init.Nat.
 Require Import Coq.Lists.List.
 Require Import coqutil.Tactics.Tactics.
-Require Import Arrow.Arrow.
-Require Import Arrow.Category.
+Require Import Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.Classes.Category.
 Require Import Arrow.CircuitArrow.
 Require Import Cava.Arrow.ArrowKind.
 Require Import Cava.Arrow.CircuitProp.
@@ -111,7 +111,7 @@ Lemma no_letrec_unitvar_equiv
   no_letrec expr2.
 Proof.
   induction 1; intros; cbn [no_letrec] in *; destruct_products; solve [eauto].
-  Unshelve. apply tt.
+  Unshelve. all: apply tt.
 Qed.
 
 Lemma closure_conversion'_preserves_semantics i o :
@@ -152,8 +152,18 @@ Proof.
     erewrite IHkappa_equivalence1, IHkappa_equivalence2 by eauto.
     reflexivity. }
   { (* Primitive *) reflexivity. }
+  { (* Let *)
+    erewrite IHkappa_equivalence by eauto.
+    match goal with
+    | IH : _ |- _ => erewrite IH with (ctxt_types:=_ :: ctxt_types)
+    end; [ reflexivity | solve [eauto] | ].
+    apply Forall_cons; [ solve [apply extend_context_entry_ok_hd] | ].
+    eapply Forall_impl; [ | eassumption].
+    apply extend_context_entry_ok_tl. }
   { (* LetRec *) tauto. }
   { (* Id *) reflexivity. }
+  { (* RemoveContext *)
+    erewrite IHkappa_equivalence with (ctxt_types:=nil); eauto. }
 Qed.
 
 Theorem closure_conversion_preserves_semantics i o (expr : Kappa i o) x :


### PR DESCRIPTION
All `kappa` constructors are now included, which paves the way to proving that the AES cipher implementations are `Wf`.