### PR TITLE
Fixup Makefile build rules for SystemVerilog generation

### DIFF
--- a/monad-examples/Makefile
+++ b/monad-examples/Makefile
@@ -41,11 +41,10 @@ coq:		Makefile.coq
 
 ExamplesSV:	ExamplesSV.hs
 		ghc --make $^
-
-.PRECIOUS:	$(SV) $(BENCHES) $(CPPS)
-
-nand2.sv:	coq ExamplesSV
 		./ExamplesSV
+
+$(SV) $(BENCHES) $(VCDS):	coq ExamplesSV
+
 
 %_tb.vcd:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp

--- a/monad-examples/xilinx/Makefile
+++ b/monad-examples/xilinx/Makefile
@@ -48,11 +48,9 @@ coq:		Makefile.coq
 
 ExamplesSV:	ExamplesSV.hs
 		ghc -O2 --make $^
-
-.PRECIOUS:	$(SV) $(BENCHES) $(CPPS)
-
-adder8.sv:	coq ExamplesSV
 		./ExamplesSV
+
+$(SV) $(BENCHES) $(VCDS):	coq ExamplesSV
 
 %_tb.vcd:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -39,11 +39,9 @@ coq:		Makefile.coq
 
 TestsSV:	TestsSV.hs
 		ghc --make $^
-
-.PRECIOUS:	$(SV) $(BENCHES) $(CPPS)
-
-instantiate.sv:	coq TestsSV
 		./TestsSV
+
+$(SV) $(BENCHES) $(VCDS):	coq TestsSV
 
 %_tb.vcd:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp

--- a/tests/xilinx/.gitignore
+++ b/tests/xilinx/.gitignore
@@ -1,0 +1,9 @@
+# Haskell files except the manually created ones
+*.hs
+!VivadoTestsSV.hs
+
+VivadoTestsSV
+
+*.sv
+*.cpp
+*.tcl

--- a/tests/xilinx/Makefile
+++ b/tests/xilinx/Makefile
@@ -28,7 +28,7 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
-all:		coq lut1_inv.sv $(VCDS)
+all:		coq $(VCDS)
 extraction:	$(SV)
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt -y $(XILINX)/data/verilog/src/xeclib
@@ -42,11 +42,9 @@ coq:		Makefile.coq
 
 VivadoTestsSV:	VivadoTestsSV.hs
 		ghc -O2 --make $^
-
-.PRECIOUS:	$(SV) $(BENCHES)
-
-lut1_inv.sv:	coq VivadoTestsSV
 		./VivadoTestsSV
+
+$(SV) $(BENCHES) $(VCDS):	coq VivadoTestsSV
 
 %_tb.vcd:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
@@ -62,6 +60,4 @@ lut1_inv.sv:	coq VivadoTestsSV
 clean:
 	-@$(MAKE) -f Makefile.coq clean
 	git clean -Xfd
-	rm -rf *.sv *.tcl *.cpp *.vcd VivadoTestsSV LUTTests.hs \
-               *.cpp *.sv *.tcl LUTTests.hs *.cpp
 	rm -rf obj_dir


### PR DESCRIPTION
This fixes the dependencies for the generation of SystemVerilog files, SV testbenches and VCD files that are the result of Verilator simulation. Now `make` can be invoked with any other intermediate targets.