### PR TITLE
Use 'circuit_evaluation' to generate the sequential tb outputs

### DIFF
--- a/arrow-examples/Counter.v
+++ b/arrow-examples/Counter.v
@@ -51,8 +51,7 @@ Definition counter_3_tb_inputs : list unit :=
  repeat tt 8.
 
 Definition counter_3_tb_expected_outputs : list (Bvector.Bvector 3) :=
-  (* TODO(#301): replace with 'circuit_evaluation' *)
-  map (N2Bv_sized 3) [0;1;2;3;4;5;6;7;0]%N.
+  unroll_circuit_evaluation (closure_conversion (counter 3)) (repeat tt 8).
 
 Definition counter_3_tb :=
   testBench "counter_3_tb" counter_3_Interface

--- a/arrow-examples/Fir.v
+++ b/arrow-examples/Fir.v
@@ -67,9 +67,8 @@ Definition fir_netlist :=
 Definition fir_tb_inputs : list (Bvector 8) :=
  map (N2Bv_sized 8) [1; 2; 3; 4; 5; 6; 7; 8; 9]%N.
 
-  (* TODO(#301): replace with 'circuit_evaluation' *)
 Definition fir_tb_expected_outputs : list (Bvector 8) :=
-  map (N2Bv_sized 8) [10;11;13;16;20;24;28;32;36]%N.
+  unroll_circuit_evaluation (closure_conversion fir) fir_tb_inputs.
 
 Definition fir_tb :=
   testBench "fir_tb" fir_Interface

--- a/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/Cava/Arrow/ArrowKind.v
@@ -236,6 +236,8 @@ Fixpoint apply_rightmost_tt (x: Kind)
   | _ => fun x => x
   end.
 
+(* Avoid eq_rect type equality rewriting by inductively matching the Kind
+* structure. *)
 Fixpoint rewrite_or_default (x y: Kind): denote_kind x -> denote_kind y :=
   match x as x' return denote_kind x' -> denote_kind y with
   | Unit =>

--- a/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/Cava/Arrow/ArrowKind.v
@@ -236,3 +236,27 @@ Fixpoint apply_rightmost_tt (x: Kind)
   | _ => fun x => x
   end.
 
+Fixpoint rewrite_or_default (x y: Kind): denote_kind x -> denote_kind y :=
+  match x as x' return denote_kind x' -> denote_kind y with
+  | Unit =>
+      match y with
+      | Unit => fun a => a
+      | _ => fun _ => kind_default _
+      end
+  | Tuple l r =>
+      match y with
+      | Tuple ll rr => fun '(a,b) => (rewrite_or_default l ll a, rewrite_or_default r rr b)
+      | _ => fun _ => kind_default _
+      end
+  | Vector t n =>
+      match y with
+      | Vector t2 n2 => fun a => VectorUtils.resize_default (kind_default _) _ (Vector.map (rewrite_or_default t t2) a)
+      | _ => fun _ => kind_default _
+      end
+  | Bit =>
+      match y with
+      | Bit => fun a => a
+      | _ => fun _ => kind_default _
+      end
+  end.
+

--- a/cava/Cava/Arrow/CircuitArrow.v
+++ b/cava/Cava/Arrow/CircuitArrow.v
@@ -64,8 +64,7 @@ Inductive Circuit: Kind -> Kind -> Type :=
   | Loopr: forall x y z, Circuit (Tuple x z) (Tuple y z) -> Circuit x y
   | Loopl: forall x y z, Circuit (Tuple z x) (Tuple z y) -> Circuit x y
 
-  | Map: forall x y n, Circuit x y -> Circuit (Vector x n) (Vector y n)
-  | Resize: forall x n nn, Circuit (Vector x n) (Vector x nn)
+  | RewriteTy: forall x y, Circuit x y
   .
 
 Instance CircuitCat : Category Kind := {

--- a/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -78,14 +78,9 @@ Inductive circuit_equiv: forall i o, Circuit i o -> (denote_kind i -> denote_kin
     (forall a, r a = a) ->
     circuit_equiv x x (Structural (Arrow.Id x)) r
 
-  | Map_equiv: forall x y n c r r1,
-    circuit_equiv x y c r1 ->
-    (forall v, r v = Vector.map r1 v) ->
-    circuit_equiv (Vector x n) (Vector y n) (Map x y n c) r
-
-  | Resize_equiv: forall x n nn r,
-    (forall v, r v = resize_default (kind_default _) nn v) ->
-    circuit_equiv (Vector x n) (Vector x nn) (Resize x n nn) r
+  | RewriteTy_equiv: forall x y r,
+    (forall v, r v = rewrite_or_default x y v) ->
+    circuit_equiv x y (RewriteTy x y ) r
 
   | Primitive_equiv: forall p r,
     (forall a, r a = combinational_evaluation' (CircuitArrow.Primitive p) a) ->

--- a/cava/Cava/Arrow/CircuitProp.v
+++ b/cava/Cava/Arrow/CircuitProp.v
@@ -30,7 +30,6 @@ Fixpoint no_delays {i o} (c: Circuit i o): bool :=
   | Second _ _ _ f => no_delays f
   | Loopr _ _ _ f => no_delays f
   | Loopl _ _ _ f => no_delays f
-  | Map _ _ _ f => no_delays f
   | _ => true
   end.
 
@@ -41,7 +40,6 @@ Fixpoint no_loops {i o} (c: Circuit i o): bool :=
   | Second _ _ _ f => no_loops f
   | Loopr _ _ _ f => false
   | Loopl _ _ _ f => false
-  | Map _ _ _ f => no_loops f
   | _ => true
   end.
 
@@ -53,7 +51,6 @@ Fixpoint min_buffering {i o} (n: nat) (c: Circuit i o): nat :=
   | Second _ _ _ f => min_buffering n f
   | Loopr _ _ _ f => min_buffering n f
   | Loopl _ _ _ f => min_buffering n f
-  | Map _ _ _ f => min_buffering n f
   | _ => n
   end.
 
@@ -64,7 +61,6 @@ Fixpoint valid_loops {i o} (c: Circuit i o): bool :=
   | Second _ _ _ f => valid_loops f
   | Loopr _ _ _ f => (0 <? min_buffering 0 f) && valid_loops f
   | Loopl _ _ _ f => (0 <? min_buffering 0 f) && valid_loops f
-  | Map _ _ _ f => valid_loops f
   | _ => true
   end.
 

--- a/cava/Cava/Arrow/ExprLowering.v
+++ b/cava/Cava/Arrow/ExprLowering.v
@@ -141,30 +141,6 @@ Section ctxt.
   Proof. auto with kappa_cc. Qed.
 End ctxt.
 
-Fixpoint rewrite_or_default (x y: Kind): x ~> y :=
-  match x with
-  | Unit =>
-      match y with
-      | Unit => Structural (Id _)
-      | _ => drop >>> Primitive (Constant _ (kind_default _))
-      end
-  | Tuple l r =>
-      match y with
-      | Tuple ll rr => first (rewrite_or_default l ll) >>> second (rewrite_or_default r rr)
-      | _ => drop >>> Primitive (Constant _ (kind_default _))
-      end
-  | Vector t n =>
-      match y with
-      | Vector t2 n2 => CircuitArrow.Map t t2 n (rewrite_or_default t t2) >>> Resize t2 n n2
-      | _ => drop >>> Primitive (Constant _ (kind_default _))
-      end
-  | Bit =>
-      match y with
-      | Bit => Structural (Id _)
-      | _ => drop >>> Primitive (Constant _ (kind_default _))
-      end
-  end.
-
 (* Construct an Arrow morphism that takes a variable list Kind
 and returns the variable at an index *)
 Fixpoint extract_nth (ctxt: list Kind) (ty: Kind) (x: nat)
@@ -173,7 +149,7 @@ Fixpoint extract_nth (ctxt: list Kind) (ty: Kind) (x: nat)
   | [] => drop >>> Primitive (Constant _(kind_default _))
   | ty' :: ctxt' =>
     if x =? (length ctxt')
-    then second drop >>> cancelr >>> rewrite_or_default ty' ty
+    then second drop >>> cancelr >>> RewriteTy ty' ty
     else first drop >>> cancell >>> extract_nth ctxt' _ x
   end.
 


### PR DESCRIPTION
Also leave `rewrite_or_default` to arrow interpreter, rather than performing `rewrite_or_default` as a construction of arrow constructors.

Fixes #301 