### PR TITLE
An experimental simplified monad kernel: Acorn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 **/*\#*
 **/obj_dir
 **/*.vcd
+cava.code-workspace

--- a/cava/Cava/Acorn/Acorn.v
+++ b/cava/Cava/Acorn/Acorn.v
@@ -14,25 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import String.
-From Coq Require Import Vector.
-
-From Cava Require Import VectorUtils.
-
-(******************************************************************************)
-(* Values of Kind can occur as the type of signals on a circuit interface *)
-(******************************************************************************)
-
-Inductive Kind : Type :=
-  | Void : Kind                    (* An empty type *)
-  | Bit : Kind                     (* A single wire *)
-  | Vec : Kind -> nat -> Kind      (* Vectors, possibly nested *)
-  | ExternalType : string -> Kind. (* An uninterpreted type *)
-
-Fixpoint listOfVecTy (bv: Kind) : Type :=
-  match bv with
-  | Void => list bool
-  | Bit => list bool
-  | Vec k2 _ => list (listOfVecTy k2)
-  | ExternalType _ => list bool
-  end.
+Require Export Acorn.AcornSignal.
+Require Export Acorn.AcornCavaClass.
+Require Export Acorn.AcornNetlist.
+Require Export Acorn.AcornState.
+Require Export Acorn.Combinational.
+Require Export Acorn.AcornNetlistGeneration.
+Require Export Acorn.Combinational.
+Require Export Acorn.AcornCombinators.

--- a/cava/Cava/Acorn/AcornCavaClass.v
+++ b/cava/Cava/Acorn/AcornCavaClass.v
@@ -14,25 +14,25 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import String.
-From Coq Require Import Vector.
+Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import VectorUtils.
+From Cava Require Import Acorn.AcornSignal.
 
-(******************************************************************************)
-(* Values of Kind can occur as the type of signals on a circuit interface *)
-(******************************************************************************)
+Open Scope type_scope.
 
-Inductive Kind : Type :=
-  | Void : Kind                    (* An empty type *)
-  | Bit : Kind                     (* A single wire *)
-  | Vec : Kind -> nat -> Kind      (* Vectors, possibly nested *)
-  | ExternalType : string -> Kind. (* An uninterpreted type *)
+Class Cava m `{Monad m} (signal : SignalType -> Type) := {
+  one : signal BitType;
+  zero : signal BitType;
+  inv : signal BitType -> m (signal BitType);
+  and2 : signal BitType * signal BitType -> m (signal BitType);
+  or2 : signal BitType * signal BitType -> m (signal BitType);
+  xor2 : signal BitType * signal BitType -> m (signal BitType);
+  pair : forall {A B : SignalType}, signal A -> signal B -> signal (PairType A B);
+  fsT : forall {A B : SignalType}, signal (PairType A B) -> signal A;
+  snD : forall {A B : SignalType}, signal (PairType A B) -> signal B;
+}.
 
-Fixpoint listOfVecTy (bv: Kind) : Type :=
-  match bv with
-  | Void => list bool
-  | Bit => list bool
-  | Vec k2 _ => list (listOfVecTy k2)
-  | ExternalType _ => list bool
-  end.
+Definition unpair {m signal} `{Cava m signal}
+          {A B : SignalType}
+          (ab: signal (PairType A B)) : (signal A * signal B) :=
+  (fsT ab, snD ab).

--- a/cava/Cava/Acorn/AcornCombinators.v
+++ b/cava/Cava/Acorn/AcornCombinators.v
@@ -1,0 +1,121 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Lists.List.
+Import ListNotations.
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
+Import VectorNotations.
+Local Open Scope vector_scope.
+Require Import ExtLib.Structures.Monads.
+Import MonadNotation.
+Open Scope monad_scope.
+
+Require Export Acorn.AcornSignal.
+Require Export Acorn.AcornCavaClass.
+
+Open Scope type_scope.
+
+Definition fork2 {m signal} `{Cava m signal} {A : SignalType}
+                 (input : signal A) : m (signal A * signal A) :=
+  ret (input, input).
+
+(*
+-------------------------------------------------------------------------------
+-- 4-Sided tile col combinators
+-------------------------------------------------------------------------------
+-- COL r, where r :: (a, vec b) -> (vec c, a)
+--            a
+--            ^
+--            |
+--          -----
+--         |     |
+--     b ->|  r  |-> c
+--         |     |
+--          -----
+--            ^
+--            |
+--            a
+--            ^
+--            |
+--          -----
+--         |     |
+--     b ->|  r  |-> c
+--         |     |
+--          -----
+--            ^
+--            |
+--            a
+--            ^
+--            |
+--          -----
+--         |     |
+--     b ->|  r  |-> c
+--         |     |
+--          -----
+--            ^
+--            |
+--            a
+-------------------------------------------------------------------------------
+*)
+
+(* colV is a col combinator that works over Vector.t of signals.
+   The input tuple is split into separate arguments so Coq can recognize
+   the decreasing vector element.
+*)
+Fixpoint colV' {m} `{Monad m} {A B C} {n : nat}
+               (circuit : A * B -> m (C * A))
+               (aIn: A) (bIn: Vector.t B n) :
+               m (Vector.t C n * A) :=
+  match bIn with
+  | [] => ret ([], aIn)
+  | x::xs => '(b0, aOut) <- circuit (aIn, x) ;;
+             '(bRest, aFinal) <- colV' circuit aOut xs ;;
+              ret (b0::bRest, aFinal)
+  end.
+
+Definition colV {m} `{Monad m} {A B C} {n : nat}
+                (circuit : A * B -> m (C * A))
+                (inputs: A * Vector.t B n) :
+                m (Vector.t C n * A) :=
+ colV' circuit (fst inputs) (snd inputs).
+
+Local Close Scope vector_scope.
+
+Local Open Scope list_scope.
+
+(* List Variant *)
+
+ Fixpoint colL' {m} `{Monad m} {A B C}
+               (circuit : A * B -> m (C * A))
+               (aIn: A) (bIn: list B) :
+               m (list C * A) :=
+  match bIn with
+  | [] => ret ([], aIn)
+  | x::xs => '(b0, aOut) <- circuit (aIn, x) ;;
+             '(bRest, aFinal) <- colL' circuit aOut xs ;;
+              ret (b0::bRest, aFinal)
+  end.
+
+Definition colL {m} `{Monad m} {A B C}
+                (circuit : A * B -> m (C * A))
+                (inputs: A * list B) :
+                m (list C * A) :=
+ colL' circuit (fst inputs) (snd inputs).
+
+(* TODO(satnam): Lemma about col_cons *)
+
+Local Close Scope list_scope.

--- a/cava/Cava/Acorn/AcornNetlist.v
+++ b/cava/Cava/Acorn/AcornNetlist.v
@@ -14,25 +14,16 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import String.
-From Coq Require Import Vector.
+From Coq Require Import Lists.List.
+Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import VectorUtils.
+From Cava Require Import Acorn.AcornSignal.
 
-(******************************************************************************)
-(* Values of Kind can occur as the type of signals on a circuit interface *)
-(******************************************************************************)
+Inductive AcornInstance : Type :=
+  | Inv : Signal BitType -> Signal BitType -> AcornInstance
+  | And2 : Signal BitType -> Signal BitType -> Signal BitType -> AcornInstance
+  | Or2 : Signal BitType -> Signal BitType -> Signal BitType -> AcornInstance
+  | Xor2 : Signal BitType -> Signal BitType -> Signal BitType -> AcornInstance.
 
-Inductive Kind : Type :=
-  | Void : Kind                    (* An empty type *)
-  | Bit : Kind                     (* A single wire *)
-  | Vec : Kind -> nat -> Kind      (* Vectors, possibly nested *)
-  | ExternalType : string -> Kind. (* An uninterpreted type *)
+Notation AcornNetlist := (list AcornInstance).
 
-Fixpoint listOfVecTy (bv: Kind) : Type :=
-  match bv with
-  | Void => list bool
-  | Bit => list bool
-  | Vec k2 _ => list (listOfVecTy k2)
-  | ExternalType _ => list bool
-  end.

--- a/cava/Cava/Acorn/AcornSignal.v
+++ b/cava/Cava/Acorn/AcornSignal.v
@@ -1,0 +1,55 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import ZArith.
+From Coq Require Import String.
+From Coq Require Import Vector.
+
+From Cava Require Import VectorUtils.
+
+Inductive SignalType :=
+  | VoidType : SignalType                      (* An empty type *)
+  | BitType : SignalType                       (* A single wire *)
+  | VecType : SignalType -> nat -> SignalType  (* Vectors, possibly nested *)
+  | ExternalType : string -> SignalType        (* An uninterpreted type *)
+  | PairType : SignalType -> SignalType -> SignalType. (* A tuple *)
+
+Inductive Signal : SignalType -> Type :=
+  | Const0 : Signal BitType
+  | Const1 : Signal BitType
+  | Void : Signal VoidType
+  | Wire : N -> Signal BitType
+  | Vec : forall {t : SignalType} {s : nat}, Vector.t (Signal t) s -> Signal (VecType t s)
+  | IndexSignal : forall {t : SignalType} {s : nat},
+                  Signal (VecType t s) -> nat -> Signal t
+  | Pair : forall {A B : SignalType}, Signal A -> Signal B -> Signal (PairType A B)
+  | Fst : forall {A B : SignalType}, Signal (PairType A B) -> Signal A
+  | Snd : forall {A B : SignalType}, Signal (PairType A B) -> Signal B.
+
+Definition peel {k: SignalType} {s: nat} (v: Signal (VecType k s)) :
+                Vector.t (Signal k) s :=
+  Vector.map (IndexSignal v) (vseq 0 s).
+
+Fixpoint denoteCombinaional (t : SignalType) : Type :=
+  match t with
+  | VoidType => unit
+  | BitType => bool
+  | VecType vt s => Vector.t (denoteCombinaional vt) s
+  | ExternalType _ => string
+  | PairType A B => denoteCombinaional A * denoteCombinaional B
+  end.
+
+Definition denoteSignal (t : SignalType) : Type := Signal t.

--- a/cava/Cava/Acorn/AcornState.v
+++ b/cava/Cava/Acorn/AcornState.v
@@ -1,0 +1,65 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Ascii String.
+From Coq Require Import ZArith.
+From Coq Require Import Lists.List.
+Import ListNotations.
+Open Scope list_scope.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.StateMonad.
+Import MonadNotation.
+Open Scope monad_scope.
+
+From Cava Require Import Acorn.AcornSignal.
+From Cava Require Import Acorn.AcornNetlist.
+
+
+Record AcornModule : Type := mkAcornModule{
+  moduleName : string;
+  netlist : AcornNetlist;
+}.
+
+Record AcornState : Type := mkAcornState {
+  netNumber : N;
+  module : AcornModule;
+}.
+
+Definition getNetNumber : state AcornState N :=
+  acornState <- get ;;
+  match acornState with
+  | mkAcornState netNr _ => ret netNr
+  end.
+
+
+Definition incrementNetNumber : state AcornState unit :=
+  acornState <- get ;;
+  match acornState with
+  | mkAcornState netNr m =>
+     put (mkAcornState (netNr + 1) m)
+  end.  
+
+Definition newWire : state AcornState (Signal BitType) :=
+  netNr <- getNetNumber ;;
+  incrementNetNumber ;;
+  ret (Wire netNr).
+
+Definition addInstance (newInst : AcornInstance) : state AcornState unit :=
+ acornState <- get ;;
+ match acornState with
+ | mkAcornState netNr (mkAcornModule name nl) =>
+     put (mkAcornState netNr (mkAcornModule name (newInst::nl)))
+ end.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -14,25 +14,23 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import String.
-From Coq Require Import Vector.
+From Coq Require Import Bool.Bool.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
 
-From Cava Require Import VectorUtils.
+From Cava Require Import Acorn.AcornSignal.
+From Cava Require Import Acorn.AcornCavaClass.
 
-(******************************************************************************)
-(* Values of Kind can occur as the type of signals on a circuit interface *)
-(******************************************************************************)
+Instance Combinational : Cava ident denoteCombinaional :=
+{ one := true;
+  zero := false;
+  inv i := ret (negb i);
+  and2 '(i0, i1) := ret (i0 && i1);
+  or2 '(i0, i1) := ret (i0 || i1);
+  xor2 '(i0, i1) := ret (xorb i0 i1);
+  pair _ _ a b := (a, b);
+  fsT _ _ '(a, b) := a;
+  snD _ _ '(a, b) := b;
+}.
 
-Inductive Kind : Type :=
-  | Void : Kind                    (* An empty type *)
-  | Bit : Kind                     (* A single wire *)
-  | Vec : Kind -> nat -> Kind      (* Vectors, possibly nested *)
-  | ExternalType : string -> Kind. (* An uninterpreted type *)
-
-Fixpoint listOfVecTy (bv: Kind) : Type :=
-  match bv with
-  | Void => list bool
-  | Bit => list bool
-  | Vec k2 _ => list (listOfVecTy k2)
-  | ExternalType _ => list bool
-  end.
+Definition combinational {a} (circuit : ident a) : a := unIdent circuit.

--- a/cava/Cava/Acorn/Lib/AcornFullAdder.v
+++ b/cava/Cava/Acorn/Lib/AcornFullAdder.v
@@ -1,0 +1,94 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Import MonadNotation.
+Open Scope monad_scope.
+Open Scope type_scope.
+
+From Cava Require Import Acorn.Acorn.
+
+Definition halfAdder {m signal} `{Cava m signal}
+                     (ab : signal BitType * signal BitType)
+                     : m (signal BitType * signal BitType) :=
+  let (a, b) := ab in 
+  partial_sum <- xor2 (a, b) ;;
+  carry <- and2 (a, b) ;;
+  ret (partial_sum, carry).
+
+(* A proof that the half-adder is correct. *)
+Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
+                            unIdent (halfAdder (a, b)) = (xorb a b, a && b).
+
+Proof.
+  auto.
+Qed.
+
+Definition halfAdderAlt {m signal} `{Cava m signal}
+                        (ab : signal (PairType BitType BitType))
+                        : m (signal (PairType BitType BitType)) :=
+  let (a, b) := unpair ab in 
+  partial_sum <- xor2 (a, b) ;;
+  carry <- and2 (a, b) ;;
+  ret (pair partial_sum carry).
+
+Definition fullAdder {m signal} `{Cava m signal}
+                     '(cin, (a, b))
+                     : m (signal BitType * signal BitType) :=
+  '(abl, abh) <- halfAdder (a, b) ;;
+  '(abcl, abch) <- halfAdder (abl, cin) ;;
+  cout <- or2 (abh, abch) ;;
+  ret (abcl, cout).
+
+(* A proof that the the full-adder is correct. *)
+Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
+                            combinational (fullAdder (cin, (a, b)))
+                              = (xorb cin (xorb a b),
+                                 (a && b) || (b && cin) || (a && cin)).
+Proof.
+  intros.
+  unfold combinational.
+  unfold fst.
+  simpl.
+  case a, b, cin.
+  all : reflexivity.
+Qed.
+
+Definition fullAdderAlt {m signal} `{Cava m signal}
+                        (cinab : signal (PairType BitType (PairType BitType BitType)))
+                       : m (signal (PairType BitType BitType)) :=
+  let (cin, ab) := unpair cinab in
+  let (a, b) := unpair ab in
+  abl_abh <- halfAdderAlt ab ;;
+  let (abl, abh) := unpair abl_abh in
+  abcl_abch <- halfAdderAlt (pair abl cin) ;;
+  let (abcl, abch) := unpair abcl_abch in
+  cout <- or2 (abh, abch) ;;
+  ret (pair abcl cout).
+
+Definition fullAdderAlt2 {m signal} `{Cava m signal}
+                        (cinab : signal BitType * signal (PairType BitType BitType))
+                       : m (signal BitType * signal BitType) :=
+  let (cin, ab) := cinab in
+  let (a, b) := unpair ab in
+  abl_abh <- halfAdderAlt ab ;;
+  let (abl, abh) := unpair abl_abh in
+  abcl_abch <- halfAdderAlt (pair abl cin) ;;
+  let (abcl, abch) := unpair abcl_abch in
+  cout <- or2 (abh, abch) ;;
+  ret (abcl, cout).

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
@@ -1,0 +1,135 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+From Coq Require Import NArith.
+From Coq Require Import Lists.List.
+Import ListNotations.
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
+Import VectorNotations.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Require Import ExtLib.Structures.MonadLaws.
+Import MonadNotation.
+Open Scope monad_scope.
+Open Scope type_scope.
+
+Require Import coqutil.Tactics.Tactics.
+Require Import Coq.micromega.Lia.
+Require Import Coq.Classes.Morphisms.
+
+From Cava Require Import BitArithmetic.
+Require Import Cava.Monad.MonadFacts.
+
+From Cava Require Import Acorn.Acorn.
+From Cava Require Import Acorn.Lib.AcornFullAdder.
+From Cava Require Import Acorn.Lib.AcornUnsignedAdders.
+
+Local Open Scope N_scope.
+
+(* First prove the full-adder correct. *)
+
+Lemma fullAdder_correct (cin a b : bool) :
+  combinational (fullAdder (cin, (a, b))) =
+  let sum := N.b2n a + N.b2n b + N.b2n cin in
+  (N.testbit sum 0, N.testbit sum 1).
+Proof. destruct cin, a, b; reflexivity. Qed.
+
+(* Lemma about how to decompose a list of vectors. *)
+Lemma list_bits_to_nat_cons b bs :
+  list_bits_to_nat (b :: bs) = (N.b2n b + 2 * (list_bits_to_nat bs))%N.
+Proof.
+  cbv [list_bits_to_nat].
+  cbn [Vector.of_list Ndigits.Bv2N].
+  destruct b; cbn [N.b2n].
+  all: rewrite ?N.succ_double_spec, ?N.double_spec.
+  all:lia.
+Qed.
+
+Hint Rewrite @bind_of_return @bind_associativity
+     using solve [typeclasses eauto] : monadlaws.
+
+(* Correctness of the list based adder. *)
+
+Lemma addLCorrect (cin : bool) (a b : list bool) :
+  length a = length b ->
+  let bitAddition := combinational (addLWithCinL cin a b) in
+  list_bits_to_nat bitAddition =
+  list_bits_to_nat a + list_bits_to_nat b + N.b2n cin.
+Proof.
+  cbv zeta. cbv [addLWithCinL adderWithGrowthL unsignedAdderL].
+  (* get rid of pair-let because it will cause problems in the inductive case *)
+  erewrite ident_bind_Proper_ext with (g := fun x => ret (fst x ++ [snd x]));
+    [ | intros; destruct_products; reflexivity ].
+  (* start induction; eliminate cases where length b <> length a and solve base
+     case immediately *)
+  revert dependent cin. revert dependent b.
+  induction a; (destruct b; cbn [length]; try lia; [ ]); intros;
+    [ destruct cin; reflexivity | ].
+
+(* Need to define/prove equivalent of col_cons.
+  (* inductive case only now; simplify *)
+  rewrite !list_bits_to_nat_cons. col_cons.
+  cbv [prod_curry]. autorewrite with monadlaws.
+
+  (* use fullAdder_correct to replace fullAdder call with addition + testbit *)
+  rewrite combinational_bind.
+  rewrite fullAdder_correct. cbv zeta.
+  (cbn match beta). autorewrite with monadlaws.
+
+   (* use fullAdder_correct to replace fullAdder call with addition + testbit *)
+  rewrite combinational_bind.
+  rewrite fullAdder_correct. cbv zeta.
+  (cbn match beta). autorewrite with monadlaws.
+
+  (* Now, use the _ext lemma to rearrange under the binder and match inductive
+     hypothesis *)
+  erewrite ident_bind_Proper_ext.
+  2:{ intro y. rewrite (surjective_pairing y) at 1.
+      autorewrite with monadlaws. cbn [fst snd].
+      rewrite <-app_comm_cons. reflexivity. }
+
+  (* pull cons out of the ret statement *)
+  rewrite ident_bind_lift_app.
+  rewrite combinational_bind, combinational_ret.
+  rewrite list_bits_to_nat_cons.
+
+  (* Finally we have the right expression to use IHa *)
+  rewrite IHa by lia.
+
+  (* Now that the recursive part matches, we can just compute all 8 cases for
+     the first step (a + b + cin) *)
+  destruct a, b, cin; cbv [N.b2n].
+  all:repeat match goal with
+             | |- context [N.testbit ?x ?n] =>
+               let b := eval compute in (N.testbit x n) in
+                   change (N.testbit x n) with b
+             end; (cbn match).
+  all:lia.
+*)
+Abort.
+
+(* Correctness of the vector based adder. *)
+
+Lemma addVCorrect (cin : bool) (n : nat) (a b : Vector.t bool n) :
+  let bitAddition := combinational (addLWithCinV cin a b) in
+  Bv2N bitAddition =
+  Bv2N a + Bv2N b + (N.b2n cin).
+Abort.
+
+Local Close Scope N_scope.
+

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
@@ -1,0 +1,101 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+From Coq Require Import Lists.List.
+Import ListNotations.
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
+Import VectorNotations.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Import MonadNotation.
+Open Scope monad_scope.
+Open Scope type_scope.
+
+From Cava Require Import VectorUtils.
+From Cava Require Import Acorn.Acorn.
+From Cava Require Import Acorn.Lib.AcornFullAdder.
+
+Local Open Scope vector_scope.
+
+(* Vector verison *)
+
+Definition unsignedAdderV {m signal} `{Cava m signal} {n : nat}
+           (inputs: signal BitType * (Vector.t (signal BitType * signal BitType)) n) :
+           m (Vector.t (signal BitType) n * signal BitType) :=
+  colV fullAdder inputs.
+
+Definition adderWithGrowthV {m signal} `{Cava m signal} {n : nat}
+                            (inputs: signal BitType * (Vector.t (signal BitType * signal BitType)) n) :
+                            m (Vector.t (signal BitType) (n + 1)) :=
+  '(sum, cout) <- unsignedAdderV inputs ;;
+  ret (sum ++ [cout]).
+
+Definition adderWithGrowthNoCarryInV
+           {m signal} `{Cava m signal} {n : nat}
+           (inputs: Vector.t (signal BitType * signal BitType) n) :
+           m (Vector.t (signal BitType) (n + 1)) :=
+  adderWithGrowthV (zero, inputs).
+
+
+Definition addLWithCinV {m signal} `{Cava m signal} {n : nat}
+                        (cin : signal BitType)
+                        (a b : Vector.t (signal BitType) n) :
+                        m (Vector.t (signal BitType) (n + 1)) :=
+  adderWithGrowthV (cin, vcombine a b).
+
+Definition addV
+           {m signal} `{Cava m signal} {n : nat}
+           (a b: Vector.t (signal BitType) n) :
+           m (Vector.t (signal BitType) (n + 1)) :=
+  adderWithGrowthNoCarryInV (vcombine a b).
+
+Local Close Scope vector_scope.
+
+Local Open Scope list_scope.
+
+(* List version *)
+
+Definition unsignedAdderL {m signal} `{Cava m signal}
+                          (inputs: signal BitType * (list (signal BitType * signal BitType))) :
+                          m (list (signal BitType) * signal BitType) :=
+  colL fullAdder inputs.
+
+Definition adderWithGrowthL {m signal} `{Cava m signal}
+                            (inputs: signal BitType * (list (signal BitType * signal BitType))) :
+                            m (list (signal BitType)) :=
+  '(sum, cout) <- unsignedAdderL inputs ;;
+  ret (sum ++ [cout]).
+
+Definition adderWithGrowthNoCarryInL
+           {m signal} `{Cava m signal}
+           (inputs: list (signal BitType * signal BitType)) :
+           m (list (signal BitType)) :=
+  adderWithGrowthL (zero, inputs).
+
+Definition addLWithCinL {m signal} `{Cava m signal}
+                        (cin : signal BitType)
+                        (a b : list (signal BitType)) :
+                        m (list (signal BitType)) :=
+  adderWithGrowthL (cin, combine a b).
+
+Definition addL {m signal} `{Cava m signal}
+                (a b : list (signal BitType)) :
+                m (list (signal BitType)) :=
+  adderWithGrowthNoCarryInL (combine a b).
+
+Local Close Scope list_scope.  

--- a/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
+++ b/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
@@ -1,0 +1,81 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+From Coq Require Import NArith.
+From Coq Require Import Lists.List.
+Import ListNotations.
+From Coq Require Import Vector.
+From Coq Require Import Bool.Bvector.
+Import VectorNotations.
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Import MonadNotation.
+Open Scope monad_scope.
+Open Scope type_scope.
+
+From Cava Require Import Acorn.Acorn.
+From Cava Require Import Acorn.Lib.AcornUnsignedAdders.
+
+(* Test vector based adder *)
+
+(******************************************************************************)
+(* Some handy test vectors                                                   *)
+(******************************************************************************)
+
+Definition bv4_0  := N2Bv_sized 4  0.
+Definition bv4_1  := N2Bv_sized 4  1.
+Definition bv4_3  := N2Bv_sized 4  3.
+Definition bv4_15 := N2Bv_sized 4 15.
+
+Definition bv5_0  := N2Bv_sized 5  0.
+Definition bv5_4  := N2Bv_sized 5  4.
+Definition bv5_30 := N2Bv_sized 5 30.
+
+(* Check 0 + 0 = 0 *)
+Example addV0_0 : combinational (addV bv4_0 bv4_0) = bv5_0.
+Proof. reflexivity. Qed.
+
+(* Check 15 + 15 = 30 *)
+Example addV15_15 : combinational (addV bv4_15 bv4_15) = bv5_30.
+Proof. reflexivity. Qed.
+
+(* Check 1 + 3 = 4 *)
+Example addV1_3 : combinational (addV bv4_1 bv4_3) = bv5_4.
+Proof. reflexivity. Qed.
+
+(* Tests for list based versions. *)
+
+Definition lv4_0  := to_list bv4_0.
+Definition lv4_1  := to_list bv4_1.
+Definition lv4_3  := to_list bv4_3.
+Definition lv4_15 := to_list bv4_15.
+
+Definition lv5_0  := to_list bv5_0.
+Definition lv5_4  := to_list bv5_4.
+Definition lv5_30 := to_list bv5_30.
+
+(* Check 0 + 0 = 0 *)
+Example addL0_0 : combinational (addL lv4_0 lv4_0) = lv5_0.
+Proof. reflexivity. Qed.
+
+(* Check 15 + 15 = 30 *)
+Example addVL15_15 : combinational (addL lv4_15 lv4_15) = lv5_30.
+Proof. reflexivity. Qed.
+
+(* Check 1 + 3 = 4 *)
+Example addL1_3 : combinational (addL lv4_1 lv4_3) = lv5_4.
+Proof. reflexivity. Qed.

--- a/cava/_CoqProject
+++ b/cava/_CoqProject
@@ -12,6 +12,20 @@ Cava/Netlist.v
 Cava/Cava.v
 Cava/Tactics.v
 
+
+Cava/Acorn/AcornSignal.v
+Cava/Acorn/AcornCavaClass.v
+Cava/Acorn/Combinational.v
+Cava/Acorn/AcornNetlist.v
+Cava/Acorn/AcornState.v
+Cava/Acorn/AcornNetlistGeneration.v
+Cava/Acorn/AcornCombinators.v
+Cava/Acorn/Acorn.v
+Cava/Acorn/Lib/AcornFullAdder.v
+Cava/Acorn/Lib/AcornUnsignedAdders.v
+Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+Cava/Acorn/Tests/UnsignedAdderTests.v
+
 Cava/Monad/CavaMonad.v
 Cava/Monad/CavaClass.v
 Cava/Monad/CombinationalMonad.v


### PR DESCRIPTION
This PR introduces an experimental kernel for Cava that is a simplified version of our current monad kernel. I'm calling this kernel "Acorn". Simplifications include dispensing with the shape type and also removing smashing at the type level. The combinator definition of `col` is also simpler than what we currently have in the monad kernel.

The PR includes two lemmas in the file `Cava/Acorn/Lib/AcornUnsignedAdderProofs.v`: one for a list-based adder and one for a vector based adder. Note some useful monad facts are imported. It would be instructive to see:

* Is the list based adder proof any simpler than what happens in https://github.com/project-oak/oak-hardware/pull/218 ? 
* If it is possible to do the equivalent proof for the vector-based adder, then how do they compare? Or can this proof be done as an "add on" to the list-baed proof by relating vectors to lists?

Part of addressing #286 

CC: @blaxill 