### PR TITLE
Proof that arrow-based AES top-level spec and FIPS-based spec are equivalent

### DIFF
--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
@@ -1,0 +1,152 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Vectors.Vector.
+Require Import Cava.Arrow.ArrowExport.
+Require Import Cava.Arrow.CombinatorProperties.
+Require Import Cava.Arrow.DeriveSpec.
+Require Import Cava.BitArithmetic.
+Require Import Cava.ListUtils.
+Require Import Cava.Tactics.
+Require Import Cava.VectorUtils.
+Require Import AesSpec.Cipher.
+Require Import AesSpec.ExpandAllKeys.
+Require Import AesSpec.InterleavedCipher.
+From Aes Require Import OpenTitanCipherProperties CipherRoundProperties
+     unrolled_opentitan_cipher.
+Import VectorNotations.
+Import ListNotations.
+
+Section Equivalence.
+  Local Notation byte := (Vector.t bool 8) (only parsing).
+  Context (sbox : pkg.SboxImpl)
+          (aes_key_expand_spec :
+             pkg.SboxImpl -> bool -> Vector.t bool 4 -> byte ->
+             Vector.t (Vector.t byte 4) 8 ->
+             byte * Vector.t (Vector.t byte 4) 8)
+          (aes_key_expand_correct :
+             forall sbox_impl op_i round_id rcon key_i,
+               kinterp (aes_key_expand sbox_impl)
+                       (op_i, (round_id, (rcon, (key_i, tt))))
+               = aes_key_expand_spec sbox_impl op_i round_id rcon key_i)
+          (aes_sub_bytes_correct :
+             forall sbox_impl op_i state,
+               kinterp (sub_bytes.aes_sub_bytes sbox_impl) (op_i, (state, tt))
+               = aes_sub_bytes_spec sbox_impl op_i state)
+          (aes_shift_rows_correct :
+             forall op_i state,
+               kinterp shift_rows.aes_shift_rows (op_i, (state, tt))
+               = aes_shift_rows_spec op_i state)
+           (aes_mix_columns_correct :
+             forall op_i state,
+               kinterp mix_columns.aes_mix_columns (op_i, (state, tt))
+               = aes_mix_columns_spec op_i state).
+
+  Notation state := (Vector.t (Vector.t (Vector.t bool 8) 4) 4) (only parsing).
+  Notation key := (Vector.t (Vector.t (Vector.t bool 8) 4) 4) (only parsing).
+  Notation rconst := (Vector.t bool 8) (only parsing).
+  Notation keypair := (Vector.t (Vector.t (Vector.t bool 8) 4) 8) (only parsing).
+
+  Notation nat_to_bitvec size n := (Ndigits.N2Bv_sized size (N.of_nat n)).
+
+  (* TODO: this transpose seems odd *)
+  Definition add_round_key : state -> key -> state :=
+    fun st k =>
+    @bitwise (Vector (Vector (Vector Bit 8) 4) 4) (fun a b => xorb a b)
+             st (PkgProperties.Vector.transpose_rev k).
+  Definition sub_bytes : state -> state := aes_sub_bytes_spec sbox false.
+  Definition shift_rows : state -> state := aes_shift_rows_spec false.
+  Definition mix_columns : state -> state := aes_mix_columns_spec false.
+  Definition key_expand : nat -> rconst -> keypair -> rconst * keypair :=
+    fun i => aes_key_expand_spec sbox false (nat_to_bitvec _ i).
+
+  Definition fstkey : keypair -> key :=
+    @slice_by_position
+      (t (t bool 8) 4) 8 3 0 (kind_default (Vector (Vector Bit 8) 4)).
+  Definition sndkey : keypair -> key :=
+    @slice_by_position
+      (t (t bool 8) 4) 8 7 4 (kind_default (Vector (Vector Bit 8) 4)).
+
+  Lemma sndkey_of_append (two_keys : keypair) :
+    sndkey (sndkey two_keys ++ fstkey two_keys) = fstkey two_keys.
+  Proof.
+    clear. cbv [fstkey sndkey slice_by_position].
+    rewrite !resize_default_id.
+    change (7-4+1) with 4. change (3-0+1) with 4.
+    cbn [splitat fst snd Vector.append].
+    autorewrite with vsimpl. reflexivity.
+  Qed.
+
+  Definition add_round_key_pair : state -> keypair -> state :=
+    fun st kp => add_round_key st (sndkey kp).
+
+  Lemma unrolled_cipher_spec_equiv
+        init_keypair first_key last_key middle_keys input :
+    let nrounds := 15 in (* TODO: is this the right # rounds? *)
+    let init_rcon : Vector.t bool 8 := nat_to_bitvec _ 1 in
+    (* TODO : why is the initial key pair reversed? *)
+    let init_keypair_rev := sndkey init_keypair ++ fstkey init_keypair in
+    let keypairs : list keypair := (first_key :: middle_keys ++ [last_key])%list in
+    all_keys key_expand (nrounds-1) init_keypair_rev init_rcon = keypairs ->
+    unrolled_cipher_spec aes_key_expand_spec sbox false input init_keypair
+    = cipher state keypair add_round_key_pair
+             sub_bytes shift_rows mix_columns
+             first_key last_key middle_keys input.
+  Proof.
+    cbv zeta. cbn [denote_kind Nat.add Nat.sub] in *.
+    intro Hall_keys.
+    pose proof (hd_all_keys _ _ _ _ _ _ Hall_keys ltac:(lia)).
+    subst first_key.
+    erewrite <-cipher_interleaved_equiv by eassumption.
+    cbv [unrolled_cipher_spec final_cipher_round_spec
+                              cipher_interleaved cipher_round_interleaved].
+    repeat destruct_pair_let.
+    rewrite denote_kind_eqb_refl. cbn [mux].
+    rewrite fold_left_fst_unchanged by auto.
+    autorewrite with push_to_list.
+    rewrite fold_left_map. cbn [fst snd].
+    match goal with
+    | |- ?LHS = ?RHS =>
+      match LHS with
+      | context [ @List.fold_left (?A1 * (?A2 * ?A3)) ?B1 ?f1 ?ls1 ?b1 ] =>
+        match RHS with
+        | context [ @List.fold_left (A1 * A3 * A2) ?B2 ?f2 ?ls2 ?b2 ] =>
+          change ls1 with ls2;
+            rewrite (fold_left_preserves_relation_seq
+                       (fun _ x y => x = (fst (fst y), (snd y, snd (fst y))))
+                       f1 f2 _ _ b1 b2)
+        end
+      end
+    end; [ | | ].
+    { (* equivalence post-loop *)
+      reflexivity. }
+    { (* equivalence at start of loop *)
+      reflexivity. }
+    { (* equivalence holds through loop body *)
+      intros; subst. cbv [key_expand_and_round_spec].
+      repeat destruct_pair_let; cbn [fst snd].
+      rewrite denote_kind_eqb_refl. cbn [mux].
+      fold fstkey sndkey. repeat (f_equal; [ ]).
+      rewrite denote_kind_eqb_N2Bv_sized by (apply N_size_nat_le; cbn; Lia.lia).
+      cbv [mux]. change 0%N with (N.of_nat 0).
+      rewrite N.eqb_compare, N2Nat.inj_compare, !Nat2N.id, <-Nat.eqb_compare.
+      reflexivity. }
+  Qed.
+End Equivalence.

--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
@@ -99,18 +99,18 @@ Section Equivalence.
 
   Lemma unrolled_cipher_spec_equiv
         init_keypair first_key last_key middle_keys input :
-    let nrounds := 15 in (* TODO: is this the right # rounds? *)
+    let Nr := 14 in
     let init_rcon : Vector.t bool 8 := nat_to_bitvec _ 1 in
     (* TODO : why is the initial key pair reversed? *)
     let init_keypair_rev := sndkey init_keypair ++ fstkey init_keypair in
     let keypairs : list keypair := (first_key :: middle_keys ++ [last_key])%list in
-    all_keys key_expand (nrounds-1) init_keypair_rev init_rcon = keypairs ->
+    all_keys key_expand Nr init_keypair_rev init_rcon = keypairs ->
     unrolled_cipher_spec aes_key_expand_spec sbox false input init_keypair
     = cipher state keypair add_round_key_pair
              sub_bytes shift_rows mix_columns
              first_key last_key middle_keys input.
   Proof.
-    cbv zeta. cbn [denote_kind Nat.add Nat.sub] in *.
+    cbv zeta. cbn [denote_kind] in *.
     intro Hall_keys.
     pose proof (hd_all_keys _ _ _ _ _ _ Hall_keys ltac:(lia)).
     subst first_key.

--- a/silveroak-opentitan/aes/Arrow/_CoqProject
+++ b/silveroak-opentitan/aes/Arrow/_CoqProject
@@ -1,4 +1,5 @@
 -R . Aes
+-R ./../Spec AesSpec
 -R ../../../cava/Cava Cava
 -R ../../../third_party/coq-ext-lib/theories ExtLib
 -R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
@@ -22,6 +23,7 @@ netlists.v
 aes_test.v
 CipherRoundProperties.v
 NaiveCipherProperties.v
+OpenTitanCipherEquivalence.v
 OpenTitanCipherProperties.v
 PkgProperties.v
 Extraction.v

--- a/silveroak-opentitan/aes/Spec/Cipher.v
+++ b/silveroak-opentitan/aes/Spec/Cipher.v
@@ -19,7 +19,7 @@ Hint Rewrite @map_app @fold_left_app : listsimpl.
 Local Ltac listsimpl :=
   repeat progress (cbn [rev map fold_left]; autorewrite with listsimpl).
 
-Module Spec.
+Section Spec.
   Context (state key : Type)
           (add_round_key : state -> key -> state)
           (sub_bytes shift_rows mix_columns : state -> state)

--- a/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
+++ b/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
@@ -24,15 +24,15 @@ Section Spec.
           (key_expand : nat -> rconst -> key -> rconst * key).
 
   Definition all_rcons_and_keys
-             (nrounds_m1 : nat) (* number of rounds minus 1 *)
+             (Nr : nat) (* number of rounds *)
              (initial_key : key) (initial_rcon : rconst)
     : list (rconst * key) :=
     fst (fold_left_accumulate
            (fun '(rcon, round_key) i => key_expand i rcon round_key)
-           (fun x => x) (List.seq 0 nrounds_m1) (initial_rcon, initial_key)).
+           (fun x => x) (List.seq 0 Nr) (initial_rcon, initial_key)).
 
-  Definition all_keys nrounds_m1 initial_key initial_rcon : list key :=
-    List.map snd (all_rcons_and_keys nrounds_m1 initial_key initial_rcon).
+  Definition all_keys Nr initial_key initial_rcon : list key :=
+    List.map snd (all_rcons_and_keys Nr initial_key initial_rcon).
 
   Section Properties.
     Lemma length_all_keys n k1 k2 r rem_keys :

--- a/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
+++ b/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
@@ -1,0 +1,104 @@
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Cava.ListUtils.
+Require Import Cava.Tactics.
+
+Section Spec.
+  Context {key rconst : Type}
+          (key_expand : nat -> rconst -> key -> rconst * key).
+
+  Definition all_rcons_and_keys
+             (nrounds_m1 : nat) (* number of rounds minus 1 *)
+             (initial_key : key) (initial_rcon : rconst)
+    : list (rconst * key) :=
+    fst (fold_left_accumulate
+           (fun '(rcon, round_key) i => key_expand i rcon round_key)
+           (fun x => x) (List.seq 0 nrounds_m1) (initial_rcon, initial_key)).
+
+  Definition all_keys nrounds_m1 initial_key initial_rcon : list key :=
+    List.map snd (all_rcons_and_keys nrounds_m1 initial_key initial_rcon).
+
+  Section Properties.
+    Lemma length_all_keys n k1 k2 r rem_keys :
+      all_keys n k1 r = (k2 :: rem_keys)%list ->
+      length rem_keys = n.
+    Proof.
+      cbv [all_keys all_rcons_and_keys]. intros.
+      rewrite @map_fold_left_accumulate in *.
+      lazymatch goal with
+      | H : @eq (list _) ?x ?y |- _ =>
+        assert (length x = length y) by (rewrite H; reflexivity)
+      end.
+      autorewrite with push_length in *. lia.
+    Qed.
+
+    Lemma hd_all_keys n k1 k2 r rem_keys :
+      all_keys n k1 r = (k2 :: rem_keys)%list -> n <> 0 -> k1 = k2.
+    Proof.
+      cbv [all_keys all_rcons_and_keys]; intros.
+      destruct n; [ congruence | ]. cbn [List.seq] in *.
+      autorewrite with push_fold_acc in *. cbn [List.map] in *.
+      match goal with
+      | H : (?x :: _ = ?y :: _)%list |- _ => inversion H
+      end.
+      congruence.
+    Qed.
+
+    Lemma nth_all_rcons_and_keys' n k r i :
+        nth i (all_rcons_and_keys (i+n) k r) (r,k)
+        = nth i (all_rcons_and_keys i k r) (r,k).
+    Proof.
+      cbv [all_rcons_and_keys].
+      induction n; intros; [ rewrite Nat.add_0_r; reflexivity | ].
+      rewrite Nat.add_succ_r, seq_S, fold_left_accumulate_snoc.
+      rewrite app_nth1 by length_hammer. eauto.
+    Qed.
+
+    Lemma nth_all_rcons_and_keys n k r i :
+      i <= n ->
+      nth i (all_rcons_and_keys n k r) (r,k)
+      = nth i (all_rcons_and_keys i k r) (r,k).
+    Proof.
+      intros. replace n with (i+(n-i)) by Lia.lia.
+      apply nth_all_rcons_and_keys'.
+    Qed.
+
+    Lemma nth_all_rcons_and_keys_succ n k r i :
+      S i <= n ->
+      nth (S i) (all_rcons_and_keys n k r) (r,k)
+      = key_expand i (fst (nth i (all_rcons_and_keys n k r) (r,k)))
+                   (snd (nth i (all_rcons_and_keys n k r) (r,k))).
+    Proof.
+      intros. rewrite !nth_all_rcons_and_keys with (n:=n) by Lia.lia.
+      cbv [all_rcons_and_keys].
+      rewrite !nth_fold_left_accumulate_id by (rewrite seq_length; Lia.lia).
+      rewrite !firstn_all2 by (rewrite seq_length; Lia.lia).
+      rewrite seq_S, Nat.add_0_l, fold_left_app. cbn [fold_left].
+      repeat destruct_pair_let. reflexivity.
+    Qed.
+
+    Lemma nth_all_rcons_and_keys_all_keys n k r i :
+      snd (nth i (all_rcons_and_keys n k r) (r,k))
+      = nth i (all_keys n k r) k.
+    Proof.
+      cbv [all_keys]. rewrite <-map_nth with (f:=snd).
+      reflexivity.
+    Qed.
+  End Properties.
+End Spec.

--- a/silveroak-opentitan/aes/Spec/InterleavedCipher.v
+++ b/silveroak-opentitan/aes/Spec/InterleavedCipher.v
@@ -1,0 +1,148 @@
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Import ListNotations.
+Local Open Scope list_scope.
+
+Require Import Cava.ListUtils.
+Require Import Cava.Tactics.
+Require Import AesSpec.Cipher.
+Require Import AesSpec.ExpandAllKeys.
+
+Section Spec.
+  Context {state key rconst : Type}
+          (add_round_key : state -> key -> state)
+          (sub_bytes shift_rows mix_columns : state -> state)
+          (inv_sub_bytes inv_shift_rows inv_mix_columns : state -> state)
+          (inv_mix_columns_key : key -> key)
+          (key_expand : nat -> rconst -> key -> rconst * key).
+
+  Definition cipher_round_interleaved
+             (rcon : rconst) (round_key : key) (st : state) (i : nat)
+    : rconst * key * state :=
+    let st := if i =? 0
+              then add_round_key st round_key
+              else
+                let st := sub_bytes st in
+                let st := shift_rows st in
+                let st := mix_columns st in
+                let st := add_round_key st round_key in
+                st in
+    let rcon_key := key_expand i rcon round_key in
+    (rcon_key, st).
+
+  (* AES cipher with interleaved key expansion and conditional split on first round *)
+  Definition cipher_interleaved
+             (nrounds_m1 : nat) (* number of rounds - 1 *)
+             (initial_key : key)
+             (initial_rcon : rconst)
+             (input : state) : state :=
+    let st := input in
+    let loop_end_state :=
+        fold_left
+          (fun (loop_state : rconst * key * state) =>
+             let '(rcon, round_key, st) := loop_state in
+             cipher_round_interleaved rcon round_key st)
+          (List.seq 0 nrounds_m1)
+          (initial_rcon, initial_key, st) in
+    let '(_, last_key, st) := loop_end_state in
+    let st := sub_bytes st in
+    let st := shift_rows st in
+    let st := add_round_key st last_key in
+    st.
+
+  Section Equivalence.
+    Context (nrounds_m1 : nat) (initial_rcon : rconst)
+            (first_key : key) (middle_keys : list key) (last_key : key)
+            (all_keys_eq :
+               all_keys key_expand nrounds_m1 first_key initial_rcon
+               = first_key :: middle_keys ++ [last_key]).
+
+    (* Interleaved cipher is equivalent to original cipher *)
+    Lemma cipher_interleaved_equiv input :
+      cipher_interleaved nrounds_m1 first_key initial_rcon input =
+      cipher state key add_round_key sub_bytes shift_rows mix_columns
+             first_key last_key middle_keys input.
+    Proof.
+      intros. cbv [cipher_interleaved cipher_round_interleaved cipher].
+      rewrite fold_left_to_seq with (default:=first_key).
+      pose proof (length_all_keys _ _ _ _ _ _ all_keys_eq).
+      autorewrite with push_length in *.
+
+      (* nrounds_m1 cannot be 0 *)
+      destruct nrounds_m1 as [|nrounds_m2]; [ lia | ].
+      replace (length middle_keys) with nrounds_m2 by lia.
+
+      (* extract first step from cipher_alt so loops are in sync *)
+      cbn [List.seq fold_left]. rewrite Nat.eqb_refl.
+      rewrite <-seq_shift, fold_left_map.
+
+      (* state the relationship between the two loop states (invariant) *)
+      lazymatch goal with
+      | H : all_keys ?key_expand ?n ?k ?r = _ |- _ =>
+        pose (R:= fun (i : nat) (x : rconst * key * state) (y : state) =>
+                    x = (nth (S i)
+                             (all_rcons_and_keys key_expand n k r) (r,k), y))
+      end.
+
+      (* find loops on each side *)
+      lazymatch goal with
+      | |- ?LHS = ?RHS =>
+        let lfold :=
+            lazymatch LHS with
+            | context [fold_left ?f ?ls ?b] => constr:(fold_left f ls b) end in
+        let rfold :=
+            lazymatch RHS with
+            | context [fold_left ?f ?ls ?b] => constr:(fold_left f ls b) end in
+        let H := fresh in
+        (* assert that invariant is satisfied at the end of the loop *)
+        assert (H: R nrounds_m2 lfold rfold);
+          [ | subst R; cbv beta in *; rewrite H ]
+      end.
+      2:{
+        (* prove that if the invariant is satisfied at the end of the loop, the
+           postcondition is true *)
+        repeat destruct_pair_let. f_equal; [ ].
+        rewrite nth_all_rcons_and_keys_all_keys.
+        rewrite all_keys_eq, app_comm_cons.
+        rewrite app_nth2 by length_hammer.
+        match goal with |- nth ?i _ _ = _ =>
+                        replace i with 0 by length_hammer end.
+        reflexivity. }
+
+      (* use the fold_left invariant lemma *)
+      apply fold_left_preserves_relation_seq with (R0:=R); subst R.
+      { (* invariant holds at loop start *)
+        cbv beta. rewrite nth_all_rcons_and_keys by lia.
+        reflexivity. }
+      { (* invariant holds through loop step *)
+        cbv beta; intros; subst. repeat destruct_pair_let.
+        rewrite Nat.eqb_compare; cbn [Nat.compare].
+        rewrite !nth_all_rcons_and_keys_succ by lia.
+        f_equal; [ ].
+        match goal with
+        | H : ?ls = (_ :: (?m ++ [_]))%list |- context [nth ?i ?mk ?d] =>
+          replace (nth i mk d) with (nth (S i) ls d)
+            by (rewrite H; apply app_nth1; Lia.lia)
+        end.
+        rewrite <-nth_all_rcons_and_keys_all_keys.
+        rewrite !nth_all_rcons_and_keys_succ by lia.
+        reflexivity. }
+    Qed.
+  End Equivalence.
+End Spec.

--- a/silveroak-opentitan/aes/Spec/_CoqProject
+++ b/silveroak-opentitan/aes/Spec/_CoqProject
@@ -1,3 +1,7 @@
+-R . AesSpec
+-R ../../../cava/Cava Cava
 -R ../../../third_party/coq-ext-lib/theories ExtLib
 -R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
-Aes.v
+Cipher.v
+ExpandAllKeys.v
+InterleavedCipher.v


### PR DESCRIPTION
Resolves the cliffhanger I teased in #298! I first defined an alternative spec-level implementation that has key-generation interleaved, and then proved that equivalent to the original spec. Then, I proved that the derived top-level behavior of the `unrolled_opentitan_cipher` matches the alternative version.

There are a few oddities I'd like to address that came up while doing the proof; I've marked them as TODOs in the code.
1. The implementation transposes the key before performing `add_round_key`. Why?
2. It looks like the implementation does 15 rounds instead of 14 -- or am I misreading the FIPS spec?
3. The starting key pair seems to be reversed.

This PR completes phase 1 of the AES verification plan! :tada: :tada: :tada: 