### PR TITLE
Separate primitive semantics

### DIFF
--- a/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -167,7 +167,7 @@ Ltac circuit_spec_instantiate :=
     lazymatch goal with
     | |- context [combinational_evaluation' (CircuitArrow.Primitive _)] =>
       (* simplify combinational_evaluation' if there's a primitive *)
-      cbv [combinational_evaluation']
+      cbv [combinational_evaluation' primitive_interp]
     | |- _ = @resize_default _ ?n ?d ?n ?v =>
       (* change resize_default to identity function if it appears *)
       transitivity v; [ | rewrite resize_default_id; reflexivity ]

--- a/cava/Cava/Arrow/DeriveSpec.v
+++ b/cava/Cava/Arrow/DeriveSpec.v
@@ -24,9 +24,9 @@ Require Import Cava.Arrow.ArrowExport.
 Ltac kappa_spec_begin :=
   intros; cbn [interp_combinational'];
   repeat match goal with
-         | |- context [combinational_evaluation' (CircuitArrow.Primitive ?p)] =>
-           let x := constr:(combinational_evaluation' (CircuitArrow.Primitive p)) in
-           let y := (eval cbv [combinational_evaluation'] in x) in
+         | |- context [primitive_interp ?p] =>
+           let x := constr:(primitive_interp p) in
+           let y := (eval cbv [primitive_interp] in x) in
            progress change x with y
          | _ => progress cbn [denote_kind primitive_input primitive_output]
          end; fold denote_kind in *.

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -42,7 +42,7 @@ Section combinational_semantics.
     | App f e => fun y =>
       (interp_combinational' f) (interp_combinational' e tt, y)
     | Comp g f => fun x => interp_combinational' g (interp_combinational' f x)
-    | Primitive p => combinational_evaluation' (CircuitArrow.Primitive p)
+    | Primitive p => primitive_interp p
     | Id => fun x => x
     | Let v f => fun y =>
       interp_combinational' (f (interp_combinational' v tt)) y


### PR DESCRIPTION
This reduces duplication and removes the need for `ExprSemantics.v ` to depend on `CircuitSemantics.v `