### PR TITLE
Acorn adder proofs

### DIFF
--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
@@ -65,6 +65,10 @@ Hint Rewrite @bind_of_return @bind_associativity
 
 (* Correctness of the list based adder. *)
 
+Lemma combinational_bind {A B} (f : ident A) (g : A -> ident B) :
+  combinational (x <- f;; g x) = combinational (g (combinational f)).
+Proof. reflexivity. Qed.
+
 Lemma addLCorrect (cin : bool) (a b : list bool) :
   length a = length b ->
   let bitAddition := combinational (addLWithCinL cin a b) in
@@ -81,17 +85,12 @@ Proof.
   induction a; (destruct b; cbn [length]; try lia; [ ]); intros;
     [ destruct cin; reflexivity | ].
 
-(* Need to define/prove equivalent of col_cons.
   (* inductive case only now; simplify *)
-  rewrite !list_bits_to_nat_cons. col_cons.
-  cbv [prod_curry]. autorewrite with monadlaws.
+  cbv [colL] in *. cbn [combine fst snd colL'] in *.
+  rewrite !list_bits_to_nat_cons.
+  autorewrite with monadlaws.
 
   (* use fullAdder_correct to replace fullAdder call with addition + testbit *)
-  rewrite combinational_bind.
-  rewrite fullAdder_correct. cbv zeta.
-  (cbn match beta). autorewrite with monadlaws.
-
-   (* use fullAdder_correct to replace fullAdder call with addition + testbit *)
   rewrite combinational_bind.
   rewrite fullAdder_correct. cbv zeta.
   (cbn match beta). autorewrite with monadlaws.
@@ -120,8 +119,7 @@ Proof.
                    change (N.testbit x n) with b
              end; (cbn match).
   all:lia.
-*)
-Abort.
+Qed.
 
 (* Correctness of the vector based adder. *)
 

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
@@ -253,27 +253,39 @@ Proof.
   rewrite IHbs. reflexivity.
 Qed.
 
+Lemma to_list_nil {A} : to_list (Vector.nil A) = [].
+Proof. reflexivity. Qed.
+
+Hint Rewrite @colL_length @combine_length @to_list_length
+     using solve [eauto] : push_length.
+Ltac simpl_length :=
+  repeat first [ progress autorewrite with push_length
+               | progress cbn [fst snd] ].
+
+Hint Rewrite @to_list_append  @to_list_vcombine
+     @to_list_of_list_opp @to_list_nil @to_list_cons
+     using solve [eauto] : push_to_list.
+Hint Rewrite @to_list_resize_default
+     using solve [simpl_length; lia] : push_to_list.
+
+Ltac simpl_monad :=
+  repeat first [ rewrite combinational_bind
+               | rewrite combinational_ret
+               | destruct_pair_let
+               | progress autorewrite with monadlaws
+               | progress cbn [fst snd] ].
+
 Lemma addVCorrect (cin : bool) (n : nat) (a b : Vector.t bool n) :
   let bitAddition := combinational (addLWithCinV cin a b) in
   Bv2N bitAddition =
   Bv2N a + Bv2N b + (N.b2n cin).
 Proof.
-  cbv zeta.
-  rewrite !Bv2N_list_bits_to_nat.
+  cbv zeta. rewrite !Bv2N_list_bits_to_nat.
   rewrite <-addLCorrect by (rewrite !to_list_length; reflexivity).
-  cbv [addLWithCinV adderWithGrowthV unsignedAdderV].
-  cbv [addLWithCinL adderWithGrowthL unsignedAdderL].
+  cbv [addLWithCinV adderWithGrowthV unsignedAdderV
+       addLWithCinL adderWithGrowthL unsignedAdderL].
   rewrite colV_colL with (d:=false).
-  cbv zeta. cbn [fst snd].
-  autorewrite with monadlaws.
-  repeat first [ rewrite combinational_bind
-               | rewrite combinational_ret
-               | destruct_pair_let ].
-  rewrite to_list_append.
-  rewrite to_list_resize_default
-    by (rewrite colL_length; apply to_list_length).
-  rewrite to_list_of_list_opp. cbn [to_list].
-  rewrite to_list_vcombine.
+  simpl_monad. autorewrite with push_to_list.
   reflexivity.
 Qed.
 


### PR DESCRIPTION
On top of #287 -- see individual commits for the real diff

Adds proofs for the list- and vector-based adders using the Acorn kernel. Some thoughts:

- The list proof ended up almost exactly the same as with the old kernel. Changes included some slight simplification due to the fact that `colL` is defined directly, while the previous `col` was defined in terms of `below_cons`.
- The vector proof was almost exactly the same as the list proof, but there was some pain involved with resizing vectors (the adder produces a vector of length `n+1`, so the inductive case ends up with a length  `S n + 1` that needs to simplify to `S (n + 1)` to allow the right simplification. And of course a normal rewrite doesn't work because then the types don't line up. I ended up solving this by putting a `resize` in front of the adder right off the bat, so that by the time I do induction I'm actually proving:
```coq
let bitAddition := combinational (addLWithCinV cin a b) in
Bv2N (resize_default false (S n) bitAddition) =
Bv2N a + Bv2N b + (N.b2n cin).
```
- Besides vector resizing, there's one (minor) pain point that remaining around destructing lets (e.g. `let (x, y) := z in ..`). These are actually `match` statements under the hood, which means that I can't do any kind of rewrite in their continuation until I destruct the match -- which I usually can't do, because it's under a monad bind.