### PR TITLE
Temporarily Revert "Cleanup primitive structures"

### DIFF
--- a/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/Cava/Arrow/CavaNotation.v
@@ -59,84 +59,84 @@ Module KappaNotation.
   using the tuple destructuring notation *)
   Definition proj1_tuple1 ty: CircuitPrimitive :=
     match ty with
-    | Tuple l r => P1 (Fst l r)
-    | _ => P1 (Fst Unit Unit)
+    | Tuple l r => Fst l r
+    | _ => Fst Unit Unit
     end.
 
   Notation "'let' '( x , y ) = a 'in' b" := (
     Let a (fun a_binder =>
-    Let (App (Primitive (P1 (Fst _ _))) (Var a_binder)) (fun x =>
-      Let (App (Primitive (P1 (Snd _ _))) (Var a_binder)) (fun y => b))))
+    Let (App (Primitive (Fst _ _)) (Var a_binder)) (fun x =>
+      Let (App (Primitive (Snd _ _)) (Var a_binder)) (fun y => b))))
     ( in custom expr at level 1, x constr, y constr, b at level 7) : kappa_scope.
 
   Notation "'let' '( x , y ) : ty = a 'in' b" := (
     Let a (fun a_binder =>
     Let (App (Primitive (proj1_tuple1 ty)) (Var a_binder)) (fun x =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var a_binder)) (fun y => b))))
+      Let (App (Primitive (Snd _ _ )) (Var a_binder)) (fun y => b))))
     ( in custom expr at level 1, x constr, y constr, ty constr at level 7, b at level 7) : kappa_scope.
 
   Notation "'let' '( x , y , z ) = a 'in' b" := (
     Let a (fun a_binder =>
-    Let (App (Primitive (P1 (Fst _ _ ))) (Var a_binder)) (fun x =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var a_binder)) (fun a_tl_binder =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var a_tl_binder)) (fun y =>
-          Let (App (Primitive (P1 (Snd _ _ ))) (Var a_tl_binder)) (fun z =>
+    Let (App (Primitive (Fst _ _ )) (Var a_binder)) (fun x =>
+      Let (App (Primitive (Snd _ _ )) (Var a_binder)) (fun a_tl_binder =>
+        Let (App (Primitive (Fst _ _ )) (Var a_tl_binder)) (fun y =>
+          Let (App (Primitive (Snd _ _ )) (Var a_tl_binder)) (fun z =>
           b))))))
     ( in custom expr at level 1, x constr, y constr, z constr, b at level 7) : kappa_scope.
   Notation "'let' '( x , y , z , w ) = a 'in' b" := (
     Let a (fun a_binder =>
-    Let (App (Primitive (P1 (Fst _ _ ))) (Var a_binder)) (fun x =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var a_binder)) (fun a_tl_binder =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var a_tl_binder)) (fun y =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var a_tl_binder)) (fun a_tl_tl_binder =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var a_tl_tl_binder)) (fun z =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var a_tl_tl_binder)) (fun w =>
+    Let (App (Primitive (Fst _ _ )) (Var a_binder)) (fun x =>
+      Let (App (Primitive (Snd _ _ )) (Var a_binder)) (fun a_tl_binder =>
+        Let (App (Primitive (Fst _ _ )) (Var a_tl_binder)) (fun y =>
+            Let (App (Primitive (Snd _ _ )) (Var a_tl_binder)) (fun a_tl_tl_binder =>
+              Let (App (Primitive (Fst _ _ )) (Var a_tl_tl_binder)) (fun z =>
+                Let (App (Primitive (Snd _ _ )) (Var a_tl_tl_binder)) (fun w =>
           b))))))))
     ( in custom expr at level 1, x constr, y constr, z constr, w constr, b at level 7) : kappa_scope.
   Notation "'let' '( x1 , x2 , x3 , x4 , x5 ) = a 'in' b" := (
     Let a (fun binder1 =>
-    Let (App (Primitive (P1 (Fst _ _ ))) (Var binder1)) (fun x1 =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var binder1)) (fun binder2 =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var binder2)) (fun x2 =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var binder2)) (fun binder3 =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var binder3)) (fun x3 =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var binder3)) (fun binder4 =>
-                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder4)) (fun x4 =>
-                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder4)) (fun x5 =>
+    Let (App (Primitive (Fst _ _ )) (Var binder1)) (fun x1 =>
+      Let (App (Primitive (Snd _ _ )) (Var binder1)) (fun binder2 =>
+        Let (App (Primitive (Fst _ _ )) (Var binder2)) (fun x2 =>
+            Let (App (Primitive (Snd _ _ )) (Var binder2)) (fun binder3 =>
+              Let (App (Primitive (Fst _ _ )) (Var binder3)) (fun x3 =>
+                Let (App (Primitive (Snd _ _ )) (Var binder3)) (fun binder4 =>
+                  Let (App (Primitive (Fst _ _ )) (Var binder4)) (fun x4 =>
+                    Let (App (Primitive (Snd _ _ )) (Var binder4)) (fun x5 =>
           b))))))))))
     ( in custom expr at level 1
     , x1 constr, x2 constr, x3 constr, x4 constr, x5 constr
     , b at level 7) : kappa_scope.
   Notation "'let' '( x1 , x2 , x3 , x4 , x5 , x6 ) = a 'in' b" := (
     Let a (fun binder1 =>
-    Let (App (Primitive (P1 (Fst _ _ ))) (Var binder1)) (fun x1 =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var binder1)) (fun binder2 =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var binder2)) (fun x2 =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var binder2)) (fun binder3 =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var binder3)) (fun x3 =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var binder3)) (fun binder4 =>
-                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder4)) (fun x4 =>
-                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder4)) (fun binder5 =>
-                      Let (App (Primitive (P1 (Fst _ _ ))) (Var binder5)) (fun x5 =>
-                        Let (App (Primitive (P1 (Snd _ _ ))) (Var binder5)) (fun x6 =>
+    Let (App (Primitive (Fst _ _ )) (Var binder1)) (fun x1 =>
+      Let (App (Primitive (Snd _ _ )) (Var binder1)) (fun binder2 =>
+        Let (App (Primitive (Fst _ _ )) (Var binder2)) (fun x2 =>
+            Let (App (Primitive (Snd _ _ )) (Var binder2)) (fun binder3 =>
+              Let (App (Primitive (Fst _ _ )) (Var binder3)) (fun x3 =>
+                Let (App (Primitive (Snd _ _ )) (Var binder3)) (fun binder4 =>
+                  Let (App (Primitive (Fst _ _ )) (Var binder4)) (fun x4 =>
+                    Let (App (Primitive (Snd _ _ )) (Var binder4)) (fun binder5 =>
+                      Let (App (Primitive (Fst _ _ )) (Var binder5)) (fun x5 =>
+                        Let (App (Primitive (Snd _ _ )) (Var binder5)) (fun x6 =>
           b))))))))))))
     ( in custom expr at level 1
     , x1 constr, x2 constr, x3 constr, x4 constr, x5 constr, x6 constr
     , b at level 7) : kappa_scope.
   Notation "'let' '( x1 , x2 , x3 , x4 , x5 , x6 , x7 ) = a 'in' b" := (
     Let a (fun binder1 =>
-    Let (App (Primitive (P1 (Fst _ _ ))) (Var binder1)) (fun x1 =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var binder1)) (fun binder2 =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var binder2)) (fun x2 =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var binder2)) (fun binder3 =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var binder3)) (fun x3 =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var binder3)) (fun binder4 =>
-                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder4)) (fun x4 =>
-                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder4)) (fun binder5 =>
-                      Let (App (Primitive (P1 (Fst _ _ ))) (Var binder5)) (fun x5 =>
-                        Let (App (Primitive (P1 (Snd _ _ ))) (Var binder5)) (fun binder6 =>
-                            Let (App (Primitive (P1 (Fst _ _ ))) (Var binder6)) (fun x6 =>
-                              Let (App (Primitive (P1 (Snd _ _ ))) (Var binder6)) (fun x7 =>
+    Let (App (Primitive (Fst _ _ )) (Var binder1)) (fun x1 =>
+      Let (App (Primitive (Snd _ _ )) (Var binder1)) (fun binder2 =>
+        Let (App (Primitive (Fst _ _ )) (Var binder2)) (fun x2 =>
+            Let (App (Primitive (Snd _ _ )) (Var binder2)) (fun binder3 =>
+              Let (App (Primitive (Fst _ _ )) (Var binder3)) (fun x3 =>
+                Let (App (Primitive (Snd _ _ )) (Var binder3)) (fun binder4 =>
+                  Let (App (Primitive (Fst _ _ )) (Var binder4)) (fun x4 =>
+                    Let (App (Primitive (Snd _ _ )) (Var binder4)) (fun binder5 =>
+                      Let (App (Primitive (Fst _ _ )) (Var binder5)) (fun x5 =>
+                        Let (App (Primitive (Snd _ _ )) (Var binder5)) (fun binder6 =>
+                            Let (App (Primitive (Fst _ _ )) (Var binder6)) (fun x6 =>
+                              Let (App (Primitive (Snd _ _ )) (Var binder6)) (fun x7 =>
           b))))))))))))))
     ( in custom expr at level 1
     , x1 constr, x2 constr, x3 constr, x4 constr, x5 constr, x6 constr, x7 constr
@@ -145,17 +145,17 @@ Module KappaNotation.
   Notation "'let' '( x1 , x2 , x3 , x4 , x5 , x6 , x7 ) : ty = a 'in' b" := (
     Let a (fun binder1 =>
     Let (App (Primitive (proj1_tuple1 ty)) (Var binder1)) (fun x1 =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var binder1)) (fun binder2 =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var binder2)) (fun x2 =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var binder2)) (fun binder3 =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var binder3)) (fun x3 =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var binder3)) (fun binder4 =>
-                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder4)) (fun x4 =>
-                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder4)) (fun binder5 =>
-                      Let (App (Primitive (P1 (Fst _ _ ))) (Var binder5)) (fun x5 =>
-                        Let (App (Primitive (P1 (Snd _ _ ))) (Var binder5)) (fun binder6 =>
-                            Let (App (Primitive (P1 (Fst _ _ ))) (Var binder6)) (fun x6 =>
-                              Let (App (Primitive (P1 (Snd _ _ ))) (Var binder6)) (fun x7 =>
+      Let (App (Primitive (Snd _ _ )) (Var binder1)) (fun binder2 =>
+        Let (App (Primitive (Fst _ _ )) (Var binder2)) (fun x2 =>
+            Let (App (Primitive (Snd _ _ )) (Var binder2)) (fun binder3 =>
+              Let (App (Primitive (Fst _ _ )) (Var binder3)) (fun x3 =>
+                Let (App (Primitive (Snd _ _ )) (Var binder3)) (fun binder4 =>
+                  Let (App (Primitive (Fst _ _ )) (Var binder4)) (fun x4 =>
+                    Let (App (Primitive (Snd _ _ )) (Var binder4)) (fun binder5 =>
+                      Let (App (Primitive (Fst _ _ )) (Var binder5)) (fun x5 =>
+                        Let (App (Primitive (Snd _ _ )) (Var binder5)) (fun binder6 =>
+                            Let (App (Primitive (Fst _ _ )) (Var binder6)) (fun x6 =>
+                              Let (App (Primitive (Snd _ _ )) (Var binder6)) (fun x7 =>
           b))))))))))))))
     ( in custom expr at level 1
     , x1 constr, x2 constr, x3 constr, x4 constr, x5 constr, x6 constr, x7 constr
@@ -165,19 +165,19 @@ Module KappaNotation.
   Notation "'let' '( x1 , x2 , x3 , x4 , x5 , x6 , x7 , x8 ) : ty = a 'in' b" := (
     Let a (fun binder1 =>
     Let (App (Primitive (proj1_tuple1 ty)) (Var binder1)) (fun x1 =>
-      Let (App (Primitive (P1 (Snd _ _ ))) (Var binder1)) (fun binder2 =>
-        Let (App (Primitive (P1 (Fst _ _ ))) (Var binder2)) (fun x2 =>
-            Let (App (Primitive (P1 (Snd _ _ ))) (Var binder2)) (fun binder3 =>
-              Let (App (Primitive (P1 (Fst _ _ ))) (Var binder3)) (fun x3 =>
-                Let (App (Primitive (P1 (Snd _ _ ))) (Var binder3)) (fun binder4 =>
-                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder4)) (fun x4 =>
-                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder4)) (fun binder5 =>
-                      Let (App (Primitive (P1 (Fst _ _ ))) (Var binder5)) (fun x5 =>
-                        Let (App (Primitive (P1 (Snd _ _ ))) (Var binder5)) (fun binder6 =>
-                            Let (App (Primitive (P1 (Fst _ _ ))) (Var binder6)) (fun x6 =>
-                              Let (App (Primitive (P1 (Snd _ _ ))) (Var binder6)) (fun binder7 =>
-                                  Let (App (Primitive (P1 (Fst _ _ ))) (Var binder7)) (fun x7 =>
-                                    Let (App (Primitive (P1 (Snd _ _ ))) (Var binder7)) (fun x8 =>
+      Let (App (Primitive (Snd _ _ )) (Var binder1)) (fun binder2 =>
+        Let (App (Primitive (Fst _ _ )) (Var binder2)) (fun x2 =>
+            Let (App (Primitive (Snd _ _ )) (Var binder2)) (fun binder3 =>
+              Let (App (Primitive (Fst _ _ )) (Var binder3)) (fun x3 =>
+                Let (App (Primitive (Snd _ _ )) (Var binder3)) (fun binder4 =>
+                  Let (App (Primitive (Fst _ _ )) (Var binder4)) (fun x4 =>
+                    Let (App (Primitive (Snd _ _ )) (Var binder4)) (fun binder5 =>
+                      Let (App (Primitive (Fst _ _ )) (Var binder5)) (fun x5 =>
+                        Let (App (Primitive (Snd _ _ )) (Var binder5)) (fun binder6 =>
+                            Let (App (Primitive (Fst _ _ )) (Var binder6)) (fun x6 =>
+                              Let (App (Primitive (Snd _ _ )) (Var binder6)) (fun binder7 =>
+                                  Let (App (Primitive (Fst _ _ )) (Var binder7)) (fun x7 =>
+                                    Let (App (Primitive (Snd _ _ )) (Var binder7)) (fun x8 =>
           b))))))))))))))))
     ( in custom expr at level 1
     , x1 constr, x2 constr, x3 constr, x4 constr, x5 constr, x6 constr, x7 constr, x8 constr
@@ -189,7 +189,7 @@ Module KappaNotation.
   Notation "! x" := (RemoveContext (x _))(in custom expr at level 2, x global) : kappa_scope.
   Notation "!( x )" := (RemoveContext (x _)) (in custom expr, x constr) : kappa_scope.
 
-  Notation tupleHelper := (fun x y => App (App (Primitive (P2 (Pair _ _))) x) y).
+  Notation tupleHelper := (fun x y => App (App (Primitive (Pair _ _)) x) y).
   Notation "( x , .. , y , z )" := (
     (tupleHelper x .. (tupleHelper y z) .. )
     )
@@ -197,24 +197,24 @@ Module KappaNotation.
 
   (* Pre defined functions *)
 
-  Notation "'fst'" := (Primitive (P1 (Fst _ _ ))) (in custom expr at level 4) : kappa_scope.
-  Notation "'snd'" := (Primitive (P1 (Snd _ _ ))) (in custom expr at level 4) : kappa_scope.
+  Notation "'fst'" := (Primitive (Fst _ _ )) (in custom expr at level 4) : kappa_scope.
+  Notation "'snd'" := (Primitive (Snd _ _ )) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'not'" := (Primitive (P1 Not)) (in custom expr at level 4) : kappa_scope.
-  Notation "'and'" := (Primitive (P2 And)) (in custom expr at level 4) : kappa_scope.
-  Notation "'nand'" := (Primitive (P2 Nand)) (in custom expr at level 4) : kappa_scope.
-  Notation "'or'" := (Primitive (P2 Or)) (in custom expr at level 4) : kappa_scope.
-  Notation "'nor'" := (Primitive (P2 Nor)) (in custom expr at level 4) : kappa_scope.
-  Notation "'xor'" := (Primitive (P2 Xor)) (in custom expr at level 4) : kappa_scope.
-  Notation "'xnor'" := (Primitive (P2 Xnor)) (in custom expr at level 4) : kappa_scope.
-  Notation "'buf'" := (Primitive (P1 BufGate)) (in custom expr at level 4) : kappa_scope.
-  Notation "'delay'" := (ExprSyntax.Delay) (in custom expr at level 4) : kappa_scope.
+  Notation "'not'" := (Primitive Not) (in custom expr at level 4) : kappa_scope.
+  Notation "'and'" := (Primitive And) (in custom expr at level 4) : kappa_scope.
+  Notation "'nand'" := (Primitive Nand) (in custom expr at level 4) : kappa_scope.
+  Notation "'or'" := (Primitive Or) (in custom expr at level 4) : kappa_scope.
+  Notation "'nor'" := (Primitive Nor) (in custom expr at level 4) : kappa_scope.
+  Notation "'xor'" := (Primitive Xor) (in custom expr at level 4) : kappa_scope.
+  Notation "'xnor'" := (Primitive Xnor) (in custom expr at level 4) : kappa_scope.
+  Notation "'buf'" := (Primitive BufGate) (in custom expr at level 4) : kappa_scope.
+  Notation "'delay'" := (Primitive (Delay _)) (in custom expr at level 4) : kappa_scope.
 
-  Notation "'xorcy'" := (Primitive (P2 Xorcy)) (in custom expr at level 4) : kappa_scope.
-  Notation "'muxcy'" := (Primitive (P2 Muxcy)) (in custom expr at level 4) : kappa_scope.
+  Notation "'xorcy'" := (Primitive Xorcy) (in custom expr at level 4) : kappa_scope.
+  Notation "'muxcy'" := (Primitive Muxcy) (in custom expr at level 4) : kappa_scope.
 
-  Definition unsigned_add2 {var a b} := Primitive (var:=var) (P2 (UnsignedAdd a b (S (max a b)))).
-  Definition unsigned_add1 {var a} := Primitive (var:=var) (P2 (UnsignedAdd a a a)).
+  Definition unsigned_add2 {var a b} := Primitive (var:=var) (UnsignedAdd a b (S (max a b))).
+  Definition unsigned_add1 {var a} := Primitive (var:=var) (UnsignedAdd a a a).
 
   Notation "x + y" :=
       (App (App unsigned_add2 x) y)
@@ -222,26 +222,26 @@ Module KappaNotation.
   Notation "x +% y" :=
       (App (App unsigned_add1 x) y)
       (in custom expr at level 4) : kappa_scope.
-  Notation "x - y" := (App (App ((Primitive (P2 (UnsignedSub _)))) x) y) (in custom expr at level 4) : kappa_scope.
-  Notation "'unsigned_add' a b c" := ((Primitive (P2 (UnsignedAdd a b c))))
+  Notation "x - y" := (App (App ((Primitive (UnsignedSub _))) x) y) (in custom expr at level 4) : kappa_scope.
+  Notation "'unsigned_add' a b c" := ((Primitive (UnsignedAdd a b c)))
     (in custom expr at level 4,
     a constr at level 4,
     b constr at level 4,
     c constr at level 4
     ) : kappa_scope.
-  Notation "'unsigned_sub' a" := ((Primitive (P2 (UnsignedSub a))))
+  Notation "'unsigned_sub' a" := ((Primitive (UnsignedSub a)))
     (in custom expr at level 4,
     a constr at level 4
     ) : kappa_scope.
 
-  Notation "'[]'" := (Primitive (P0 (EmptyVec _))) (in custom expr at level 4) : kappa_scope.
-  Notation "x ++ y" := (App (App (Primitive (P2 (Concat _ _))) x) y) (in custom expr at level 4) : kappa_scope.
-  Notation "x :: y" := (App (App (Primitive (P2 (Cons _ _))) x) y) (in custom expr at level 7, right associativity) : kappa_scope.
+  Notation "'[]'" := ((Primitive (EmptyVec _))) (in custom expr at level 4) : kappa_scope.
+  Notation "x ++ y" := (App (App ((Primitive (Concat _ _))) x) y) (in custom expr at level 4) : kappa_scope.
+  Notation "x :: y" := (App (App ((Primitive (Cons _ _))) x) y) (in custom expr at level 7, right associativity) : kappa_scope.
 
-  Notation "'true''" := (Primitive (P0 (Constant Bit true))) (in custom expr at level 2) : kappa_scope.
-  Notation "'false''" := (Primitive (P0 (Constant Bit false))) (in custom expr at level 2) : kappa_scope.
+  Notation "'true''" := ((Primitive (Constant Bit true))) (in custom expr at level 2) : kappa_scope.
+  Notation "'false''" := ((Primitive (Constant Bit false))) (in custom expr at level 2) : kappa_scope.
 
-  Notation "# x" := (Primitive (P0 (Constant (Vector Bit _) (N2Bv_sized _ x))))%N
+  Notation "# x" := ((Primitive (Constant (Vector Bit _) (N2Bv_sized _ x))))%N
     (in custom expr at level 2,
     x constr at level 4, no associativity) : kappa_scope.
 
@@ -249,35 +249,35 @@ Module KappaNotation.
   Notation "{ x , y , .. , z }" :=
     (
       let ls := (cons x (cons y .. (cons z nil) ..)) in
-      (Primitive (P0
+      (Primitive
       (ConstantVec
         (List.length ls)
         (Vector Bit _)
         (List.map (N2Bv_sized _) ls)
-      ))))%list%N
+      )))%list%N
     (in custom expr at level 2,
     x constr at level 4, y constr at level 4, z constr at level 4, no associativity) : kappa_scope.
 
-  Notation "v [ x ]" := (App (App (Primitive (P2 (Index _ _))) v) x)
+  Notation "v [ x ]" := (App (App ((Primitive (Index _ _))) v) x)
     ( in custom expr at level 2
     , x at level 7
     ) : kappa_scope.
   Notation "v [: x : y ]" :=
-        (App (Primitive (P1 (Slice _ (x <: nat) (y <: nat) _))) v)
+        (App ((Primitive (Slice _ (x <: nat) (y <: nat) _))) v)
     (in custom expr at level 2,
     (* v constr, *)
     x constr at level 7,
     y constr at level 7
     ) : kappa_scope.
 
-  Notation "'index'" := (Primitive (P2 (Index _ _))) (in custom expr at level 4) : kappa_scope.
-  Notation "'empty'" := (Primitive (P0 EmptyVec)) (in custom expr at level 4) : kappa_scope.
-  Notation "'cons'" := (Primitive (P2 (Cons _ _))) (in custom expr at level 4) : kappa_scope.
-  Notation "'snoc'" := (Primitive (P2 (Snoc _ _))) (in custom expr at level 4) : kappa_scope.
-  Notation "'concat'" := (Primitive (P2 (Concat _ _ _))) (in custom expr at level 4) : kappa_scope.
-  Notation "'split_at' x" := (Primitive (P1 (Split x _ _))) (in custom expr at level 4, x constr at level 4) : kappa_scope.
-  Notation "'uncons'" := (Primitive (P1 (Uncons _ _))) (in custom expr at level 4) : kappa_scope.
-  Notation "'unsnoc'" := (Primitive (P1 (Unsnoc _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'index'" := ((Primitive (Index _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'empty'" := ((Primitive EmptyVec)) (in custom expr at level 4) : kappa_scope.
+  Notation "'cons'" := ((Primitive (Cons _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'snoc'" := ((Primitive (Snoc _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'concat'" := ((Primitive (Concat _ _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'split_at' x" := ((Primitive (Split x _ _))) (in custom expr at level 4, x constr at level 4) : kappa_scope.
+  Notation "'uncons'" := ((Primitive (Uncons _ _))) (in custom expr at level 4) : kappa_scope.
+  Notation "'unsnoc'" := ((Primitive (Unsnoc _ _))) (in custom expr at level 4) : kappa_scope.
 
 End KappaNotation.
 

--- a/cava/Cava/Arrow/CircuitArrow.v
+++ b/cava/Cava/Arrow/CircuitArrow.v
@@ -64,8 +64,6 @@ Inductive Circuit: Kind -> Kind -> Type :=
   | Loopr: forall x y z, Circuit (Tuple x z) (Tuple y z) -> Circuit x y
   | Loopl: forall x y z, Circuit (Tuple z x) (Tuple z y) -> Circuit x y
 
-  | Delay: forall x, Circuit x x
-
   | RewriteTy: forall x y, Circuit x y
   .
 
@@ -102,5 +100,5 @@ Ltac match_compose X :=
   | (Composition _ _ ?Y ?Z) => idtac
   end.
 
-Definition high : Unit ~> Bit := Primitive (P0 (Constant Bit true)).
-Definition low : Unit ~> Bit := Primitive (P0 (Constant Bit false)).
+Definition high : Unit ~> Bit := Primitive (Constant Bit true).
+Definition low : Unit ~> Bit := Primitive (Constant Bit false).

--- a/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
+++ b/cava/Cava/Arrow/CircuitFunctionalEquivalence.v
@@ -162,7 +162,7 @@ Ltac circuit_spec_instantiate :=
     lazymatch goal with
     | |- context [combinational_evaluation' (CircuitArrow.Primitive _)] =>
       (* simplify combinational_evaluation' if there's a primitive *)
-      cbv [combinational_evaluation' primitive_semantics]
+      cbv [combinational_evaluation' primitive_interp]
     | |- _ = @resize_default _ ?n ?d ?n ?v =>
       (* change resize_default to identity function if it appears *)
       transitivity v; [ | rewrite resize_default_id; reflexivity ]

--- a/cava/Cava/Arrow/CircuitProp.v
+++ b/cava/Cava/Arrow/CircuitProp.v
@@ -24,7 +24,7 @@ Import VectorNotations.
 
 Fixpoint no_delays {i o} (c: Circuit i o): bool :=
   match c with
-  | Delay _ => false
+  | Primitive (Delay _) => false
   | Composition _ _ _ f g => no_delays f && no_delays g
   | First _ _ _ f => no_delays f
   | Second _ _ _ f => no_delays f
@@ -45,7 +45,7 @@ Fixpoint no_loops {i o} (c: Circuit i o): bool :=
 
 Fixpoint min_buffering {i o} (n: nat) (c: Circuit i o): nat :=
   match c with
-  | Delay _ => S n
+  | Primitive (Delay _) => S n
   | Composition _ _ _ f g => min (min_buffering n f) (min_buffering n g)
   | First _ _ _ f => min_buffering n f
   | Second _ _ _ f => min_buffering n f
@@ -98,7 +98,7 @@ Section example.
   Proof. vm_compute. intros. inversion x3. Qed.
 
   Example not_gate_is_combinational :
-    is_combinational (Primitive (P1 Not)).
+    is_combinational (Primitive Not).
   Proof.  simply_combinational. Qed.
 End example.
 

--- a/cava/Cava/Arrow/CircuitSemantics.v
+++ b/cava/Cava/Arrow/CircuitSemantics.v
@@ -52,8 +52,7 @@ Fixpoint combinational_evaluation' {i o}
   | Structural (Swap x y) => fun '(x,y) => (y,x)
   | Structural (Copy x) => fun x => (x,x)
 
-  | Primitive p => primitive_semantics p
-  | Delay _ => fun _ => kind_default _
+  | Primitive p => primitive_interp p
   | RewriteTy x y => rewrite_or_default x y
 
   end.
@@ -65,7 +64,7 @@ Fixpoint circuit_state {i o} (c: Circuit i o) : Type :=
   | Second x y z f => circuit_state f
   | Loopr x y z f => circuit_state f
   | Loopl x y z f => circuit_state f
-  | Delay o => denote_kind o
+  | Primitive (Delay o) => denote_kind o
   | _ => Datatypes.unit
   end.
 
@@ -76,7 +75,7 @@ Fixpoint default_state {i o} (c: Circuit i o) : circuit_state c :=
   | Second x y z f => default_state f
   | Loopr x y z f => default_state f
   | Loopl x y z f => default_state f
-  | Delay o => kind_default o
+  | Primitive (Delay o) => kind_default o
   | _ => tt
   end.
 
@@ -116,8 +115,8 @@ Fixpoint circuit_evaluation' {i o} (c: Circuit i o)
   | Structural (Swap x y) => fun '(x,y) _ => ((y,x), tt)
   | Structural (Copy x) => fun x _ => ((x,x),tt)
 
-  | Delay o => fun x s => (s, x)
-  | Primitive p => fun x _ => (primitive_semantics p x, tt)
+  | Primitive (Delay o) => fun x s => (s, fst x)
+  | Primitive p => fun x _ => (primitive_interp p x, tt)
 
   | RewriteTy x y => fun v _ => (rewrite_or_default x y v, tt)
   end.

--- a/cava/Cava/Arrow/Classes/Arrow.v
+++ b/cava/Cava/Arrow/Classes/Arrow.v
@@ -188,7 +188,7 @@ Section arrowstkc.
     | First: object -> object -> object -> ArrowComposition
     | Second: object -> object -> object -> ArrowComposition.
 
-  Definition arrow_input (a: ArrowStructure): object :=
+  Fixpoint arrow_input (a: ArrowStructure): object :=
     match a with
     | Id x => x
     | Assoc x y z => (product (product x y) z)
@@ -202,7 +202,7 @@ Section arrowstkc.
     | Swap x y => product x y
     end.
 
-  Definition arrow_output (a: ArrowStructure): object :=
+  Fixpoint arrow_output (a: ArrowStructure): object :=
     match a with
     | Id x => x
     | Assoc x y z => (product x (product y z))

--- a/cava/Cava/Arrow/Classes/Category.v
+++ b/cava/Cava/Arrow/Classes/Category.v
@@ -1,7 +1,6 @@
 From Coq Require Import Setoid Classes.Morphisms.
 
-Reserved Notation "x ~> y" (at level 90).
-
+Reserved Infix "~>" (at level 90, no associativity).
 Reserved Infix "~[ C ]~>" (at level 90, no associativity).
 Reserved Infix ">>>" (at level 53, right associativity).
 Reserved Infix "=M=" (at level 54, no associativity).

--- a/cava/Cava/Arrow/CombinatorProperties.v
+++ b/cava/Cava/Arrow/CombinatorProperties.v
@@ -138,13 +138,12 @@ Ltac kequiv_step :=
   | |- kappa_equivalence _ (Comp _ _) (Comp _ _) => eapply Compose_equiv
   | |- @kappa_equivalence ?var1 ?var2 ?x ?y ?E (Primitive ?p) (Primitive _) =>
     change (@kappa_equivalence
-              var1 var2 (extended_prim_input p) (primitive_output p)
+              var1 var2 (primitive_input p) (primitive_output p)
               E (Primitive p) (Primitive p));
     eapply Prim_equiv
   | |- kappa_equivalence _ (Let _ _) (Let _ _) => eapply Let_equiv
   | |- kappa_equivalence _ (LetRec _ _) (LetRec _ _) => eapply Letrec_equiv
   | |- kappa_equivalence _ Id Id => eapply Id_equiv
-  | |- kappa_equivalence _ Delay Delay => eapply Delay_equiv
   | |- kappa_equivalence _ (RemoveContext _) (RemoveContext _) =>
     eapply RemoveContext_equiv
   end; intros.
@@ -202,9 +201,7 @@ Section CombinatorWf.
   Hint Resolve equality_Wf : Wf.
 
   Lemma mux_item_Wf A : Wf (@Combinators.mux_item A).
-  Proof. cbv [Combinators.mux_item]; prove_Wf; [ ].
-    eapply bitwise_Wf; prove_Wf.
-  Qed.
+  Proof. cbv [Combinators.mux_item]; prove_Wf. Qed.
   Hint Resolve mux_item_Wf : Wf.
 
   Lemma curry_Wf A B C args c : Wf c -> Wf (@Combinators.curry A B C args c).

--- a/cava/Cava/Arrow/DeriveSpec.v
+++ b/cava/Cava/Arrow/DeriveSpec.v
@@ -24,12 +24,11 @@ Require Import Cava.Arrow.ArrowExport.
 Ltac kappa_spec_begin :=
   intros; cbn [interp_combinational'];
   repeat match goal with
-         | |- context [primitive_semantics ?p] =>
-           let x := constr:(primitive_semantics p) in
-           let y := (eval cbv [primitive_semantics] in x) in
+         | |- context [primitive_interp ?p] =>
+           let x := constr:(primitive_interp p) in
+           let y := (eval cbv [primitive_interp] in x) in
            progress change x with y
-         | _ => progress cbn [denote_kind primitive_input primitive_output
-           nullary_semantics unary_semantics binary_semantics]
+         | _ => progress cbn [denote_kind primitive_input primitive_output]
          end; fold denote_kind in *.
 
 Create HintDb kappa_interp discriminated.

--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -70,8 +70,6 @@ Set Asymmetric Patterns.
 
     | Id_equiv : forall x E, kappa_equivalence E (@Id var1 x) Id
 
-    | Delay_equiv : forall x E, kappa_equivalence E (@Delay var1 x) Delay
-
     | RemoveContext_equiv : forall x y E
       (f1 : kappa var1 x y)
       (f2 : kappa var2 x y),

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -42,19 +42,12 @@ Section combinational_semantics.
     | App f e => fun y =>
       (interp_combinational' f) (interp_combinational' e tt, y)
     | Comp g f => fun x => interp_combinational' g (interp_combinational' f x)
-    | Primitive p =>
-      match p with
-      | P0 p => primitive_semantics (P0 p)
-      | P1 p => fun x => primitive_semantics (P1 p) (fst x)
-      | P2 p => fun x => primitive_semantics (P2 p) (fst x, fst (snd x))
-      end
+    | Primitive p => primitive_interp p
     | Id => fun x => x
     | Let v f => fun y =>
       interp_combinational' (f (interp_combinational' v tt)) y
-    | RemoveContext f => interp_combinational' f
-
     | LetRec v f => fun _ => kind_default _
-    | Delay => fun _ => kind_default _
+    | RemoveContext f => interp_combinational' f
     end.
 
   Definition interp_combinational {x y: Kind}

--- a/cava/Cava/Arrow/ExprSyntax.v
+++ b/cava/Cava/Arrow/ExprSyntax.v
@@ -13,13 +13,6 @@ Section vars.
   Definition natvar : Kind -> Type := fun _ => nat.
   Definition unitvar : Kind -> Type := fun _ => unit.
 
-  Definition extended_prim_input p :=
-    match p with
-    | P0 _ _ => Unit
-    | P1 x _ _ => Tuple x Unit
-    | P2 x y z _ => Tuple x (Tuple y Unit)
-    end.
-
   Section Vars.
     Variable (var: Kind -> Type).
 
@@ -28,8 +21,7 @@ Section vars.
     | Abs : forall {x y z}, (var x -> kappa y z) -> kappa (Tuple x y) z
     | App : forall {x y z}, kappa (Tuple x y) z -> kappa Unit x -> kappa y z
     | Comp: forall {x y z}, kappa y z -> kappa x y -> kappa x z
-    | Delay: forall {x}, kappa (Tuple x Unit) x
-    | Primitive : forall prim, kappa (extended_prim_input prim) (primitive_output prim)
+    | Primitive : forall prim, kappa (primitive_input prim) (primitive_output prim)
     | Let: forall {x y z}, kappa Unit x -> (var x -> kappa y z) -> kappa y z
     | LetRec : forall {x y z}, (var x -> kappa Unit x) -> (var x -> kappa y z) -> kappa y z
     | Id : forall {x}, kappa x x
@@ -58,7 +50,6 @@ Section vars.
     | Abs x _ _ f => wf_phoas_context (x :: ctxt) (f (length ctxt))
     | App _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2
     | Comp _ _ _ e1 e2 => wf_phoas_context ctxt e1 /\ wf_phoas_context ctxt e2
-    | Delay _ => True
     | Primitive _ => True
     | Id _ => True
     | Let x _ _ v f => wf_phoas_context (x :: ctxt) (f (length ctxt)) /\ wf_phoas_context ctxt v
@@ -74,7 +65,6 @@ Arguments Var {var _}.
 Arguments Abs {var _ _ _}.
 Arguments App {var _ _ _}.
 Arguments Comp {var _ _ _}.
-Arguments Delay {var _}.
 Arguments Primitive {var}.
 Arguments LetRec {var _ _ _}.
 Arguments Id {var _}.

--- a/silveroak-opentitan/aes/Arrow/_CoqProject
+++ b/silveroak-opentitan/aes/Arrow/_CoqProject
@@ -18,6 +18,7 @@ unrolled_naive_cipher.v
 unrolled_opentitan_cipher.v
 cipher_round.v
 key_expand.v
+cipher_control.v
 netlists.v
 aes_test.v
 CipherRoundProperties.v

--- a/silveroak-opentitan/aes/Arrow/pkg.v
+++ b/silveroak-opentitan/aes/Arrow/pkg.v
@@ -26,10 +26,10 @@ Notation "|^ x" :=
   (App (RemoveContext (foldr1 <[\a b => xor a b]> _)) x)
   (in custom expr at level 5, no associativity) : kappa_scope.
 Notation "x && y" :=
-  (App (App (Primitive (P2 And)) x) y)
+  (App (App (Primitive And) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x || y" :=
-  (App (App (Primitive (P2 And)) x) y)
+  (App (App (Primitive And) x) y)
   (in custom expr at level 6, left associativity) : kappa_scope.
 Notation "x & y" :=
   (App (App (RemoveContext (bitwise <[and]>  _)) x) y)


### PR DESCRIPTION
Reverts project-oak/oak-hardware#314

- Reverting since this change broke some proofs that CI missed