### PR TITLE
Remove m as typeclass variable

### DIFF
--- a/cava/Cava/Acorn/AcornCavaClass.v
+++ b/cava/Cava/Acorn/AcornCavaClass.v
@@ -20,7 +20,8 @@ From Cava Require Import Acorn.AcornSignal.
 
 Open Scope type_scope.
 
-Class Cava m `{Monad m} (signal : SignalType -> Type) := {
+Class Cava (signal : SignalType -> Type) := {
+  m : Type -> Type;
   one : signal Bit;
   zero : signal Bit;
   inv : signal Bit -> m (signal Bit);
@@ -34,8 +35,7 @@ Class Cava m `{Monad m} (signal : SignalType -> Type) := {
   unpeel : forall {s : nat} {k : SignalType}, Vector.t (signal k) s -> signal (Vec k s);
 }.
 
-Definition unpair {m signal} `{Cava m signal}
+Definition unpair {signal} `{Cava signal}
           {A B : SignalType}
           (ab: signal (Pair A B)) : (signal A * signal B) :=
   (fsT ab, snD ab).
-  

--- a/cava/Cava/Acorn/AcornCombinators.v
+++ b/cava/Cava/Acorn/AcornCombinators.v
@@ -32,7 +32,7 @@ From Cava Require Import VectorUtils.
 Open Scope type_scope.
 
 Section WithCava.
-  Context {m signal} {monad: Monad m} {cava : Cava m signal}.
+  Context {signal} {cava : Cava signal}.
   
   Definition fork2 {m} `{Monad m}  {A : SignalType}
                   (input : signal A) : m (signal A * signal A) :=
@@ -123,7 +123,7 @@ Section WithCava.
 
   (* TODO(satnam): Lemma about col_cons *)
 
-  Definition zipWith {A B C : SignalType} {n : nat}
+  Definition zipWith `{Monad m} {A B C : SignalType} {n : nat}
            (f : signal A * signal B -> m (signal C))
            (a : signal (Vec A n))
            (b : signal (Vec B n))

--- a/cava/Cava/Acorn/AcornNetlistGeneration.v
+++ b/cava/Cava/Acorn/AcornNetlistGeneration.v
@@ -40,8 +40,9 @@ Definition binaryGate (gate : Signal Bit -> Signal Bit -> Signal Bit -> AcornIns
   addInstance (gate i0 i1 o) ;;
   ret o.
                      
-Instance AcornNetlist : Cava (state AcornState) denoteSignal :=
-{ one := Const1;
+Instance AcornNetlist : Cava denoteSignal :=
+{ m := state AcornState;
+  one := Const1;
   zero := Const0;
   inv :=  invNet;
   and2 := binaryGate And2;

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -21,8 +21,9 @@ Require Export ExtLib.Data.Monads.IdentityMonad.
 From Cava Require Import Acorn.AcornSignal.
 From Cava Require Import Acorn.AcornCavaClass.
 
-Instance Combinational : Cava ident denoteCombinaional :=
-{ one := true;
+Instance Combinational : Cava denoteCombinaional :=
+{ m := ident;
+  one := true;
   zero := false;
   inv i := ret (negb i);
   and2 '(i0, i1) := ret (i0 && i1);

--- a/cava/Cava/Acorn/Lib/AcornFullAdder.v
+++ b/cava/Cava/Acorn/Lib/AcornFullAdder.v
@@ -24,7 +24,8 @@ Open Scope type_scope.
 From Cava Require Import Acorn.Acorn.
 
 Section WithCava.
-  Context {m signal} {monad: Monad m} {cava : Cava m signal}.
+  Context {signal} {cava : Cava signal}.
+  Context {monad: Monad m}.
 
   Definition halfAdder (ab : signal Bit * signal Bit)
                        : m (signal Bit * signal Bit) :=
@@ -33,8 +34,7 @@ Section WithCava.
     carry <- and2 (a, b) ;;
     ret (partial_sum, carry).
 
-  Definition halfAdderAlt {m signal} `{Cava m signal}
-                          (ab : signal (Pair Bit Bit))
+  Definition halfAdderAlt (ab : signal (Pair Bit Bit))
                           : m (signal (Pair Bit Bit)) :=
     let (a, b) := unpair ab in 
     partial_sum <- xor2 (a, b) ;;
@@ -72,25 +72,29 @@ Section WithCava.
     ret (abcl, cout).
 
  End WithCava.
+ 
+Section Combinational.
 
-(* A proof that the half-adder is correct. *)
-Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
-                            unIdent (halfAdder (a, b)) = (xorb a b, a && b).
+  (* A proof that the half-adder is correct. *)
+  Lemma halfAdder_behaviour : forall (a : bool) (b : bool),
+                              unIdent (halfAdder (a, b)) = (xorb a b, a && b).
 
-Proof.
-  auto.
-Qed.
+  Proof.
+    auto.
+  Qed.
 
-(* A proof that the the full-adder is correct. *)
-Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
-                            combinational (fullAdder (cin, (a, b)))
-                              = (xorb cin (xorb a b),
-                                (a && b) || (b && cin) || (a && cin)).
-Proof.
-  intros.
-  unfold combinational.
-  unfold fst.
-  simpl.
-  case a, b, cin.
-  all : reflexivity.
-Qed.
+  (* A proof that the the full-adder is correct. *)
+  Lemma fullAdder_behaviour : forall (a : bool) (b : bool) (cin : bool),
+                              combinational (fullAdder (cin, (a, b)))
+                                = (xorb cin (xorb a b),
+                                  (a && b) || (b && cin) || (a && cin)).
+  Proof.
+    intros.
+    unfold combinational.
+    unfold fst.
+    simpl.
+    case a, b, cin.
+    all : reflexivity.
+  Qed.
+
+End Combinational.

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
@@ -33,7 +33,8 @@ From Cava Require Import Acorn.Lib.AcornFullAdder.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {m signal} {monad: Monad m} {cava : Cava m signal}.
+  Context {signal} {cava : Cava signal}.
+  Context {monad: Monad m}.
 
   (* Vector verison *)
 

--- a/cava/Cava/Acorn/Lib/AcornVectors.v
+++ b/cava/Cava/Acorn/Lib/AcornVectors.v
@@ -28,7 +28,7 @@ From Cava Require Import VectorUtils.
 From Cava Require Import Acorn.Acorn.
 
 (* xor two bit-vectors *)
-Definition xorV {m signal} `{Cava m signal}
+Definition xorV {signal} `{Cava signal} `{Monad m} 
   {n : nat} (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
   m (signal (Vec Bit n)) :=
   let a' := peel (fst ab) in

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -31,7 +31,8 @@ From Cava Require Import Acorn.Lib.AcornVectors.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {m signal} {monad: Monad m} {cava : Cava m signal}.
+  Context {signal} {cava : Cava signal}.
+  Context {monad: Monad m}.
 
   Local Notation state := (Vec (Vec (Vec Bit 8) 4) 4)
                           (only parsing).


### PR DESCRIPTION
This removes `m` as a typeclass variable and makes it a member instead. This simplifies the type context for Acorn circuits.
Addresses #318 