### PR TITLE
Rename BitVec constructor of Kind to Vec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ tests:
 # the Xilinx-specific targets)
 monad-examples:
 	cd monad-examples && $(MAKE)
+	cd monad-examples/xilinx && $(MAKE) extraction
 
 # The arrow-example builds and tests the arrow examples (except for
 # the Xilinx-specific targets)
@@ -63,5 +64,6 @@ clean:
 	cd tests && $(MAKE) clean
 	cd tests/xilinx && $(MAKE) clean
 	cd monad-examples && $(MAKE) clean
+	cd monad-examples/xilinx && $(MAKE) clean
 	cd arrow-examples && $(MAKE) clean
 	cd silveroak-opentitan && $(MAKE) clean

--- a/arrow-examples/Aes/netlists.v
+++ b/arrow-examples/Aes/netlists.v
@@ -24,8 +24,8 @@ Require Import Cava.Netlist.
 
 Definition sbox_canright_interface
   := combinationalInterface "sbox_canright"
-     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.BitVec Kind.Bit 8))
-     (mkPort "data_o" (Kind.BitVec Kind.Bit 8))
+     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8))
+     (mkPort "data_o" (Kind.Vec Kind.Bit 8))
      nil.
 
 Definition sbox_canright_netlist :=
@@ -33,8 +33,8 @@ Definition sbox_canright_netlist :=
 
 Definition sbox_lut_interface
   := combinationalInterface "sbox_lut"
-     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.BitVec Kind.Bit 8))
-     (mkPort "data_o" (Kind.BitVec Kind.Bit 8))
+     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8))
+     (mkPort "data_o" (Kind.Vec Kind.Bit 8))
      nil.
 
 Definition sbox_lut_netlist :=

--- a/arrow-examples/UnsignedAdder.v
+++ b/arrow-examples/UnsignedAdder.v
@@ -81,33 +81,33 @@ Require Import Cava.Netlist.
 
 Definition adder445_interface
   := combinationalInterface "adder445"
-     (mkPort "a" (Kind.BitVec Kind.Bit 4), mkPort "b" (Kind.BitVec Kind.Bit 4))
-     (mkPort "sum" (Kind.BitVec Kind.Bit 5))
+     (mkPort "a" (Kind.Vec Kind.Bit 4), mkPort "b" (Kind.Vec Kind.Bit 4))
+     (mkPort "sum" (Kind.Vec Kind.Bit 5))
      [].
 Definition adder88810_interface
   := combinationalInterface "adder88810"
-     (mkPort "a" (Kind.BitVec Kind.Bit 8), (mkPort "b" (Kind.BitVec Kind.Bit 8), mkPort "c" (Kind.BitVec Kind.Bit 8)))
-     (mkPort "sum" (Kind.BitVec Kind.Bit 10))
+     (mkPort "a" (Kind.Vec Kind.Bit 8), (mkPort "b" (Kind.Vec Kind.Bit 8), mkPort "c" (Kind.Vec Kind.Bit 8)))
+     (mkPort "sum" (Kind.Vec Kind.Bit 10))
      [].
 Definition adder444_tree_4_interface
   := combinationalInterface "adder444_tree_4"
-     (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 4))
-     (mkPort "result" (Kind.BitVec Kind.Bit 4))
+     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 4))
+     (mkPort "result" (Kind.Vec Kind.Bit 4))
      [].
 Definition adder444_tree_8_interface
   := combinationalInterface "adder444_tree_8"
-     (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 8))
-     (mkPort "result" (Kind.BitVec Kind.Bit 4))
+     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 8))
+     (mkPort "result" (Kind.Vec Kind.Bit 4))
      [].
 Definition adder444_tree_64_interface
   := combinationalInterface "adder444_tree_64"
-     (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 64))
-     (mkPort "result" (Kind.BitVec Kind.Bit 4))
+     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 64))
+     (mkPort "result" (Kind.Vec Kind.Bit 4))
      [].
 Definition growth_tree_8_interface
   := combinationalInterface "growth_tree_8"
-     (mkPort "vec" (Kind.BitVec (Kind.BitVec Kind.Bit 4) 8))
-     (mkPort "result" (Kind.BitVec Kind.Bit 7))
+     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 8))
+     (mkPort "result" (Kind.Vec Kind.Bit 7))
      [].
 
 Definition adder445_netlist :=

--- a/cava/Cava/Kind.v
+++ b/cava/Cava/Kind.v
@@ -24,13 +24,13 @@ From Coq Require Import Vector.
 Inductive Kind : Type :=
   | Void : Kind                    (* An empty type *)
   | Bit : Kind                     (* A single wire *)
-  | BitVec : Kind -> nat -> Kind   (* Vectors, possibly nested *)
+  | Vec : Kind -> nat -> Kind      (* Vectors, possibly nested *)
   | ExternalType : string -> Kind. (* An uninterpreted type *)
 
 Fixpoint listOfVecTy (bv: Kind) : Type :=
   match bv with
   | Void => list bool
   | Bit => list bool
-  | BitVec k2 _ => list (listOfVecTy k2)
+  | Vec k2 _ => list (listOfVecTy k2)
   | ExternalType _ => list bool
   end.

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -98,7 +98,7 @@ Fixpoint defaultKindBool (k: Kind) : smashTy bool k :=
   match k return smashTy bool k  with
   | Void => UndefinedSignal
   | Bit => false
-  | BitVec k2 sz => Vector.const (defaultKindBool k2) sz
+  | Vec k2 sz => Vector.const (defaultKindBool k2) sz
   | ExternalType _ => UninterpretedSignal "XXX"
   end.
 

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -30,24 +30,24 @@ Inductive Signal : Kind -> Type :=
   | Vcc: Signal Bit
   | Wire: N -> Signal Bit
   | NamedWire: string -> Signal Bit
-  | NamedVector: forall k s, string -> Signal (BitVec k s)
-  | LocalBitVec: forall k s, N -> Signal (BitVec k s)
-  | VecLit: forall {k s}, Vector.t (Signal k) s -> Signal (BitVec k s)
+  | NamedVector: forall k s, string -> Signal (Vec k s)
+  | LocalVec: forall k s, N -> Signal (Vec k s)
+  | VecLit: forall {k s}, Vector.t (Signal k) s -> Signal (Vec k s)
   (* Dynamic index *)
-  | IndexAt:  forall {k sz isz}, Signal (BitVec k sz) ->
-              Signal (BitVec Bit isz) -> Signal k
+  | IndexAt:  forall {k sz isz}, Signal (Vec k sz) ->
+              Signal (Vec Bit isz) -> Signal k
   (* Static indexing *)
-  | IndexConst: forall {k sz}, Signal (BitVec k sz) -> nat -> Signal k
+  | IndexConst: forall {k sz}, Signal (Vec k sz) -> nat -> Signal k
   (* Static slice *)
-  | Slice: forall {k sz} (start len: nat), Signal (BitVec k sz) ->
-                                           Signal (BitVec k len).
+  | Slice: forall {k sz} (start len: nat), Signal (Vec k sz) ->
+                                           Signal (Vec k len).
 
 (* A default unsmashed value for a given Kind. *)
 Fixpoint defaultKindSignal (k: Kind) : Signal k :=
   match k with
   | Void => UndefinedSignal
   | Bit => Gnd
-  | BitVec k s => VecLit (Vector.const (defaultKindSignal k) s)
+  | Vec k s => VecLit (Vector.const (defaultKindSignal k) s)
   | ExternalType s => UninterpretedSignal "default-error"
   end.
 

--- a/cava/Cava/Types.v
+++ b/cava/Cava/Types.v
@@ -141,18 +141,18 @@ Instance ToShapePair2 {A t1 t2 : Type} `{@ToShape A t1} `{@ToShape A t2}:
 
 Notation bundle := (@shape Kind).
 
-Fixpoint denoteBitVecWith {A : Type} (T : Type) (n : list A) : Type :=
+Fixpoint denoteVecWith {A : Type} (T : Type) (n : list A) : Type :=
   match n with
   | [] => T
   | [x] => list T
-  | x::xs => list (denoteBitVecWith T xs)
+  | x::xs => list (denoteVecWith T xs)
   end.
 
 Fixpoint denoteKindWith (k : Kind) (T : Type) : Type :=
   match k with
   | Void => unit
   | Bit => T
-  | BitVec k2 s => Vector.t (denoteKindWith k2 T) s
+  | Vec k2 s => Vector.t (denoteKindWith k2 T) s
   | ExternalType t => T
   end.
 
@@ -160,7 +160,7 @@ Fixpoint bitsInPort (p : Kind) : nat :=
   match p with
   | Void => 0
   | Bit => 1
-  | BitVec xs sz => sz * bitsInPort xs
+  | Vec xs sz => sz * bitsInPort xs
   | ExternalType _ => 0
   end.
 
@@ -235,7 +235,7 @@ Fixpoint smashTy (T: Type) (k: Kind) : Type :=
   match k with
   | Void => Signal Void
   | Bit => T
-  | BitVec k2 s => Vector.t (smashTy T k2) s
+  | Vec k2 s => Vector.t (smashTy T k2) s
   | ExternalType t => Signal (ExternalType t)
   end.
 
@@ -252,7 +252,7 @@ Fixpoint smash {k: Kind} (v: Signal k) : smashTy (Signal Bit) k :=
   match k, v return smashTy (Signal Bit) k with
   | Void, vv => UndefinedSignal
   | Bit, vv => vv
-  | BitVec k2 s, vv => Vector.map (fun i => smash (IndexConst vv i)) (vseq 0 s)
+  | Vec k2 s, vv => Vector.map (fun i => smash (IndexConst vv i)) (vseq 0 s)
   | ExternalType t, vv => UninterpretedSignal "smash-error"
   end.
 
@@ -260,7 +260,7 @@ Fixpoint smash {k: Kind} (v: Signal k) : smashTy (Signal Bit) k :=
 Fixpoint vecLitS {k: Kind} (v: smashTy (Signal Bit) k) : Signal k :=
   match k, v return Signal k with
   | Bit, vv => vv
-  | BitVec k2 s2, vv => VecLit (Vector.map vecLitS vv)
+  | Vec k2 s2, vv => VecLit (Vector.map vecLitS vv)
   | Void, _ => UndefinedSignal
   | ExternalType s, _ => UninterpretedSignal "vecLitS-error"
   end.
@@ -270,7 +270,7 @@ Definition unsmash {k : Kind} (v : smashTy (Signal Bit) k) : Signal k :=
   match k, v with
   | Void, vv => UndefinedSignal
   | Bit, vv => vv
-  | BitVec k2 s, vv => vecLitS vv
+  | Vec k2 s, vv => vecLitS vv
   | ExternalType t, vv => UninterpretedSignal "unsmash-error"
   end.
 

--- a/monad-examples/AdderTree.v
+++ b/monad-examples/AdderTree.v
@@ -88,8 +88,8 @@ Proof. reflexivity. Qed.
 
 Definition adder_tree_Interface name nrInputs bitSize
   := combinationalInterface name
-     (mkPort "inputs" (BitVec (BitVec Bit bitSize) nrInputs))
-     (mkPort "sum" (BitVec Bit bitSize))
+     (mkPort "inputs" (Vec (Vec Bit bitSize) nrInputs))
+     (mkPort "sum" (Vec Bit bitSize))
      [].
 
 (* Create netlist and test-bench for a 4-input adder tree. *)

--- a/monad-examples/Multiplexers.v
+++ b/monad-examples/Multiplexers.v
@@ -109,8 +109,8 @@ Definition mux2_1_tb
 
   Definition mux2_1_bit_Interface
     := combinationalInterface "mux2_1_bit"
-       (mkPort "v" (BitVec Bit 4),
-        mkPort "sel" (BitVec Bit 2))
+       (mkPort "v" (Vec Bit 4),
+        mkPort "sel" (Vec Bit 2))
        (mkPort "o" Bit)
        [].
 
@@ -134,23 +134,23 @@ Definition mux2_1_tb
 (* Mux between input buses *)
 
 Definition muxBusAlt {m bit} `{Cava m bit} {k} {sz isz: nat}
-                     (vsel: smashTy bit (BitVec k sz) *
+                     (vsel: smashTy bit (Vec k sz) *
                             Vector.t bit isz) :
                      m (smashTy bit k) :=
   let (v, sel) := vsel in
   ret (indexAt v sel).
 
 Definition muxBus {m bit} `{Cava m bit} {sz isz dsz: nat}
-                     (vsel: Vector.t (smashTy bit (BitVec Bit dsz)) sz *
+                     (vsel: Vector.t (smashTy bit (Vec Bit dsz)) sz *
                             Vector.t bit isz) :
-                     m (smashTy bit (BitVec Bit dsz)) :=
+                     m (smashTy bit (Vec Bit dsz)) :=
   let (v, sel) := vsel in
   ret (indexAt v sel).
 
 Definition muxBus4_8 {m bit} `{Cava m bit}
-                     (vsel: Vector.t (smashTy bit (BitVec Bit 8)) 4 *
+                     (vsel: Vector.t (smashTy bit (Vec Bit 8)) 4 *
                             Vector.t bit 2) :
-                     m (smashTy bit (BitVec Bit 8)) :=
+                     m (smashTy bit (Vec Bit 8)) :=
   let (v, sel) := vsel in
   ret (indexAt v sel).
 
@@ -177,8 +177,8 @@ Local Close Scope vector_scope.
 
 Definition muxBus4_8Interface
   := combinationalInterface "muxBus4_8"
-     (mkPort "i" (BitVec (BitVec Bit 8) 4), mkPort "sel" (BitVec Bit 2))
-     (mkPort "o" (BitVec Bit 8))
+     (mkPort "i" (Vec (Vec Bit 8) 4), mkPort "sel" (Vec Bit 2))
+     (mkPort "o" (Vec Bit 8))
      [].
 
 Definition muxBus4_8Netlist := makeNetlist muxBus4_8Interface muxBus4_8.

--- a/monad-examples/Sorter.v
+++ b/monad-examples/Sorter.v
@@ -39,7 +39,7 @@ Lemma zero_lt_z: 0 < 2. auto. Qed.
 Lemma one_lt_z: 1 < 2. auto. Qed.
 
 Definition twoSorter {m bit} `{Cava m bit} {n}
-                     (ab: Vector.t (smashTy bit (BitVec Bit n)) 2) :
+                     (ab: Vector.t (smashTy bit (Vec Bit n)) 2) :
                      m (Vector.t (Vector.t bit n) 2) :=
    let a := @Vector.nth_order _ 2 ab 0 zero_lt_z in
    let b := @Vector.nth_order _ 2 ab 1 one_lt_z in
@@ -51,8 +51,8 @@ Definition twoSorter {m bit} `{Cava m bit} {n}
 
 Definition two_sorter_Interface bitSize
   := combinationalInterface "two_sorter"
-     (mkPort "inputs" (BitVec (BitVec Bit bitSize) 2))
-     (mkPort "sorted" (BitVec (BitVec Bit bitSize) 2))
+     (mkPort "inputs" (Vec (Vec Bit bitSize) 2))
+     (mkPort "sorted" (Vec (Vec Bit bitSize) 2))
      [].
 
 Definition two_sorter_Netlist

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -93,8 +93,8 @@ Local Open Scope nat_scope.
 
 Definition adder4Interface
   := combinationalInterface "adder4"
-     (mkPort "a" (BitVec Bit 4), mkPort "b" (BitVec Bit 4))
-     (mkPort "sum" (BitVec Bit 5))
+     (mkPort "a" (Vec Bit 4), mkPort "b" (Vec Bit 4))
+     (mkPort "sum" (Vec Bit 5))
      [].
 
 Definition adder4Netlist
@@ -116,8 +116,8 @@ Definition adder4_tb
 
 Definition adder8_3inputInterface
   := combinationalInterface "adder8_3input"
-     (mkPort "a" (BitVec Bit 8), mkPort "b" (BitVec Bit 8), mkPort "c" (BitVec Bit 8))
-     (mkPort "sum" (BitVec Bit 10))
+     (mkPort "a" (Vec Bit 8), mkPort "b" (Vec Bit 8), mkPort "c" (Vec Bit 8))
+     (mkPort "sum" (Vec Bit 10))
      [].
 
 Definition add3InputTuple {m bit} `{Cava m bit}

--- a/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/monad-examples/xilinx/XilinxAdderExamples.v
@@ -71,8 +71,8 @@ Proof. reflexivity. Qed.
 
 Definition adder8Interface
   := combinationalInterface "adder8"
-     (mkPort "cin" Bit, (mkPort "a" (BitVec Bit 8), mkPort "b" (BitVec Bit 8)))
-     (mkPort "sum" (BitVec Bit 8), mkPort "cout" Bit)
+     (mkPort "cin" Bit, (mkPort "a" (Vec Bit 8), mkPort "b" (Vec Bit 8)))
+     (mkPort "sum" (Vec Bit 8), mkPort "cout" Bit)
      [].
 
 Definition adder8Netlist := makeNetlist adder8Interface xilinxAdderWithCarry.

--- a/monad-examples/xilinx/XilinxAdderTree.v
+++ b/monad-examples/xilinx/XilinxAdderTree.v
@@ -92,8 +92,8 @@ Local Open Scope nat_scope.
 
 Definition adder_tree_Interface name nrInputs bitSize
   := combinationalInterface name
-     (mkPort "inputs" (BitVec (BitVec Bit bitSize) nrInputs))
-     (mkPort "sum" (BitVec Bit bitSize))
+     (mkPort "inputs" (Vec (Vec Bit bitSize) nrInputs))
+     (mkPort "sum" (Vec Bit bitSize))
      [].
 
 (* Create netlist and test-bench for a 4-input adder tree. *)

--- a/monad-examples/xilinx/_CoqProject
+++ b/monad-examples/xilinx/_CoqProject
@@ -1,4 +1,6 @@
 -R ../../cava/Cava Cava
+-R ../../third_party/coq-ext-lib/theories ExtLib
+-R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 -R . XilinxExamples
 NandLUT.v
 XilinxAdderExamples.v

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -61,13 +61,13 @@ Definition pinmuxInterface :=
   sequentialInterface "pinmux"
      "clk_i" NegativeEdge "rst_ni" NegativeEdge
      (mkPort "tl_i" (ExternalType "tlul_pkg::tl_h2d_t"),
-      mkPort "periph_to_mio_i" (BitVec Bit NPeriphOut),
-      mkPort "periph_to_mio_oe_i" (BitVec Bit NPeriphOut),
-      mkPort "mio_in_i" (BitVec Bit NMioPads))
+      mkPort "periph_to_mio_i" (Vec Bit NPeriphOut),
+      mkPort "periph_to_mio_oe_i" (Vec Bit NPeriphOut),
+      mkPort "mio_in_i" (Vec Bit NMioPads))
      (mkPort "tl_o" (ExternalType "tlul_pkg::tl_d2h_t"),
-      mkPort "mio_to_periph_o" (BitVec Bit NPeriphIn),
-      mkPort "mio_out_o" (BitVec Bit NMioPads),
-      mkPort "mio_oe_o" (BitVec Bit NMioPads))
+      mkPort "mio_to_periph_o" (Vec Bit NPeriphIn),
+      mkPort "mio_out_o" (Vec Bit NMioPads),
+      mkPort "mio_oe_o" (Vec Bit NMioPads))
      [].
 
 
@@ -99,11 +99,11 @@ Definition pinmux_reg2hw_periph_insel_mreg_t
   := ExternalType "pinmux_reg2hw_periph_insel_mreg_t".
 
 Definition kq (f: string)
-              (reg2hw: Signal pinmux_reg2hw_t) (k: nat) : Signal (BitVec Bit 6) :=
-  let periph_insel : Signal (BitVec (BitVec Bit 6) NPeriphIn) :=
-     SelectField (BitVec (BitVec Bit 6) NPeriphIn)
+              (reg2hw: Signal pinmux_reg2hw_t) (k: nat) : Signal (Vec Bit 6) :=
+  let periph_insel : Signal (Vec (Vec Bit 6) NPeriphIn) :=
+     SelectField (Vec (Vec Bit 6) NPeriphIn)
         reg2hw f in
-  SelectField (BitVec Bit 6) (IndexConst periph_insel k) "q".
+  SelectField (Vec Bit 6) (IndexConst periph_insel k) "q".
 
 Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
                            Vector.t (Signal Bit) NPeriphOut  *


### PR DESCRIPTION
Rename `BitVec` to `Vec`.
Adresses #276 

In preparation for trying to remove type level vector smahsing.