### PR TITLE
Prove Wf for arrow combinators and unrolled_cipher_naive

### DIFF
--- a/arrow-examples/Aes/CipherProperties.v
+++ b/arrow-examples/Aes/CipherProperties.v
@@ -56,6 +56,38 @@ Module Vector.
   Qed.
 End Vector.
 
+Section Wf.
+  Lemma aes_transpose_Wf n m : Wf (@pkg.aes_transpose n m).
+  Proof. induction n; cbn [pkg.aes_transpose]; prove_Wf. Qed.
+  Hint Resolve aes_transpose_Wf : Wf.
+
+  Axiom aes_256_naive_key_expansion_Wf :
+    forall sbox_impl, Wf (aes_256_naive_key_expansion sbox_impl).
+  Axiom cipher_round_Wf :
+    forall sbox_impl, Wf (Combinators.curry (cipher_round sbox_impl)).
+  Axiom final_cipher_round_Wf :
+    forall sbox_impl, Wf (final_cipher_round sbox_impl).
+  Axiom aes_mix_columns_Wf : Wf mix_columns.aes_mix_columns.
+  Hint Resolve aes_256_naive_key_expansion_Wf
+       cipher_round_Wf final_cipher_round_Wf aes_mix_columns_Wf : Wf.
+
+  Lemma CIPH_FWD_Wf : Wf (pkg.CIPH_FWD).
+  Proof. cbv [pkg.CIPH_FWD]; prove_Wf. Qed.
+  Hint Resolve CIPH_FWD_Wf : Wf.
+  Lemma CIPH_INV_Wf : Wf (pkg.CIPH_INV).
+  Proof. cbv [pkg.CIPH_INV]; prove_Wf. Qed.
+  Hint Resolve CIPH_INV_Wf : Wf.
+
+  Lemma unrolled_cipher_naive'_Wf :
+    forall sbox_impl, Wf (unrolled_cipher_naive' sbox_impl).
+  Proof. cbv [unrolled_cipher_naive']; prove_Wf. Qed.
+  Hint Resolve unrolled_cipher_naive'_Wf : Wf.
+
+  Lemma unrolled_cipher_naive_Wf :
+    forall sbox_impl, Wf (unrolled_cipher_naive sbox_impl).
+  Proof. cbv [unrolled_cipher_naive]; prove_Wf. Qed.
+End Wf.
+
 Local Ltac derived_spec_done :=
   lazymatch goal with
   | |- context [interp_combinational' ?x] =>

--- a/arrow-examples/CombinatorProperties.v
+++ b/arrow-examples/CombinatorProperties.v
@@ -145,6 +145,16 @@ End CombinatorWf.
 Hint Resolve replicate_Wf reverse_Wf reshape_Wf flatten_Wf map_Wf map2_Wf
      foldl_Wf enable_Wf bitwise_Wf equality_Wf mux_item_Wf : Wf.
 
+(* Extra power for lemmas that produce Wf preconditions; use prove_Wf *)
+Hint Extern 4 (Wf (Combinators.foldl _)) =>
+(simple eapply foldl_Wf; solve [prove_Wf]) : Wf.
+Hint Extern 4 (Wf (Combinators.bitwise _)) =>
+(simple eapply bitwise_Wf; solve [prove_Wf]) : Wf.
+Hint Extern 4 (Wf (Combinators.map _)) =>
+(simple eapply map_Wf; solve [prove_Wf]) : Wf.
+Hint Extern 4 (Wf (Combinators.map2 _)) =>
+(simple eapply map2_Wf; solve [prove_Wf]) : Wf.
+
 (* Miscellaneous helpful proofs for combinator equivalence *)
 Section Misc.
   Lemma eqb_negb_xor x y : Bool.eqb x y = negb (xorb x y).


### PR DESCRIPTION
This is not yet plugged into proofs, but serves as a sanity check that the circuits follow the preconditions needed to prove that `closure_conversion` preserves semantics (see #273). I'm leaving `Wf` admitted for the same subcircuits that I've left admitted for the equivalence proofs.