### PR TITLE
Bad Loop Combinator

### DIFF
--- a/investigations/modeling/BadLoop.v
+++ b/investigations/modeling/BadLoop.v
@@ -1,0 +1,76 @@
+
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Bool.Bool.
+From Coq Require Import Lists.List.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Require Export ExtLib.Data.Monads.IdentityMonad.
+Export MonadNotation.
+Open Scope monad_scope.
+
+Open Scope type_scope.
+
+Generalizable All Variables.
+
+(* Haskell code from https://github.com/project-oak/oak-hardware/blob/main/investigations/lava/Lava.hs:
+
+loopMF' :: MonadFix m => ((a, c) -> m (b, c)) -> a -> m (b, c)
+loopMF' circuit a
+  = mfix (\bc -> do (b, c') <- circuit (a, snd bc)
+                    return (b, c'))
+*)
+
+
+(* Bad attempt at implementing the Haskell loop combinator in Coq
+   which is specialized to a feedback wire of type bool and also
+   uses a default feedback value of [false] which is probably bogus
+   but is there as a workaround for not having lazy evaluation.
+*)
+Definition loop `{Monad m} `{MonadFix m} {A B}
+           (circuit : (A * list bool) -> m (B * list bool)) (a:A) : m B :=
+  '(b, _) <- mfix (fun f bc => '(b, c') <- circuit (a, snd bc) ;;
+                               ret (b, c')
+                  ) (a, [false]) ;;
+  ret b.
+
+Definition nand2 (ab : list bool * list bool) : ident (list bool) :=
+  ret (map (fun '(a,b) => a && b) (combine (fst ab) (snd ab))).
+
+Definition fork2 {A} (a:A)  : ident (A * A) := ret (a, a).
+
+(* loopedNAND also causes Coq to go into an infinite loop. *)
+
+Definition delayBit (input: list bool) : ident (list bool) :=
+  ret (false :: input).
+
+(* The loopedNAND definition below gives the error:
+Unable to satisfy the following constraints:
+In environment:
+a : list bool
+
+?H0 : "MonadFix ident"
+Not in proof mode.
+
+because there is no MonadFix instance for the identity monad.
+Perhaps the best way forward is to make a list monad and define
+MonadFix for that?
+*)
+
+Definition loopedNAND (a : list bool) : ident (list bool) :=
+  loop (nand2 >=> delayBit >=> fork2) a.


### PR DESCRIPTION
This PR explains an issue I have with trying to get the Lava-style loop combinator to work with circuit build using the `coq-ext-lib` Monads. You can see what I am trying to achieve for modeling circuits in the Haskell code at https://github.com/project-oak/oak-hardware/blob/main/investigations/lava/Lava.hs which shows several ways of "typing the knot to make a loop" which can be simulated and works in Haskell because `MonadFix` makes _essential_ use of laziness in Haskell. Of the three versions the one that is closest to what we can transcribe into Coq is:
```haskell
loopMF' :: MonadFix m => ((a, c) -> m (b, c)) -> a -> m (b, c)
loopMF' circuit a
  = mfix (\bc -> do (b, c') <- circuit (a, snd bc)
                    return (b, c'))
```
My attempt at trying to re-implement the Haskell-style loop combinator is shown in this PR:
```coq
(* Bad attempt at implementing the Haskell loop combinator in Coq
   which is specialized to a feedback wire of type bool and also
   uses a default feedback value of [false] which is probably bogus
   but is there as a workaround for not having lazy evaluation.
*)
Definition loop `{Monad m} `{MonadFix m} {A B}
           (circuit : (A * list bool) -> m (B * list bool)) (a:A) : m B :=
  '(b, _) <- mfix (fun f bc => '(b, c') <- circuit (a, snd bc) ;;
                               ret (b, c')
                  ) (a, [false]) ;;
  ret b.
```
My attempt to use it to try and produce a description of a sequential circuit we can simulate is this:
```coq
Definition nand2 (ab : list bool * list bool) : ident (list bool) :=
  ret (map (fun '(a,b) => a && b) (combine (fst ab) (snd ab))).

Definition fork2 {A} (a:A)  : ident (A * A) := ret (a, a).

Definition delayBit (input: list bool) : ident (list bool) :=
  ret (false :: input).

Definition loopedNAND (a : list bool) : ident (list bool) :=
  loop (nand2 >=> delayBit >=> fork2) a.
```
But this does not work out because we don't have an instance of `MonadFix` for `ident`. The instances I can find in `coq-ext-lib` are:
```console
./coq-ext-lib/theories/Data/Monads/EitherMonad.v:  Global Instance MonadFix_eitherT (MF : MonadFix m) : MonadFix eitherT :=
./coq-ext-lib/theories/Data/Monads/FuelMonad.v:  Global Instance MonadFix_GFix : MonadFix GFix :=
./coq-ext-lib/theories/Data/Monads/ReaderMonad.v:  Global Instance MonadFix_readerT (MF : MonadFix m) : MonadFix readerT :=
./coq-ext-lib/theories/Data/Monads/StateMonad.v:  Global Instance MonadFix_stateT (MF : MonadFix m) : MonadFix stateT :=
```
Perhaps one way forward is to view lists as monads and define a `MonadFix` instance for them?

What I did as a workaround when I had the sequential elements previously was to build loops in two stages: first create a wire and name it, and then use this name to both drive the second input and attach to the second output of the circuit to be looped. However, this requires knowing the type of the wire to be created so I had to make specialized versions e.g. `loopBit` and `loopVector` etc. What's nice about the Haskell lazy loop is that we don't need to break the loop apart in this way and the description is polymorphic over the looped type.

What do you think is the best way of implementing in Coq the loop mechanism that I did in Haskell? Thank you!

CC: @blaxill 
