### PR TITLE
De-noise `make`

### DIFF
--- a/arrow-examples/ArrowAdderTutorial.v
+++ b/arrow-examples/ArrowAdderTutorial.v
@@ -19,7 +19,7 @@ From Cava Require Import Arrow.ArrowExport.
 Require Import Coq.Strings.String.
 Local Open Scope string_scope.
 
-From Coq Require Import Lists.List NArith Lia.
+From Coq Require Import Lists.List NArith.NArith micromega.Lia.
 Import ListNotations.
 
 Section notation.

--- a/arrow-examples/ArrowExtraction.v
+++ b/arrow-examples/ArrowExtraction.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Require Import coqutil.Z.HexNotation.
@@ -26,14 +26,14 @@ Set Extraction Optimize.
 
 Extraction Language Haskell.
 
-Require Import Arrow.Combinators.
-Require Import SyntaxExamples.
-Require Import Mux2_1.
-Require Import UnsignedAdder.
-Require Import Counter.
-Require Import Fir.
+Require Import Cava.Arrow.Combinators.
+Require Import ArrowExamples.SyntaxExamples.
+Require Import ArrowExamples.Mux2_1.
+Require Import ArrowExamples.UnsignedAdder.
+Require Import ArrowExamples.Counter.
+Require Import ArrowExamples.Fir.
 
-Require Import ArrowAdderTutorial.
+Require Import ArrowExamples.ArrowAdderTutorial.
 
 Extraction Library Combinators.
 Extraction Library SyntaxExamples.

--- a/arrow-examples/Counter.v
+++ b/arrow-examples/Counter.v
@@ -16,7 +16,7 @@
 
 
 From Cava Require Import Arrow.ArrowExport.
-From Coq Require Import Lists.List NArith String.
+From Coq Require Import Lists.List NArith.NArith Strings.String.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/Fir.v
+++ b/arrow-examples/Fir.v
@@ -15,7 +15,7 @@
 (****************************************************************************)
 
 From Cava Require Import Arrow.ArrowExport.
-From Coq Require Import Lists.List NArith String Bvector.
+From Coq Require Import Lists.List NArith.NArith Strings.String Bool.Bvector.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/Makefile.coq.local
+++ b/arrow-examples/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/arrow-examples/UnsignedAdder.v
+++ b/arrow-examples/UnsignedAdder.v
@@ -16,7 +16,8 @@
 
 From Cava Require Import Arrow.ArrowExport.
 
-From Coq Require Import Strings.String Bvector List NArith Nat Lia Plus.
+From Coq Require Import Strings.String Bool.Bvector Lists.List NArith.NArith
+     Init.Nat micromega.Lia Arith.Plus.
 Import ListNotations.
 Import EqNotations.
 

--- a/arrow-examples/_CoqProject
+++ b/arrow-examples/_CoqProject
@@ -1,7 +1,8 @@
+INSTALLDEFAULTROOT = ArrowExamples
+-R . ArrowExamples
 -R ../cava/Cava Cava
 -R ../third_party/coq-ext-lib/theories ExtLib
 -R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
--R . ArrowExamples
 
 Mux2_1.v
 SyntaxExamples.v

--- a/cava/Cava/Acorn/AcornCombinators.v
+++ b/cava/Cava/Acorn/AcornCombinators.v
@@ -16,7 +16,7 @@
 
 From Coq Require Import Lists.List.
 Import ListNotations.
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 Local Open Scope vector_scope.

--- a/cava/Cava/Acorn/AcornSignal.v
+++ b/cava/Cava/Acorn/AcornSignal.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import ZArith.
-From Coq Require Import String.
-From Coq Require Import Vector.
+From Coq Require Import ZArith.ZArith.
+From Coq Require Import Strings.String.
+From Coq Require Import Vectors.Vector.
 
 From Cava Require Import VectorUtils.
 

--- a/cava/Cava/Acorn/AcornState.v
+++ b/cava/Cava/Acorn/AcornState.v
@@ -14,8 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
-From Coq Require Import ZArith.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import ZArith.ZArith.
 From Coq Require Import Lists.List.
 Import ListNotations.
 Open Scope list_scope.

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.
+From Coq Require Import NArith.NArith.
 From Coq Require Import Lists.List.
 Import ListNotations.
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
@@ -17,7 +17,7 @@
 From Coq Require Import Bool.Bool.
 From Coq Require Import Lists.List.
 Import ListNotations.
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.

--- a/cava/Cava/Acorn/Lib/AcornVectors.v
+++ b/cava/Cava/Acorn/Lib/AcornVectors.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 Local Open Scope vector_scope.
 

--- a/cava/Cava/Acorn/Lib/AcornVectors.v
+++ b/cava/Cava/Acorn/Lib/AcornVectors.v
@@ -39,4 +39,4 @@ Definition xorV {signal} `{Cava signal} `{Monad m}
 Definition v1 := [false; false; true; true].
 Definition v2 := [false; true;  false; true].
 
-Compute combinational (xorV (v1, v2)).
+(* Compute combinational (xorV (v1, v2)). *)

--- a/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
+++ b/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.
+From Coq Require Import NArith.NArith.
 From Coq Require Import Lists.List.
 Import ListNotations.
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.

--- a/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/Cava/Arrow/ArrowKind.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List NaryFunctions Arith NArith Vector Eqdep_dec.
+From Coq Require Import Lists.List Numbers.NaryFunctions Arith.Arith
+     NArith.NArith Vectors.Vector Logic.Eqdep_dec.
 From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
 
 Import ListNotations.

--- a/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/Cava/Arrow/ArrowKind.v
@@ -137,7 +137,7 @@ Ltac reduce_kind_eq :=
 Declare Scope kind_scope.
 Bind Scope kind_scope with Kind.
 
-Notation "<< x >>" := (x) : kind_scope.
+Notation "<< x >>" := (x) (only parsing) : kind_scope.
 Notation "<< x , .. , y , z >>" := (Tuple x .. (Tuple y z )  .. ) : kind_scope.
 
 Fixpoint arg_length (ty: Kind) :=

--- a/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/Cava/Arrow/CavaNotation.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec List Lia NArith Omega String.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Lists.List micromega.Lia
+     NArith.NArith Strings.String.
 From Cava Require Import Arrow.Classes.Category.
 From Cava Require Import BitArithmetic Arrow.CircuitArrow Arrow.ExprSyntax.
 From Cava Require Import Arrow.ArrowKind.

--- a/cava/Cava/Arrow/CircuitArrow.v
+++ b/cava/Cava/Arrow/CircuitArrow.v
@@ -14,10 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List NaryFunctions String Arith NArith Vector Lia.
-
-Import ListNotations.
-Import VectorNotations.
+From Coq Require Import Lists.List Numbers.NaryFunctions Strings.String
+     Arith.Arith NArith.NArith Vectors.Vector micromega.Lia.
 
 From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
 From Cava Require Import Arrow.ArrowKind.

--- a/cava/Cava/Arrow/CircuitLowering.v
+++ b/cava/Cava/Arrow/CircuitLowering.v
@@ -14,7 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool ZArith NaryFunctions Vector String List DecimalString Lia.
+From Coq Require Import Bool.Bool ZArith.ZArith Numbers.NaryFunctions
+     Vectors.Vector Strings.String Lists.List Numbers.DecimalString
+     micromega.Lia.
 From Cava Require Import Arrow.Classes.Arrow.
 From Cava Require Import Arrow.Classes.Category.
 From Cava Require Import Arrow.Classes.Kleisli.

--- a/cava/Cava/Arrow/CircuitSemantics.v
+++ b/cava/Cava/Arrow/CircuitSemantics.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool ZArith NArith NaryFunctions Vector Lia List.
+From Coq Require Import Bool.Bool ZArith.ZArith NArith.NArith
+     Numbers.NaryFunctions Vectors.Vector micromega.Lia Lists.List.
 From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
 From Cava Require Import Arrow.CircuitArrow Arrow.ArrowKind Arrow.Primitives.
 

--- a/cava/Cava/Arrow/Classes/Arrow.v
+++ b/cava/Cava/Arrow/Classes/Arrow.v
@@ -188,7 +188,7 @@ Section arrowstkc.
     | First: object -> object -> object -> ArrowComposition
     | Second: object -> object -> object -> ArrowComposition.
 
-  Fixpoint arrow_input (a: ArrowStructure): object :=
+  Definition arrow_input (a: ArrowStructure): object :=
     match a with
     | Id x => x
     | Assoc x y z => (product (product x y) z)
@@ -202,7 +202,7 @@ Section arrowstkc.
     | Swap x y => product x y
     end.
 
-  Fixpoint arrow_output (a: ArrowStructure): object :=
+  Definition arrow_output (a: ArrowStructure): object :=
     match a with
     | Id x => x
     | Assoc x y z => (product x (product y z))

--- a/cava/Cava/Arrow/CombinatorProperties.v
+++ b/cava/Cava/Arrow/CombinatorProperties.v
@@ -15,8 +15,8 @@
 (****************************************************************************)
 
 Require Import Coq.NArith.NArith.
-From Cava.Arrow Require Import ArrowExport DeriveSpec.
-From Cava Require Import BitArithmetic Tactics VectorUtils.
+Require Import Cava.Arrow.ArrowExport Cava.Arrow.DeriveSpec.
+Require Import Cava.BitArithmetic Cava.Tactics Cava.VectorUtils.
 
 (* Functional specifications for circuit combinators *)
 Section Specs.

--- a/cava/Cava/Arrow/Combinators.v
+++ b/cava/Cava/Arrow/Combinators.v
@@ -14,10 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+From Coq Require Import Strings.String Bool.Bvector Lists.List NArith.NArith
+     Init.Nat micromega.Lia Arith.Plus.
 From Cava.Arrow Require Import ArrowKind CavaNotation ExprSyntax.
 From Cava.Arrow.Classes Require Import Category.
 
-From Coq Require Import Strings.String Bvector List NArith Nat Lia Plus.
 Import ListNotations.
 Import EqNotations.
 

--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -1,4 +1,4 @@
-From Coq Require Import List PeanoNat Arith.Peano_dec.
+From Coq Require Import Lists.List Arith.PeanoNat Arith.Peano_dec.
 From Cava Require Import Arrow.ArrowKind Arrow.ExprSyntax.
 
 Import ListNotations.

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -56,8 +56,10 @@ Section combinational_semantics.
     (i: denote_kind (remove_rightmost_unit x)): (denote_kind y) :=
     interp_combinational' expr (apply_rightmost_tt x i).
 
+  (*
   Axiom expression_evaluation_is_arrow_evaluation: forall i o (expr: Kappa i o), forall (x: denote_kind i),
     combinational_evaluation' (closure_conversion expr) x =
     interp_combinational' (expr _) x.
+  *)
 
 End combinational_semantics.

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -23,7 +23,8 @@ From Cava Require Import Arrow.ExprLowering.
 From Cava Require Import Arrow.ArrowKind.
 From Cava Require Import Arrow.Primitives.
 
-From Coq Require Import Arith NArith Lia NaryFunctions.
+From Coq Require Import Arith.Arith NArith.NArith micromega.Lia
+     Numbers.NaryFunctions.
 
 Import EqNotations.
 

--- a/cava/Cava/Arrow/Primitives.v
+++ b/cava/Cava/Arrow/Primitives.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import NaryFunctions Arith NArith.
+From Coq Require Import Numbers.NaryFunctions Arith.Arith NArith.NArith.
 From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bool.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 From Cava Require Import VectorUtils.
 From Cava Require Import BitArithmetic.
 

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -293,10 +293,6 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma nat_of_bits_sized_n: forall n (v : nat),
-      bitvec_to_nat (nat_to_bitvec_sized n v) = v.
-Admitted.
-
 Lemma Pos_size_nat_nonzero (p : positive) : 0 < Pos.size_nat p.
 Proof. destruct p; cbn; lia. Qed.
 

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -18,13 +18,13 @@
 
 From Coq Require Import Bool.Bool.
 From Coq Require Import Lists.List.
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 From Coq Require Import NArith.Ndigits.
 From Coq Require Import NArith.Nnat.
-From Coq Require Import Nat.
-From Coq Require Import Omega.
-From Coq Require Import Lia.
+From Coq Require Import Init.Nat.
+From Coq Require Import omega.Omega.
+From Coq Require Import micromega.Lia.
 From Coq Require Import btauto.Btauto.
 From Coq Require Import Arith.PeanoNat.
 From Coq Require Strings.HexString.

--- a/cava/Cava/Kind.v
+++ b/cava/Cava/Kind.v
@@ -14,8 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import String.
-From Coq Require Import Vector.
+From Coq Require Import Strings.String.
+From Coq Require Import Vectors.Vector.
 
 From Cava Require Import VectorUtils.
 

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -15,7 +15,7 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
 Import ListNotations.
 Require Import ExtLib.Structures.Monads.
@@ -26,9 +26,9 @@ Require Vector.
 From Coq Require Import Bool.Bvector.
 From Coq Require Import Fin.
 From Coq Require Import NArith.Ndigits.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 
-From Coq Require Import Lia.
+From Coq Require Import micromega.Lia.
 
 Require Import Cava.Cava.
 From Cava Require Import Kind.

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -75,7 +75,7 @@ Local Open Scope monad_scope.
 -------------------------------------------------------------------------------
 *)
 
-Fixpoint below `{Monad m} {A B C D E F G}
+Definition below `{Monad m} {A B C D E F G}
              (r : A * B -> m (D * G)%type)
              (s : G * C -> m (E * F)%type)
              (abc : A * (B * C)) : m ((D * E) * F)%type :=
@@ -307,7 +307,7 @@ Fixpoint treeList {T: Type} {m} `{Monad m}
            circuit aS bS
   end.
 
-Fixpoint treeWithList {T: Type} {m bit} `{Cava m bit}
+Definition treeWithList {T: Type} {m bit} `{Cava m bit}
                       (circuit: T -> T -> m T) (def: T)
                       (n : nat) (v: Vector.t T (2^(n+1))) : m T :=
   treeList circuit def n (to_list v).

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -14,16 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 
-From Coq Require Import Lists.List Lia.
+From Coq Require Import Lists.List micromega.Lia.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.MonadFix.
-From Coq Require Arith.PeanoNat.
-Require Import Omega.
+From Coq Require Import Arith.PeanoNat.
 
 Export MonadNotation.
 
@@ -35,7 +34,6 @@ Require Import Cava.Tactics.
 
 Generalizable All Variables.
 
-From Coq Require Import Lia.
 Require Import ExtLib.Structures.MonadLaws.
 
 Local Open Scope monad_scope.

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Import Vector.
-From Coq Require Import ZArith.
+From Coq Require Import Vectors.Vector.
+From Coq Require Import ZArith.ZArith.
 
 From Coq Require Import Lists.List.
 Import ListNotations.

--- a/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/Cava/Monad/UnsignedAdders.v
@@ -16,7 +16,7 @@
 
 Require Import ExtLib.Structures.Monads.
 
-Require Import Nat Arith Lia.
+Require Import Init.Nat Arith.Arith micromega.Lia.
 
 Require Import Cava.Cava.
 From Cava Require Import Kind.

--- a/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/Cava/Monad/XilinxAdder.v
@@ -14,10 +14,10 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
-From Coq Require Import NArith.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import NArith.NArith.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 
 From Coq Require Import Lists.List.

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -19,9 +19,9 @@
    Experimental work, very much in flux, as Satnam learns Coq!
 *)
 
-Require Import Program.Basics.
-From Coq Require Import Ascii String.
-From Coq Require Import ZArith.
+Require Import Coq.Program.Basics.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import ZArith.ZArith.
 From Coq Require Import Lists.List.
 From Coq Require Import Bool.Bool.
 From Coq Require Import Numbers.NaryFunctions.
@@ -31,8 +31,6 @@ Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.StateMonad.
 Require Export ExtLib.Data.List.
 From ExtLib Require Import Structures.Traversable.
-
-Require Import Omega.
 
 Import ListNotations.
 Import MonadNotation.

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
-From Coq Require Import ZArith.
-From Coq Require Import Vector.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import ZArith.ZArith.
+From Coq Require Import Vectors.Vector.
 
 From Cava Require Import Kind.
 From Cava Require Import VectorUtils.

--- a/cava/Cava/Types.v
+++ b/cava/Cava/Types.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Program.Basics.
-From Coq Require Import Ascii String.
-From Coq Require Import ZArith.
+Require Import Coq.Program.Basics.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import ZArith.ZArith.
 From Coq Require Import Lists.List.
 From Coq Require Import Bool.Bool.
 (* From Coq Require Import Numbers.NaryFunctions.
@@ -32,9 +32,8 @@ From Cava Require Import Kind.
 From Cava Require Import Signal.
 From Cava Require Import VectorUtils.
 
-Require Import Program.
-Require Import Omega.
-Require Import Nat Arith Lia.
+Require Import Coq.Program.Program.
+Require Import Coq.Init.Nat Coq.Arith.Arith Coq.micromega.Lia.
 
 (******************************************************************************)
 (* shape describes the types of wires going into or out of a Cava circuit,    *)

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -17,11 +17,11 @@
 From Coq Require Import Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 
-From Coq Require Import ZArith.
-From Coq Require Import Nat Arith Lia.
+From Coq Require Import ZArith.ZArith.
+From Coq Require Import Init.Nat Arith.Arith micromega.Lia.
 
 From ExtLib Require Import Structures.Applicative.
 From ExtLib Require Import Structures.Traversable.

--- a/cava/Makefile.coq.local
+++ b/cava/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/cava/_CoqProject
+++ b/cava/_CoqProject
@@ -1,3 +1,4 @@
+INSTALLDEFAULTROOT = Cava
 -R Cava Cava
 -R ../third_party/coq-ext-lib/theories ExtLib
 -R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil

--- a/monad-examples/AdderTree.v
+++ b/monad-examples/AdderTree.v
@@ -15,12 +15,11 @@
 (****************************************************************************)
 
 From Coq Require Import Program.Basics.
-From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
-From Coq Require Import NArith.
-Require Import Omega.
+From Coq Require Import Bool.Bool Init.Nat.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import NArith.NArith.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 

--- a/monad-examples/FullAdder.v
+++ b/monad-examples/FullAdder.v
@@ -14,9 +14,8 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
-Require Import Omega.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/FullAdderNat.v
+++ b/monad-examples/FullAdderNat.v
@@ -18,12 +18,12 @@
    separate because they are not used for extraction to SystemVerilog.
 *)
 
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 From Coq Require Import ZArith.BinInt.
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
-Require Import Nat Arith Lia.
+Require Import Coq.Init.Nat Coq.Arith.Arith Coq.micromega.Lia.
 Import ListNotations.
 
 From Coq Require Import btauto.Btauto.

--- a/monad-examples/Makefile.coq.local
+++ b/monad-examples/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/monad-examples/MonadExtraction.v
+++ b/monad-examples/MonadExtraction.v
@@ -14,17 +14,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Examples.
-Require Import NandGate.
-Require Import Multiplexers.
-Require Import FullAdder.
-Require Import UnsignedAdderExamples.
-Require Import AdderTree.
-Require Import Sorter.
-From Coq Require Import Extraction.
+Require Import MonadExamples.Examples.
+Require Import MonadExamples.NandGate.
+Require Import MonadExamples.Multiplexers.
+Require Import MonadExamples.FullAdder.
+Require Import MonadExamples.UnsignedAdderExamples.
+Require Import MonadExamples.AdderTree.
+Require Import MonadExamples.Sorter.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.

--- a/monad-examples/Multiplexers.v
+++ b/monad-examples/Multiplexers.v
@@ -13,20 +13,18 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Bool.Bool NArith.NArith.
+From Coq Require Import Strings.Ascii Strings.String.
 
 From Coq Require Import Lists.List.
 Import ListNotations.
-
-Require Import Omega.
 
 Require Import ExtLib.Structures.Monads.
 
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
 
-From Coq Require Vector.
+From Coq Require Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import Vector.VectorNotations.
 

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Program.Basics.
+Require Import Coq.Program.Basics.
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/Sorter.v
+++ b/monad-examples/Sorter.v
@@ -16,22 +16,21 @@
 
 Require Import ExtLib.Structures.Monads.
 
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 
 From Coq Require Import Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 
-From Coq Require Import NArith.Ndigits.
-
+From Coq Require Import Arith.PeanoNat NArith.Ndigits NArith.NArith.
 Require Import Cava.Cava.
 Require Import Cava.VectorUtils.
 Require Import Cava.Monad.CavaMonad.
 
-From Coq Require Import Lia Omega.
+From Coq Require Import micromega.Lia.
 
 Local Open Scope vector_scope.
 

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -14,19 +14,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.
+From Coq Require Import NArith.NArith.
 From Coq Require Import Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Vector.
+From Coq Require Vectors.Vector.
 From Coq Require Import Bool.Bvector.
-
-Require Import Omega.
 
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.

--- a/monad-examples/_CoqProject
+++ b/monad-examples/_CoqProject
@@ -1,7 +1,8 @@
+INSTALLDEFAULTROOT = MonadExamples
+-R . MonadExamples
 -R ../cava/Cava Cava
 -R ../third_party/coq-ext-lib/theories ExtLib
 -R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
--R . MonadExamples
 Examples.v
 NandGate.v
 Multiplexers.v

--- a/monad-examples/bits.v
+++ b/monad-examples/bits.v
@@ -1,6 +1,6 @@
-Require Import List.
+Require Import Lists.List.
 Import ListNotations.
-Require Import Nat Arith Lia.
+Require Import Init.Nat Arith.Arith micromega.Lia.
 
 
 Definition nat_to_pair (n:nat) : bool * bool :=

--- a/monad-examples/xilinx/Makefile.coq.local
+++ b/monad-examples/xilinx/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/monad-examples/xilinx/NandLUT.v
+++ b/monad-examples/xilinx/NandLUT.v
@@ -15,7 +15,7 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
 Import ListNotations.
 

--- a/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/monad-examples/xilinx/XilinxAdderExamples.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.
-From Coq Require Import Ascii String.
+From Coq Require Import NArith.NArith.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/xilinx/XilinxAdderTree.v
+++ b/monad-examples/xilinx/XilinxAdderTree.v
@@ -14,15 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
-From Coq Require Import NArith.
-Require Import Omega.
+From Coq Require Import Bool.Bool Init.Nat.
+From Coq Require Import Strings.Ascii Strings.String.
+From Coq Require Import NArith.NArith.
 
 From Coq Require Import Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 From Coq Require Import Bool.Bvector.
 Import VectorNotations.
 

--- a/monad-examples/xilinx/XilinxExtraction.v
+++ b/monad-examples/xilinx/XilinxExtraction.v
@@ -14,17 +14,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import NandLUT.
-Require Import XilinxAdderExamples.
-Require Import XilinxAdderTree.
+Require Import XilinxExamples.NandLUT.
+Require Import XilinxExamples.XilinxAdderExamples.
+Require Import XilinxExamples.XilinxAdderTree.
 Extraction Library NandLUT.
 Extraction Library XilinxAdderExamples.
 Extraction Library XilinxAdderTree.

--- a/monad-examples/xilinx/_CoqProject
+++ b/monad-examples/xilinx/_CoqProject
@@ -1,7 +1,8 @@
+INSTALLDEFAULTROOT = XilinxExamples
+-R . XilinxExamples
 -R ../../cava/Cava Cava
 -R ../../third_party/coq-ext-lib/theories ExtLib
 -R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
--R . XilinxExamples
 NandLUT.v
 XilinxAdderExamples.v
 XilinxAdderTree.v

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -17,7 +17,7 @@
 Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/silveroak-opentitan/aes/Acorn/Makefile.coq.local
+++ b/silveroak-opentitan/aes/Acorn/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/silveroak-opentitan/aes/Acorn/_CoqProject
+++ b/silveroak-opentitan/aes/Acorn/_CoqProject
@@ -1,3 +1,4 @@
+INSTALLDEFAULTROOT = AcornAes
 -R . AcornAes
 -R ../Spec AesSpec
 -R ../../../cava/Cava Cava

--- a/silveroak-opentitan/aes/Arrow/CipherRoundProperties.v
+++ b/silveroak-opentitan/aes/Arrow/CipherRoundProperties.v
@@ -14,10 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Derive.
+From Coq Require Import derive.Derive.
 From coqutil Require Import Tactics.Tactics.
 From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic Tactics VectorUtils.
+     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Cava.Tactics.
 
 From Aes Require Import PkgProperties cipher_round
      mix_columns sbox sub_bytes shift_rows.

--- a/silveroak-opentitan/aes/Arrow/Extraction.v
+++ b/silveroak-opentitan/aes/Arrow/Extraction.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Require Import coqutil.Z.HexNotation.

--- a/silveroak-opentitan/aes/Arrow/Makefile.coq.local
+++ b/silveroak-opentitan/aes/Arrow/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/silveroak-opentitan/aes/Arrow/NaiveCipherProperties.v
+++ b/silveroak-opentitan/aes/Arrow/NaiveCipherProperties.v
@@ -14,9 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Derive.
+From Coq Require Import derive.Derive.
 From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic Tactics VectorUtils.
+     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Cava.Tactics.
 
 From Aes Require Import PkgProperties CipherRoundProperties
      cipher_round unrolled_naive_cipher.

--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherProperties.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherProperties.v
@@ -14,10 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Derive.
+From Coq Require Import derive.Derive.
 From coqutil Require Import Tactics.Tactics.
 From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic Tactics VectorUtils.
+     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Cava.Tactics.
 
 From Aes Require Import PkgProperties CipherRoundProperties
      cipher_round unrolled_opentitan_cipher.

--- a/silveroak-opentitan/aes/Arrow/PkgProperties.v
+++ b/silveroak-opentitan/aes/Arrow/PkgProperties.v
@@ -15,9 +15,10 @@
 (****************************************************************************)
 
 Require Import Coq.Strings.String.
-From Coq Require Import Derive.
+From Coq Require Import derive.Derive.
 From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic Tactics VectorUtils.
+     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Cava.Tactics.
 
 From Aes Require Import pkg.
 

--- a/silveroak-opentitan/aes/Arrow/_CoqProject
+++ b/silveroak-opentitan/aes/Arrow/_CoqProject
@@ -1,3 +1,4 @@
+INSTALLDEFAULTROOT = Aes
 -R . Aes
 -R ./../Spec AesSpec
 -R ../../../cava/Cava Cava

--- a/silveroak-opentitan/aes/Arrow/aes_test.v
+++ b/silveroak-opentitan/aes/Arrow/aes_test.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith ZArith.ZArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic VectorUtils.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.

--- a/silveroak-opentitan/aes/Arrow/cipher_control.v
+++ b/silveroak-opentitan/aes/Arrow/cipher_control.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.

--- a/silveroak-opentitan/aes/Arrow/cipher_round.v
+++ b/silveroak-opentitan/aes/Arrow/cipher_round.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows.

--- a/silveroak-opentitan/aes/Arrow/key_expand.v
+++ b/silveroak-opentitan/aes/Arrow/key_expand.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox.

--- a/silveroak-opentitan/aes/Arrow/mix_columns.v
+++ b/silveroak-opentitan/aes/Arrow/mix_columns.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox mix_single_column.

--- a/silveroak-opentitan/aes/Arrow/mix_single_column.v
+++ b/silveroak-opentitan/aes/Arrow/mix_single_column.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox.

--- a/silveroak-opentitan/aes/Arrow/netlists.v
+++ b/silveroak-opentitan/aes/Arrow/netlists.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox unrolled_opentitan_cipher.

--- a/silveroak-opentitan/aes/Arrow/pkg.v
+++ b/silveroak-opentitan/aes/Arrow/pkg.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 Import VectorNotations.

--- a/silveroak-opentitan/aes/Arrow/sbox.v
+++ b/silveroak-opentitan/aes/Arrow/sbox.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox_canright_pkg sbox_canright sbox_canright_masked_noreuse sbox_lut.

--- a/silveroak-opentitan/aes/Arrow/sbox_canright.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright.v
@@ -14,9 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport Arrow.CircuitFunctionalEquivalence
-     BitArithmetic Tactics VectorUtils.
+     BitArithmetic VectorUtils.
+Require Import Cava.Tactics.
 
 From Aes Require Import pkg sbox_canright_pkg.
 

--- a/silveroak-opentitan/aes/Arrow/sbox_canright.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright.v
@@ -127,24 +127,24 @@ Proof.
 Qed.
 
 (* TODO: fill in these axioms *)
-Axiom aes_sbox_canright_spec :
-  denote_kind (<<Bit, Vector Bit 8, Unit >>) -> denote_kind (Vector Bit 8).
-Axiom aes_sbox_canright_correct :
-  obeys_spec aes_sbox_canright aes_sbox_canright_spec.
-Axiom CircuitLaws : CategoryLaws CircuitCat.
-Existing Instance CircuitLaws.
+Section WithSboxSpec.
+  Context (aes_sbox_canright_spec :
+             denote_kind (<<Bit, Vector Bit 8, Unit >>) -> denote_kind (Vector Bit 8))
+          (aes_sbox_canright_correct :
+             obeys_spec aes_sbox_canright aes_sbox_canright_spec).
 
-Hint Resolve aes_sbox_canright_correct CIPH_FWD_correct CIPH_INV_correct
-  : circuit_spec_correctness.
+  Local Hint Resolve aes_sbox_canright_correct CIPH_FWD_correct CIPH_INV_correct
+    : circuit_spec_correctness.
 
-Derive canright_composed_spec
-       SuchThat (obeys_spec canright_composed canright_composed_spec)
-       As canright_composed_correct.
-Proof.
-  cbv [canright_composed]. circuit_spec.
-  subst canright_composed_spec.
-  instantiate_app_by_reflexivity.
-Qed.
+  Derive canright_composed_spec
+         SuchThat (obeys_spec canright_composed canright_composed_spec)
+         As canright_composed_correct.
+  Proof.
+    cbv [canright_composed]. circuit_spec.
+    subst canright_composed_spec.
+    instantiate_app_by_reflexivity.
+  Qed.
+End WithSboxSpec.
 (* Uncomment below to see derived spec for canright_composed *)
 (* Print canright_composed_spec. *)
 

--- a/silveroak-opentitan/aes/Arrow/sbox_canright_masked_noreuse.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright_masked_noreuse.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox_canright_pkg.

--- a/silveroak-opentitan/aes/Arrow/sbox_canright_pkg.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright_pkg.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg.

--- a/silveroak-opentitan/aes/Arrow/sbox_lut.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_lut.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg.

--- a/silveroak-opentitan/aes/Arrow/shift_rows.v
+++ b/silveroak-opentitan/aes/Arrow/shift_rows.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox.

--- a/silveroak-opentitan/aes/Arrow/sub_bytes.v
+++ b/silveroak-opentitan/aes/Arrow/sub_bytes.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg sbox.

--- a/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
@@ -19,6 +19,7 @@ From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
 From Cava Require Import BitArithmetic VectorUtils Arrow.ArrowExport.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.
+From Aes Require Import aes_test.
 
 Require Import coqutil.Z.HexNotation.
 
@@ -162,7 +163,6 @@ Definition unrolled_cipher_naive
     ]>.
 
 Section tests.
-  From Aes Require Import aes_test.
 
   Definition unrolled_cipher_naive_ mode key data :=
     interp_combinational (unrolled_cipher_naive SboxCanright _) (mode,(data,key)).

--- a/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import BitArithmetic VectorUtils Arrow.ArrowExport.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.

--- a/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
@@ -19,6 +19,7 @@ From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.
+From Aes Require Import aes_test.
 
 Import VectorNotations.
 Import KappaNotation.
@@ -247,7 +248,6 @@ Definition unrolled_cipher_flat
     ]>.
 
 Section tests.
-  From Aes Require Import aes_test.
 
   Definition unrolled_cipher' mode key data :=
     interp_combinational (unrolled_cipher_flat SboxCanright _) (mode,(data,key)).

--- a/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
@@ -14,7 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith Eqdep_dec Vector Lia NArith Omega String Ndigits.
+From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
+     NArith.NArith Strings.String NArith.Ndigits.
 From Cava Require Import Arrow.ArrowExport BitArithmetic.
 
 From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.

--- a/silveroak-opentitan/aes/Spec/Makefile.coq.local
+++ b/silveroak-opentitan/aes/Spec/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/silveroak-opentitan/aes/Spec/_CoqProject
+++ b/silveroak-opentitan/aes/Spec/_CoqProject
@@ -1,3 +1,4 @@
+INSTALLDEFAULTROOT = AesSpec
 -R . AesSpec
 -R ../../../cava/Cava Cava
 -R ../../../third_party/coq-ext-lib/theories ExtLib

--- a/silveroak-opentitan/pinmux/Makefile.coq.local
+++ b/silveroak-opentitan/pinmux/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 
 From Coq Require Lists.List.
 Import List.ListNotations.
@@ -22,7 +22,7 @@ Import List.ListNotations.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Import Vector.
+From Coq Require Import Vectors.Vector.
 Import VectorNotations.
 
 Open Scope monad_scope.

--- a/silveroak-opentitan/pinmux/PinmuxExtraction.v
+++ b/silveroak-opentitan/pinmux/PinmuxExtraction.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Pinmux.
+Require Import Pinmux.Pinmux.
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.

--- a/silveroak-opentitan/pinmux/_CoqProject
+++ b/silveroak-opentitan/pinmux/_CoqProject
@@ -1,3 +1,4 @@
+INSTALLDEFAULTROOT = Pinmux
 -R . Pinmux
 -R ../../cava/Cava Cava
 -R ../../third_party/coq-ext-lib/theories ExtLib

--- a/silveroak-opentitan/pinmux/_CoqProject
+++ b/silveroak-opentitan/pinmux/_CoqProject
@@ -1,3 +1,4 @@
+-R . Pinmux
 -R ../../cava/Cava Cava
 -R ../../third_party/coq-ext-lib/theories ExtLib
 -R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Import Program.Basics.
+Require Import Coq.Program.Basics.
 From Coq Require Import Bool.Bool.
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
-From Coq Require Import ZArith.
+From Coq Require Import ZArith.ZArith.
 Import ListNotations.
 
 Require Import Cava.Cava.

--- a/tests/Makefile.coq.local
+++ b/tests/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/tests/TestsExtraction.v
+++ b/tests/TestsExtraction.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
 From Coq Require Import ExtrHaskellBasic.

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -1,3 +1,5 @@
+INSTALLDEFAULTROOT = Tests
+-R . Tests
 -R ../cava/Cava Cava
 -R ../third_party/coq-ext-lib/theories ExtLib
 -R ../third_party/bedrock2/deps/coqutil/src/coqutil coqutil

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
+From Coq Require Import Strings.Ascii Strings.String.
 From Coq Require Import Lists.List.
 Import ListNotations.
 

--- a/tests/xilinx/Makefile.coq.local
+++ b/tests/xilinx/Makefile.coq.local
@@ -1,0 +1,4 @@
+# This file contains custom settings and is included by Makefile.coq
+
+# Pass a -w flag to coqc which disables extraction-opaque-accessed warnings
+COQEXTRAFLAGS=-w -extraction-opaque-accessed

--- a/tests/xilinx/VivadoExtraction.v
+++ b/tests/xilinx/VivadoExtraction.v
@@ -14,13 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
+From Coq Require Import extraction.Extraction.
 From Coq Require Import extraction.ExtrHaskellZInteger.
 From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
+From Coq Require Import extraction.ExtrHaskellBasic.
 From Coq Require Import extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import LUTTests.
+Require Import VivadoTests.LUTTests.
 Extraction Library LUTTests.

--- a/tests/xilinx/_CoqProject
+++ b/tests/xilinx/_CoqProject
@@ -1,5 +1,6 @@
--R ../../cava/Cava Cava
+INSTALLDEFAULTROOT = VivadoTests
 -R . VivadoTests
+-R ../../cava/Cava Cava
 -R ../../third_party/coq-ext-lib/theories ExtLib
 -R ../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 LUTTests.v


### PR DESCRIPTION
Resolves #305 

- Suppresses `extraction-opaque-accessed` warnings using `Makefile.coq.local` files
- Removes/comments out some unused admitted lemmas and axioms so they don't cause extraction warnings
- Fully qualifies *all* imports to avoid warnings and ambiguities (most of the LOC changes are this)
- Inserts `INSTALLDEFAULTROOT` to every `_CoqProject` so that `coq_makefile` doesn't complain
- Reorders the `-R` arguments in `_CoqProject`s with the current directory first to avoid `not a subdirectory of the current directory` warnings
- Changes some non-recursive `Fixpoint`s to `Definition`s

Much quieter `make` now!