### PR TITLE
Clean up key-expansion-interleaving proofs

### DIFF
--- a/silveroak-opentitan/aes/Spec/CipherRepresentationChange.v
+++ b/silveroak-opentitan/aes/Spec/CipherRepresentationChange.v
@@ -1,0 +1,44 @@
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Lists.List.
+Require Import Cava.ListUtils.
+Require Import AesSpec.Cipher.
+
+Section ChangeKeyRepresentation.
+  Context (state key key_alt : Type)
+          (projkey : key_alt -> key)
+          (add_round_key : state -> key -> state)
+          (sub_bytes shift_rows mix_columns : state -> state)
+          (inv_sub_bytes inv_shift_rows inv_mix_columns : state -> state)
+          (inv_mix_columns_key : key -> key).
+
+  Lemma cipher_change_key_rep first_key last_key middle_keys
+        first_key_alt last_key_alt middle_keys_alt input :
+    projkey first_key_alt = first_key ->
+    projkey last_key_alt = last_key ->
+    map projkey middle_keys_alt = middle_keys ->
+    cipher state key add_round_key sub_bytes shift_rows mix_columns
+           first_key last_key middle_keys input
+    = cipher state key_alt (fun st k => add_round_key st (projkey k))
+             sub_bytes shift_rows mix_columns first_key_alt last_key_alt
+             middle_keys_alt input.
+  Proof.
+    intros; subst; cbv [cipher].
+    repeat (f_equal; [ ]).
+    rewrite fold_left_map.
+    reflexivity.
+  Qed.
+End ChangeKeyRepresentation.

--- a/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
+++ b/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
@@ -35,6 +35,18 @@ Section Spec.
     List.map snd (all_rcons_and_keys Nr initial_key initial_rcon).
 
   Section Properties.
+    Lemma length_all_rcons_and_keys n r k rk rem :
+      all_rcons_and_keys n k r = (rk :: rem)%list ->
+      length rem = n.
+    Proof.
+      cbv [all_rcons_and_keys]. intros.
+      lazymatch goal with
+      | H : @eq (list _) ?x ?y |- _ =>
+        assert (length x = length y) by (rewrite H; reflexivity)
+      end.
+      autorewrite with push_length in *. lia.
+    Qed.
+
     Lemma length_all_keys n k1 k2 r rem_keys :
       all_keys n k1 r = (k2 :: rem_keys)%list ->
       length rem_keys = n.
@@ -48,16 +60,28 @@ Section Spec.
       autorewrite with push_length in *. lia.
     Qed.
 
-    Lemma hd_all_keys n k1 k2 r rem_keys :
-      all_keys n k1 r = (k2 :: rem_keys)%list -> n <> 0 -> k1 = k2.
+    Lemma hd_all_rcons_and_keys n k r rk rem :
+      all_rcons_and_keys n k r = (rk :: rem)%list -> n <> 0 ->
+      rk = (r, k).
     Proof.
-      cbv [all_keys all_rcons_and_keys]; intros.
+      cbv [all_rcons_and_keys]; intros.
       destruct n; [ congruence | ]. cbn [List.seq] in *.
-      autorewrite with push_fold_acc in *. cbn [List.map] in *.
+      autorewrite with push_fold_acc in *.
       match goal with
       | H : (?x :: _ = ?y :: _)%list |- _ => inversion H
       end.
       congruence.
+    Qed.
+
+    Lemma hd_all_keys n k1 k2 r rem_keys :
+      all_keys n k1 r = (k2 :: rem_keys)%list -> n <> 0 -> k1 = k2.
+    Proof.
+      cbv [all_keys]. intro Hall; intros.
+      map_inversion Hall.
+      match goal with H : all_rcons_and_keys _ _ _ = _ |- _ =>
+                      apply hd_all_rcons_and_keys in H;
+                        [ | assumption ] end.
+      subst. reflexivity.
     Qed.
 
     Lemma nth_all_rcons_and_keys' n k r i :

--- a/silveroak-opentitan/aes/Spec/InterleavedCipher.v
+++ b/silveroak-opentitan/aes/Spec/InterleavedCipher.v
@@ -28,8 +28,6 @@ Section Spec.
   Context {state key rconst : Type}
           (add_round_key : state -> key -> state)
           (sub_bytes shift_rows mix_columns : state -> state)
-          (inv_sub_bytes inv_shift_rows inv_mix_columns : state -> state)
-          (inv_mix_columns_key : key -> key)
           (key_expand : nat -> rconst -> key -> rconst * key).
 
   Definition cipher_round_interleaved
@@ -46,7 +44,7 @@ Section Spec.
     let rcon_key := key_expand i rcon round_key in
     (rcon_key, st).
 
-  (* AES cipher with interleaved key expansion and conditional split on first round *)
+  (* AES cipher with interleaved key expansion and conditional for first round *)
   Definition cipher_interleaved
              (Nr : nat) (* number of rounds *)
              (initial_key : key)
@@ -67,19 +65,13 @@ Section Spec.
     st.
 
   Section Equivalence.
-    Context (key_alt : Type) (* allow cipher to have a different type for keys *)
-            (projkey : key -> key_alt) (* convert to alternative key rep *)
-            (Nr : nat) (initial_rcon : rconst) (initial_key : key)
-            (first_key : key_alt) (middle_keys : list key_alt) (last_key : key_alt)
-            (add_round_key_alt : state -> key_alt -> state)
-            (add_round_key_alt_equiv :
-               forall st k, add_round_key_alt st (projkey k) = add_round_key st k)
-            (all_keys_eq :
-               List.map projkey
-                        (all_keys key_expand Nr initial_key initial_rcon)
+    Context (Nr : nat) (initial_rcon : rconst) (initial_key : key)
+            (first_key : key) (middle_keys : list key) (last_key : key).
+    Context (all_keys_eq :
+               all_keys key_expand Nr initial_key initial_rcon
                = first_key :: middle_keys ++ [last_key]).
 
-    Let cipher := cipher state key_alt add_round_key_alt sub_bytes shift_rows mix_columns.
+    Let cipher := cipher state key add_round_key sub_bytes shift_rows mix_columns.
 
     (* Interleaved cipher is equivalent to original cipher *)
     Lemma cipher_interleaved_equiv input :
@@ -97,7 +89,7 @@ Section Spec.
       cbv [cipher_interleaved cipher_round_interleaved Cipher.cipher].
       (* pick the initial key as the default for nth_default *)
       let x := lazymatch type of Hall_keys with all_keys _ _ ?k _ = _ => k end in
-      rewrite fold_left_to_seq with (default:=projkey x).
+      rewrite fold_left_to_seq with (default:=x).
       pose proof (length_all_keys _ _ _ _ _ _ Hall_keys).
       autorewrite with push_length in *.
 
@@ -140,7 +132,6 @@ Section Spec.
         (* prove that if the invariant is satisfied at the end of the loop, the
            postcondition is true *)
         repeat destruct_pair_let.
-        rewrite <-add_round_key_alt_equiv.
         f_equal; [ ].
         rewrite nth_all_rcons_and_keys_all_keys.
         rewrite Hall_keys, app_comm_cons.
@@ -153,14 +144,12 @@ Section Spec.
       apply fold_left_preserves_relation_seq with (R0:=R); subst R.
       { (* invariant holds at loop start *)
         cbv beta. rewrite nth_all_rcons_and_keys by lia.
-        rewrite add_round_key_alt_equiv.
         reflexivity. }
       { (* invariant holds through loop step *)
         cbv beta; intros; subst. repeat destruct_pair_let.
         rewrite Nat.eqb_compare; cbn [Nat.compare].
         rewrite !nth_all_rcons_and_keys_succ by lia.
-        rewrite <-add_round_key_alt_equiv.
-        f_equal; [ ]. rewrite map_nth.
+        f_equal; [ ].
         lazymatch goal with
         | H : @eq (list key) ?ls (_ :: (?m ++ [_]))%list
           |- context [@nth key ?i ?mk ?d] =>

--- a/silveroak-opentitan/aes/Spec/InterleavedCipher.v
+++ b/silveroak-opentitan/aes/Spec/InterleavedCipher.v
@@ -31,8 +31,9 @@ Section Spec.
           (key_expand : nat -> rconst -> key -> rconst * key).
 
   Definition cipher_round_interleaved
-             (rcon : rconst) (round_key : key) (st : state) (i : nat)
+             (loop_state : rconst* key * state) (i : nat)
     : rconst * key * state :=
+    let '(rcon, round_key, st) := loop_state in
     let st := if i =? 0
               then add_round_key st round_key
               else
@@ -52,12 +53,8 @@ Section Spec.
              (input : state) : state :=
     let st := input in
     let loop_end_state :=
-        fold_left
-          (fun (loop_state : rconst * key * state) =>
-             let '(rcon, round_key, st) := loop_state in
-             cipher_round_interleaved rcon round_key st)
-          (List.seq 0 Nr)
-          (initial_rcon, initial_key, st) in
+        fold_left cipher_round_interleaved
+          (List.seq 0 Nr) (initial_rcon, initial_key, st) in
     let '(_, last_key, st) := loop_end_state in
     let st := sub_bytes st in
     let st := shift_rows st in

--- a/silveroak-opentitan/aes/Spec/_CoqProject
+++ b/silveroak-opentitan/aes/Spec/_CoqProject
@@ -4,5 +4,6 @@ INSTALLDEFAULTROOT = AesSpec
 -R ../../../third_party/coq-ext-lib/theories ExtLib
 -R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 Cipher.v
+CipherRepresentationChange.v
 ExpandAllKeys.v
 InterleavedCipher.v


### PR DESCRIPTION
Reduces the complexity of the definitions and proofs in `silveroak-opentitan/aes/Spec/InterleavedCipher.v`, which defines a version of the top-level AES cipher that interleaves key expansion with cipher rounds and proves that it's equivalent to the version with keys precomputed (`Cipher.v`). The key trick here is a generic proof about changing the representation of keys in the top-level spec.

Previously, we proved that the interleaved version was equivalent to the precomputed-keys version _defined over a different key type_, which was necessary because the existing AES implementation operates on pairs of keys instead of single keys. That introduced a lot of extra boilerplate like a different definition of `add_round_key` for each key type. With a generic key-representation change lemma, we can instead write the interleaved key expansion <-> precomputed keys proof assuming the two have the same key type, and change the representation before using the lemma.

This change also let me simplify the definitions and proofs in `ExpandAllKeys.v`, which previously had to pass around a round constant. With less painful key representation changes, we can effectively treat the AES implementation's key type as `rconst * keypair`, so tracking it when precomputing the keys is not necessary.