### PR TITLE
Clean up logic in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,6 @@ SUBDIRS = third_party cava tests monad-examples arrow-examples silveroak-opentit
 
 .PHONY: all coq clean subdirs $(SUBDIRS)
 
-# if the "make clean" or "make coq" targets were called, pass these to subdirs
-ifeq ($(MAKECMDGOALS), coq)
-SUBDIRTARGET="coq"
-else ifeq ($(MAKECMDGOALS), clean)
-SUBDIRTARGET="clean"
-endif
-
 all: subdirs
 
 subdirs: $(SUBDIRS)
@@ -46,6 +39,12 @@ $(SUBDIRS):
 coq: $(SUBDIRS)
 
 clean: $(SUBDIRS)
+
+# pass the 'coq' target down to subdirs
+coq: SUBDIRTARGET=coq
+
+# pass the 'clean' target down to subdirs
+clean: SUBDIRTARGET=clean
 
 # cava depends on third_party
 cava : third_party

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,20 @@ $(SUBDIRS):
 
 coq: $(SUBDIRS)
 
-clean: $(SUBDIRS)
+# clean everything *except for* third_party
+clean:
+	for dir in $(filter-out third_party,$(SUBDIRS)); do \
+		$(MAKE) -C $$dir clean; \
+	done
+
+# clean everything *including* third_party
+cleanall:
+	for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir clean; \
+	done
 
 # pass the 'coq' target down to subdirs
 coq: SUBDIRTARGET=coq
-
-# pass the 'clean' target down to subdirs
-clean: SUBDIRTARGET=clean
 
 # strip off the first subdir name, then call make on that subdir with the specified .vo target
 # for example, "make cava/X/Y/Foo.vo" will call "make -C cava X/Y/Foo.vo"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,16 @@ coq: SUBDIRTARGET=coq
 # pass the 'clean' target down to subdirs
 clean: SUBDIRTARGET=clean
 
+# strip off the first subdir name, then call make on that subdir with the specified .vo target
+# for example, "make cava/X/Y/Foo.vo" will call "make -C cava X/Y/Foo.vo"
+%.vo:
+	$(MAKE) -C $(DIR) $(TARGET)
+
+%.vo: DIR=$(firstword $(subst /, , $@))
+
+%.vo: TARGET=$(subst $(DIR)/,,$@)
+
+
 # cava depends on third_party
 cava : third_party
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@
 # Clean everything:
 # make clean
 
-SUBDIRS = third_party cava tests monad-examples arrow-examples silveroak-opentitan monad-examples/xilinx tests/xilinx
+SUBDIRS = third_party cava tests monad-examples arrow-examples silveroak-opentitan \
+	  monad-examples/xilinx tests/xilinx
 
 .PHONY: all coq clean subdirs $(SUBDIRS)
 

--- a/arrow-examples/Makefile
+++ b/arrow-examples/Makefile
@@ -37,6 +37,9 @@ Makefile.coq:
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 ArrowExamplesSV:	coq ArrowExamplesSV.hs *.hs
 			ghc --make ArrowExamplesSV.hs
 			./ArrowExamplesSV

--- a/monad-examples/Makefile
+++ b/monad-examples/Makefile
@@ -39,6 +39,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 ExamplesSV:	coq ExamplesSV.hs
 		ghc --make ExamplesSV.hs
 		./ExamplesSV

--- a/monad-examples/xilinx/Makefile
+++ b/monad-examples/xilinx/Makefile
@@ -46,6 +46,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 ExamplesSV:	coq ExamplesSV.hs
 		ghc -O2 --make ExamplesSV.hs
 		./ExamplesSV

--- a/silveroak-opentitan/Makefile
+++ b/silveroak-opentitan/Makefile
@@ -14,23 +14,32 @@
 # limitations under the License.
 #
 
-all: pinmux aes
+SUBDIRS = pinmux aes
 
-pinmux:
-	cd pinmux && $(MAKE)
+.PHONY: all coq clean subdirs $(SUBDIRS)
 
-aes:
-	cd aes && $(MAKE)
+all: subdirs
 
-pinmux-coq:
-	cd pinmux && $(MAKE) coq
+subdirs: $(SUBDIRS)
 
-aes-coq:
-	cd aes && $(MAKE) coq
+$(SUBDIRS):
+	$(MAKE) -C $@ $(SUBDIRTARGET)
 
-coq: pinmux-coq aes-coq
+coq: $(SUBDIRS)
 
-clean:
-	cd pinmux && $(MAKE) clean
-	cd aes && $(MAKE) clean
+clean: $(SUBDIRS)
 
+# pass the 'coq' target down to subdirs
+coq: SUBDIRTARGET=coq
+
+# pass the 'clean' target down to subdirs
+clean: SUBDIRTARGET=clean
+
+# strip off the first subdir name, then call make on that subdir with the specified .vo target
+# for example, "make X/Y/Foo.vo" will call "make -C X Y/Foo.vo"
+%.vo:
+	$(MAKE) -C $(DIR) $(TARGET)
+
+%.vo: DIR=$(firstword $(subst /, , $@))
+
+%.vo: TARGET=$(subst $(DIR)/,,$@)

--- a/silveroak-opentitan/aes/Acorn/Makefile
+++ b/silveroak-opentitan/aes/Acorn/Makefile
@@ -24,6 +24,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 clean:		
 		-@$(MAKE) -f Makefile.coq clean
 		rm -rf Makefile.coq Makefile.coq.conf

--- a/silveroak-opentitan/aes/Arrow/Makefile
+++ b/silveroak-opentitan/aes/Arrow/Makefile
@@ -24,6 +24,9 @@ Makefile.coq:
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 clean:
 		-@$(MAKE) -f Makefile.coq clean
 		git clean -Xfd

--- a/silveroak-opentitan/aes/Makefile
+++ b/silveroak-opentitan/aes/Makefile
@@ -14,17 +14,32 @@
 # limitations under the License.
 #
 
-all:
-	cd Spec && $(MAKE)
-	cd Arrow && $(MAKE)
-	cd Acorn && $(MAKE)
+SUBDIRS = Spec Arrow Acorn
 
-coq:
-	cd Spec && $(MAKE) coq
-	cd Arrow && $(MAKE) coq
-	cd Acorn && $(MAKE) coq
+.PHONY: all coq clean subdirs $(SUBDIRS)
 
-clean:
-	cd Spec && $(MAKE) clean
-	cd Arrow && $(MAKE) clean
-	cd Acorn && $(MAKE) clean
+all: subdirs
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@ $(SUBDIRTARGET)
+
+coq: $(SUBDIRS)
+
+clean: $(SUBDIRS)
+
+# pass the 'coq' target down to subdirs
+coq: SUBDIRTARGET=coq
+
+# pass the 'clean' target down to subdirs
+clean: SUBDIRTARGET=clean
+
+# strip off the first subdir name, then call make on that subdir with the specified .vo target
+# for example, "make X/Y/Foo.vo" will call "make -C X Y/Foo.vo"
+%.vo:
+	$(MAKE) -C $(DIR) $(TARGET)
+
+%.vo: DIR=$(firstword $(subst /, , $@))
+
+%.vo: TARGET=$(subst $(DIR)/,,$@)

--- a/silveroak-opentitan/aes/Makefile
+++ b/silveroak-opentitan/aes/Makefile
@@ -43,3 +43,9 @@ clean: SUBDIRTARGET=clean
 %.vo: DIR=$(firstword $(subst /, , $@))
 
 %.vo: TARGET=$(subst $(DIR)/,,$@)
+
+# Arrow depends on Spec
+Arrow: Spec
+
+# Acorn depends on Spec
+Acorn: Spec

--- a/silveroak-opentitan/aes/Spec/Makefile
+++ b/silveroak-opentitan/aes/Spec/Makefile
@@ -24,6 +24,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 clean:	
 	-@$(MAKE) -f Makefile.coq clean
 	rm -rf Makefile.coq Makefile.coq.conf

--- a/silveroak-opentitan/pinmux/Makefile
+++ b/silveroak-opentitan/pinmux/Makefile
@@ -27,6 +27,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 PinmuxSV:	coq PinmuxSV.hs
 		ghc --make $^
 

--- a/silveroak-opentitan/pinmux/Makefile
+++ b/silveroak-opentitan/pinmux/Makefile
@@ -31,7 +31,7 @@ coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq $@
 
 PinmuxSV:	coq PinmuxSV.hs
-		ghc --make $^
+		ghc --make PinmuxSV.hs
 
 pinmux.sv:	coq PinmuxSV
 		./PinmuxSV

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,6 +38,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 TestsSV:	coq TestsSV.hs
 		ghc --make TestsSV
 		./TestsSV

--- a/tests/xilinx/Makefile
+++ b/tests/xilinx/Makefile
@@ -40,6 +40,9 @@ Makefile.coq:	_CoqProject
 coq:		Makefile.coq
 		$(MAKE) -f Makefile.coq
 
+%.vo:		Makefile.coq
+		$(MAKE) -f Makefile.coq $@
+
 VivadoTestsSV:	coq VivadoTestsSV.hs
 		ghc -O2 --make VivadoTestsSV.hs
 		./VivadoTestsSV

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -34,6 +34,8 @@ install: update
 	cd bedrock2 && $(MAKE) install_coqutil && $(MAKE) install_bedrock2
 	cd coq-ext-lib && $(MAKE) install
 
+coq: all
+
 clean:
 	-cd bedrock2 && $(MAKE) clean_all
 	-cd coq-ext-lib && $(MAKE) clean


### PR DESCRIPTION
I wanted to get rid of some of the repetitive code in our Makefiles. In particular, we have a lot of sub-makes, and logic was repeated for every subdirectory. I also wanted to make the Makefiles a little more uniform. This PR:
- Inserts a `SUBDIRS` variable in each Makefile with sub-makes that contains all the subdirectories, and makes all the logic dependent on that variable. Now, to add a subdirectory, you don't need to go through and copy code in several targets; you need only to add its name to `SUBDIRS` and, if it has dependencies on other subdirectories, add a `foo: bar` target to declare `bar` should be built before `foo`.
- Adds `.vo` targets to every Makefile, including the higher-level ones; you can now call `make cava/Cava/Acorn/AcornCombinators.vo` on the top-level directory and it will run `make -C cava Cava/Acorn/AcornCombinators.vo`
- No longer cleans `third_party` when you run `make clean` at the top level; you have to run `make cleanall` to clean `third_party` -- I know I very rarely need to clean `third_party`, and it takes a while to build