### PR TITLE
Fix typo in bedrock2 clean target

### DIFF
--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -27,5 +27,5 @@ install:
 	cd coq-ext-lib && $(MAKE) install
 
 clean:
-	-cd bedrock2 && $(MAKE) cleanall
+	-cd bedrock2 && $(MAKE) clean_all
 	-cd coq-ext-lib && $(MAKE) clean


### PR DESCRIPTION
Found a missing underscore! This was causing the `clean` target in `third_party` to error. Shows me to assume I know the bedrock2 targets well enough not to thoroughly test them.