### PR TITLE
Acorn-based AES equivalence

### DIFF
--- a/cava/Cava/Acorn/AcornCombinators.v
+++ b/cava/Cava/Acorn/AcornCombinators.v
@@ -148,7 +148,7 @@ Section WithCava.
                foldLM f ks st'
     end.
 
-  Lemma foldLM_fold_right {A B}
+  Lemma foldLM_fold_right {m} `{Monad m} {A B}
         (bind_ext : forall {A B} x (f g : A -> m B),
             (forall y, f y = g y) -> bind x f = bind x g)
         (f : B -> A -> m B) (input : list A) (accum : B) :
@@ -163,7 +163,8 @@ Section WithCava.
     rewrite IHinput. reflexivity.
   Qed.
 
-  Lemma foldLM_ident_fold_left {A B} (f : B -> A -> ident B) ls b :
+  Lemma foldLM_ident_fold_left {m} `{Monad m}
+        {A B} (f : B -> A -> ident B) ls b :
     unIdent (foldLM f ls b) = List.fold_left (fun b a => unIdent (f b a)) ls b.
   Proof.
     revert b; induction ls; [ reflexivity | ].

--- a/cava/Cava/Acorn/AcornSignal.v
+++ b/cava/Cava/Acorn/AcornSignal.v
@@ -39,13 +39,13 @@ Inductive Signal : SignalType -> Type :=
   | Fst : forall {A B : SignalType}, Signal (Pair A B) -> Signal A
   | Snd : forall {A B : SignalType}, Signal (Pair A B) -> Signal B.
 
-Fixpoint denoteCombinaional (t : SignalType) : Type :=
+Fixpoint denoteCombinational (t : SignalType) : Type :=
   match t with
   | Void => unit
   | Bit => bool
-  | Vec vt s => Vector.t (denoteCombinaional vt) s
+  | Vec vt s => Vector.t (denoteCombinational vt) s
   | ExternalType _ => string
-  | Pair A B => denoteCombinaional A * denoteCombinaional B
+  | Pair A B => denoteCombinational A * denoteCombinational B
   end.
 
 Definition denoteSignal (t : SignalType) : Type := Signal t.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -21,7 +21,7 @@ Require Export ExtLib.Data.Monads.IdentityMonad.
 From Cava Require Import Acorn.AcornSignal.
 From Cava Require Import Acorn.AcornCavaClass.
 
-Instance Combinational : Cava denoteCombinaional :=
+Instance Combinational : Cava denoteCombinational :=
 { m := ident;
   one := true;
   zero := false;

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -1,0 +1,79 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Coq.Vectors.Vector.
+Require Import ExtLib.Structures.Monads.
+Require Import Cava.ListUtils.
+Require Import Cava.VectorUtils.
+Require Import Cava.Monad.MonadFacts.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornVectors.
+Require Import Cava.Acorn.Combinational.
+
+Require Import AesSpec.Cipher.
+Require Import AcornAes.CipherRound.
+
+Import MonadNotation.
+Existing Instance Combinational.
+
+Section WithSubroutines.
+  Local Notation byte := (t bool 8).
+  Local Notation state := (t (t byte 4) 4) (only parsing).
+  Local Notation key := (t (t byte 4) 4) (only parsing).
+  Context (sub_bytes:     state -> ident state)
+          (shift_rows:    state -> ident state)
+          (mix_columns:   state -> ident state).
+  Let add_round_key : key -> state -> ident state := xor4x4V.
+
+  Let sub_bytes' : state -> state := (fun st => unIdent (sub_bytes st)).
+  Let shift_rows' : state -> state := (fun st => unIdent (shift_rows st)).
+  Let mix_columns' : state -> state := (fun st => unIdent (mix_columns st)).
+  (* Note: argument order is switched for spec *)
+  Let add_round_key' : state -> key -> state :=
+    (fun st k => unIdent (add_round_key k st)).
+
+  Lemma cipher_equiv
+        (first_key last_key : key) (middle_keys : list key) (input : state) :
+    let cipher := (cipher sub_bytes shift_rows mix_columns add_round_key) in
+    let cipher_spec := (Cipher.cipher _ _ add_round_key'
+                                      sub_bytes' shift_rows' mix_columns') in
+    unIdent (cipher first_key last_key middle_keys input)
+    = cipher_spec first_key last_key middle_keys input.
+  Proof.
+    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key' add_round_key.
+    cbv [cipher cipher_round Cipher.cipher]. cbn [bind ret Monad_ident unIdent].
+    repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
+    eapply fold_left_preserves_relation; [ reflexivity | ].
+    intros; subst. reflexivity.
+  Qed.
+
+  Lemma cipher_alt_equiv
+        (first_key last_key : key) (middle_keys : list key) (input : state) :
+    let cipher := (cipher_alt sub_bytes shift_rows mix_columns add_round_key) in
+    let cipher_spec := (Cipher.cipher _ _ add_round_key'
+                                      sub_bytes' shift_rows' mix_columns') in
+    unIdent (cipher first_key last_key middle_keys input)
+    = cipher_spec first_key last_key middle_keys input.
+  Proof.
+    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key' add_round_key.
+    cbv [cipher_alt cipher_round Cipher.cipher].
+    cbn [bind ret Monad_ident unIdent mcompose].
+    repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
+    eapply fold_left_preserves_relation; [ reflexivity | ].
+    intros; subst. reflexivity.
+  Qed.
+End WithSubroutines.

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -55,11 +55,12 @@ Section WithCava.
   Definition xor4x4V (a b : signal state) : m (signal state) :=
     zipWith xor4xV a b.
 
-  Definition cipher_round (key input: signal state) : m (signal state) :=
+  Definition cipher_round (input: signal state) (key : signal key)
+    : m (signal state) :=
     stage1 <- sub_bytes input ;;
     stage2 <- shift_rows stage1 ;;
     stage3 <- mix_columns stage2 ;;
-    xor4x4V stage3 key.
+    xor4x4V key stage3.
 
   Local Open Scope list_scope.
 

--- a/silveroak-opentitan/aes/Acorn/_CoqProject
+++ b/silveroak-opentitan/aes/Acorn/_CoqProject
@@ -1,3 +1,7 @@
+-R . AcornAes
+-R ../Spec AesSpec
 -R ../../../cava/Cava Cava
 -R ../../../third_party/coq-ext-lib/theories ExtLib
+-R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 CipherRound.v
+CipherEquivalence.v


### PR DESCRIPTION
Resolves #315 

This proof was very easy! Probably had a lot to do with the fact that the implementation was based on the spec. A good follow-up to this would be to create an Acorn-based AES implementation that's closer to OpenTitan, and see how we do with that.

Also included in this PR is a typo fix and a couple of proofs about the new `foldLM` definition -- only one is currently used, but the other might be useful later.