### PR TITLE
Major overhaul of Acorn/Monad kernel

### DIFF
--- a/arrow-examples/ArrowAdderTutorial.v
+++ b/arrow-examples/ArrowAdderTutorial.v
@@ -153,8 +153,8 @@ Require Import Cava.Netlist.
 
 Definition fullAdderInterface
   := combinationalInterface "fullAdder"
-     (mkPort "cin" Kind.Bit, (mkPort "a" Kind.Bit, mkPort "b" Kind.Bit))
-     (mkPort "sum" Kind.Bit, mkPort "cout" Kind.Bit)
+     [mkPort "cin" Signal.Bit; mkPort "a" Signal.Bit; mkPort "b" Signal.Bit]
+     [mkPort "sum" Signal.Bit; mkPort "cout" Signal.Bit]
      [].
 
 Definition fullAdder_tb_inputs :=
@@ -169,11 +169,11 @@ Definition fullAdder_tb_inputs :=
 ].
 
 Definition fullAdder_netlist :=
-  makeNetlist fullAdderInterface (build_netlist (closure_conversion fullAdder)).
+  build_netlist (closure_conversion fullAdder) "fullAdder" ("cin", ("a", "b")) ("sum", "cout").
 
 Definition fullAdder_tb_expected_outputs  : list (bool * bool)
   := (List.map (fun i => combinational_evaluation (closure_conversion fullAdder) i) fullAdder_tb_inputs) .
 
 Definition fullAdder_tb :=
   testBench "fullAdder_tb" fullAdderInterface
-            fullAdder_tb_inputs fullAdder_tb_expected_outputs.
+            (map (fun '(a,(b,c)) => (a,b,c)) fullAdder_tb_inputs) fullAdder_tb_expected_outputs.

--- a/arrow-examples/Counter.v
+++ b/arrow-examples/Counter.v
@@ -39,13 +39,12 @@ Open Scope kind_scope.
 Require Import Cava.Types.
 Require Import Cava.Netlist.
 
-(* this circuit has no inputs, hence tt. *)
 Definition counter_3_Interface :=
    sequentialInterface "counter_3" "clk" PositiveEdge "rst" PositiveEdge
-     tt (mkPort "count" (Kind.Vec Kind.Bit 3)) [].
+     [] [mkPort "count" (Signal.Vec Signal.Bit 3)] [].
 
 Definition counter_3_netlist :=
-  makeNetlist counter_3_Interface (build_netlist' (closure_conversion (counter 3))).
+  build_netlist (closure_conversion (counter 3)) "counter_3_netlist" tt "count".
 
 Definition counter_3_tb_inputs : list unit :=
  repeat tt 8.

--- a/arrow-examples/Counter.v
+++ b/arrow-examples/Counter.v
@@ -44,7 +44,7 @@ Definition counter_3_Interface :=
      [] [mkPort "count" (Signal.Vec Signal.Bit 3)] [].
 
 Definition counter_3_netlist :=
-  build_netlist (closure_conversion (counter 3)) "counter_3_netlist" tt "count".
+  build_netlist (closure_conversion (counter 3)) "counter_3" tt "count".
 
 Definition counter_3_tb_inputs : list unit :=
  repeat tt 8.

--- a/arrow-examples/Fir.v
+++ b/arrow-examples/Fir.v
@@ -56,13 +56,13 @@ Open Scope kind_scope.
 Require Import Cava.Types.
 Require Import Cava.Netlist.
 
-Local Notation Byte := (Kind.Vec Kind.Bit 8).
+Local Notation Byte := (Signal.Vec Signal.Bit 8).
 Definition fir_Interface :=
    sequentialInterface "fir" "clk" PositiveEdge "rst" PositiveEdge
-     (mkPort "in_stream" Byte) (mkPort "out_stream" Byte) [].
+     [mkPort "in_stream" Byte] [mkPort "out_stream" Byte] [].
 
 Definition fir_netlist :=
-  makeNetlist fir_Interface (build_netlist (closure_conversion fir)).
+  build_netlist (closure_conversion fir) "fir" "in_stream" "out_stream".
 
 Definition fir_tb_inputs : list (Bvector 8) :=
  map (N2Bv_sized 8) [1; 2; 3; 4; 5; 6; 7; 8; 9]%N.

--- a/arrow-examples/Mux2_1.v
+++ b/arrow-examples/Mux2_1.v
@@ -28,8 +28,9 @@ Section notation.
   Local Open Scope kind_scope.
 
   Definition mux2_1
-    : << ArrowKind.Bit, ArrowKind.Bit, ArrowKind.Bit, Unit >> ~> ArrowKind.Bit :=
-    <[ \ sel a b =>
+    : << Bit, << Bit, Bit >>, Unit >> ~> Bit :=
+    <[ \ sel ab =>
+      let '(a,b) = ab in
       let sel_a = and sel a in
       let inv_sel = not sel in
       let sel_b = and inv_sel b in
@@ -45,15 +46,10 @@ Proof. simply_combinational. Qed.
 
 Require Import Cava.Types.
 Require Import Cava.Netlist.
-
-Definition mux2_1_Interface :=
-   combinationalInterface "mux2_1"
-     [mkPort "s" Signal.Bit; mkPort "a" Signal.Bit; mkPort "b" Signal.Bit]
-     [mkPort "o" Signal.Bit]
-     [].
+Require Import Cava.Signal.
 
 Definition mux2_1_netlist :=
-  makeNetlist mux2_1_Interface (build_netlist (closure_conversion mux2_1)).
+  build_netlist (closure_conversion mux2_1) "mux2_1" ("s", ("a", "b")) "o".
 
 Definition mux2_1_tb_inputs : list (bool * (bool * bool)) :=
  [(false, (false, true));
@@ -69,5 +65,8 @@ Definition mux2_1_tb_expected_outputs : list bool :=
 Goal is_combinational (closure_conversion mux2_1). Proof. simply_combinational. Qed.
 
 Definition mux2_1_tb :=
-  testBench "mux2_1_tb" mux2_1_Interface
-            mux2_1_tb_inputs mux2_1_tb_expected_outputs.
+  testBench "mux2_1_tb"
+   (combinationalInterface "mux2_1"
+     [mkPort "s" Bit; mkPort "a" Bit; mkPort "b" Bit]
+     [mkPort "o" Bit] [])
+  (map (fun '(a,(b,c)) => (a,b,c)) mux2_1_tb_inputs) mux2_1_tb_expected_outputs.

--- a/arrow-examples/Mux2_1.v
+++ b/arrow-examples/Mux2_1.v
@@ -28,9 +28,8 @@ Section notation.
   Local Open Scope kind_scope.
 
   Definition mux2_1
-    : << Bit, << Bit, Bit >>, Unit >> ~> Bit :=
-    <[ \ sel ab =>
-      let '(a,b) = ab in
+    : << ArrowKind.Bit, ArrowKind.Bit, ArrowKind.Bit, Unit >> ~> ArrowKind.Bit :=
+    <[ \ sel a b =>
       let sel_a = and sel a in
       let inv_sel = not sel in
       let sel_b = and inv_sel b in
@@ -49,8 +48,8 @@ Require Import Cava.Netlist.
 
 Definition mux2_1_Interface :=
    combinationalInterface "mux2_1"
-     (mkPort "s" Kind.Bit, (mkPort "a" Kind.Bit, mkPort "b" Kind.Bit))
-     (mkPort "o" Kind.Bit)
+     [mkPort "s" Signal.Bit; mkPort "a" Signal.Bit; mkPort "b" Signal.Bit]
+     [mkPort "o" Signal.Bit]
      [].
 
 Definition mux2_1_netlist :=

--- a/arrow-examples/UnsignedAdder.v
+++ b/arrow-examples/UnsignedAdder.v
@@ -81,37 +81,37 @@ Require Import Cava.Netlist.
 
 Definition adder445_interface
   := combinationalInterface "adder445"
-     (mkPort "a" (Kind.Vec Kind.Bit 4), mkPort "b" (Kind.Vec Kind.Bit 4))
-     (mkPort "sum" (Kind.Vec Kind.Bit 5))
+     [mkPort "a" (Signal.Vec Signal.Bit 4); mkPort "b" (Signal.Vec Signal.Bit 4)]
+     [mkPort "sum" (Signal.Vec Signal.Bit 5)]
      [].
 Definition adder88810_interface
   := combinationalInterface "adder88810"
-     (mkPort "a" (Kind.Vec Kind.Bit 8), (mkPort "b" (Kind.Vec Kind.Bit 8), mkPort "c" (Kind.Vec Kind.Bit 8)))
-     (mkPort "sum" (Kind.Vec Kind.Bit 10))
+     [mkPort "a" (Signal.Vec Signal.Bit 8); mkPort "b" (Signal.Vec Signal.Bit 8); mkPort "c" (Signal.Vec Signal.Bit 8)]
+     [mkPort "sum" (Signal.Vec Signal.Bit 10)]
      [].
 Definition adder444_tree_4_interface
   := combinationalInterface "adder444_tree_4"
-     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 4))
-     (mkPort "result" (Kind.Vec Kind.Bit 4))
+     [mkPort "vec" (Signal.Vec (Signal.Vec Signal.Bit 4) 4)]
+     [mkPort "result" (Signal.Vec Signal.Bit 4)]
      [].
 Definition adder444_tree_8_interface
   := combinationalInterface "adder444_tree_8"
-     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 8))
-     (mkPort "result" (Kind.Vec Kind.Bit 4))
+     [mkPort "vec" (Signal.Vec (Signal.Vec Signal.Bit 4) 8)]
+     [mkPort "result" (Signal.Vec Signal.Bit 4)]
      [].
 Definition adder444_tree_64_interface
   := combinationalInterface "adder444_tree_64"
-     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 64))
-     (mkPort "result" (Kind.Vec Kind.Bit 4))
+     [mkPort "vec" (Signal.Vec (Signal.Vec Signal.Bit 4) 64)]
+     [mkPort "result" (Signal.Vec Signal.Bit 4)]
      [].
 Definition growth_tree_8_interface
   := combinationalInterface "growth_tree_8"
-     (mkPort "vec" (Kind.Vec (Kind.Vec Kind.Bit 4) 8))
-     (mkPort "result" (Kind.Vec Kind.Bit 7))
+     [mkPort "vec" (Signal.Vec (Signal.Vec Signal.Bit 4) 8)]
+     [mkPort "result" (Signal.Vec Signal.Bit 7)]
      [].
 
 Definition adder445_netlist :=
-  makeNetlist adder445_interface (build_netlist (closure_conversion adder445)).
+  build_netlist (closure_conversion adder445) "adder445" ("a","b") "sum".
 
 Definition adder445_tb_inputs :=
   map (fun '(x, y) => (N2Bv_sized 4 x, N2Bv_sized 4 y))
@@ -125,7 +125,7 @@ Definition adder445_tb
      adder445_tb_inputs adder445_tb_expected_outputs.
 
 Definition adder88810_netlist :=
-  makeNetlist adder88810_interface (build_netlist (closure_conversion adder88810)).
+  build_netlist (closure_conversion adder88810) "adder88810" ("a",("b","c")) "sum".
 
 Definition adder88810_tb_inputs :=
   map (fun '(x, y, z) => (N2Bv_sized 8 x, (N2Bv_sized 8 y, N2Bv_sized 8 z)))
@@ -136,16 +136,16 @@ Definition adder88810_tb_expected_outputs
 
 Definition adder88810_tb
   := testBench "adder88810_tb" adder88810_interface
-     adder88810_tb_inputs adder88810_tb_expected_outputs.
+     (map (fun '(a,(b,c)) => (a,b,c)) adder88810_tb_inputs) adder88810_tb_expected_outputs.
 
 Definition adder444_tree_4_netlist :=
-  makeNetlist adder444_tree_4_interface (build_netlist (closure_conversion adder444_tree_4)).
+  build_netlist (closure_conversion adder444_tree_4) "adder444_tree_4" "vec" "result".
 
 Definition adder444_tree_8_netlist :=
-  makeNetlist adder444_tree_8_interface (build_netlist (closure_conversion adder444_tree_8)).
+  build_netlist (closure_conversion adder444_tree_8) "adder444_tree_8" "vec" "result".
 
 Definition adder444_tree_64_netlist :=
-  makeNetlist adder444_tree_64_interface (build_netlist (closure_conversion adder444_tree_64)).
+  build_netlist (closure_conversion adder444_tree_64) "adder444_tree_64" "vec" "result".
 
 Definition adder444_tree_4_inputs :=
   map (fun '(x, y, z, w) => [N2Bv_sized 4 x; N2Bv_sized 4 y; N2Bv_sized 4 z; N2Bv_sized 4 w]%vector)
@@ -162,7 +162,7 @@ Definition adder444_tree_4_tb
      adder444_tree_4_inputs adder444_tree_4_tb_expected_outputs.
 
 Definition growth_tree_8_netlist :=
-  makeNetlist growth_tree_8_interface (build_netlist (closure_conversion growth_tree_8)).
+  build_netlist (closure_conversion growth_tree_8) "growth_tree_8" "vec" "result".
 
 Definition growth_tree_8_inputs :=
   map (Vector.map (N2Bv_sized 4))

--- a/cava/Cava/Acorn/AcornNetlistGeneration.v
+++ b/cava/Cava/Acorn/AcornNetlistGeneration.v
@@ -39,7 +39,7 @@ Definition binaryGate (gate : Signal Bit -> Signal Bit -> Signal Bit -> AcornIns
   o <- newWire ;;
   addInstance (gate i0 i1 o) ;;
   ret o.
-                     
+
 Instance AcornNetlist : Cava denoteSignal :=
 { m := state AcornState;
   one := Const1;

--- a/cava/Cava/Acorn/AcornSignal.v
+++ b/cava/Cava/Acorn/AcornSignal.v
@@ -16,6 +16,8 @@
 
 From Coq Require Import ZArith.ZArith.
 From Coq Require Import Strings.String.
+From Coq Require Import Lists.List.
+Import ListNotations.
 From Coq Require Import Vectors.Vector.
 
 From Cava Require Import VectorUtils.
@@ -39,13 +41,14 @@ Inductive Signal : SignalType -> Type :=
   | Fst : forall {A B : SignalType}, Signal (Pair A B) -> Signal A
   | Snd : forall {A B : SignalType}, Signal (Pair A B) -> Signal B.
 
-Fixpoint denoteCombinational (t : SignalType) : Type :=
-  match t with
-  | Void => unit
-  | Bit => bool
-  | Vec vt s => Vector.t (denoteCombinational vt) s
-  | ExternalType _ => string
-  | Pair A B => denoteCombinational A * denoteCombinational B
-  end.
+Local Open Scope list_scope.
 
-Definition denoteSignal (t : SignalType) : Type := Signal t.
+Fixpoint denoteInterface (denotion : SignalType -> Type)
+                         (v : list (string * SignalType)) : Type :=
+  match v with
+  | [] => unit
+  | [(n, t)] => denotion t
+  | [(n1, t1); (n2, t2)] => denotion t1 * denotion t2
+  | (n1, t1)::(n2, t2)::pds => denotion t1 * denotion t2 *
+                               denoteInterface denotion pds
+  end.

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -15,13 +15,23 @@
 (****************************************************************************)
 
 From Coq Require Import Bool.Bool.
+From Coq Require Import String.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 
 From Cava Require Import Acorn.AcornSignal.
 From Cava Require Import Acorn.AcornCavaClass.
 
-Instance Combinational : Cava denoteCombinational :=
+Fixpoint denoteCombinaional (t : SignalType) : Type :=
+  match t with
+  | Void => unit
+  | Bit => bool
+  | Vec vt s => Vector.t (denoteCombinaional vt) s
+  | ExternalType _ => string
+  | Pair A B => denoteCombinaional A * denoteCombinaional B
+  end.
+
+Instance Combinational : Cava denoteCombinaional :=
 { m := ident;
   one := true;
   zero := false;

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -81,13 +81,10 @@ Class Cava (signal : SignalType -> Type) := {
   (* Synthesizable relational operators *)
   greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
                        cava (signal Bit);
-  (* Hierarchy
+  (* Hierarchy *)
   instantiate : forall (intf: CircuitInterface),
-                 (tupleInterface (circuitInputs intf) ->
-                  cava (tupleInterface (circuitOutputs intf))) ->
-                 tupleInterface (circuitInputs intf) ->
-                 cava (tupleInterface (circuitOutputs intf));
-  *)
+                 (tupleInterface signal (map port_type (circuitInputs intf)) ->
+                  cava (tupleInterface signal (map port_type (circuitOutputs intf)))) ->
+                 tupleInterface signal (map port_type (circuitInputs intf)) ->
+                 cava (tupleInterface signal ((map port_type (circuitOutputs intf))));
 }.               
-
-

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -81,12 +81,12 @@ Class Cava (signal : SignalType -> Type) := {
   (* Synthesizable relational operators *)
   greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
                        cava (signal Bit);
-  (* Hierarchy 
+  (* Hierarchy
   instantiate : forall (intf: CircuitInterface),
-                 (denote doSomethingToOne (mapShape port_shape (circuitInputs intf)) ->
-                 cava (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)))) ->
-                 denote doSomethingToOne (mapShape port_shape (circuitInputs intf)) ->
-                 cava (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)));
+                 (tupleInterface (circuitInputs intf) ->
+                  cava (tupleInterface (circuitOutputs intf))) ->
+                 tupleInterface (circuitInputs intf) ->
+                 cava (tupleInterface (circuitOutputs intf));
   *)
 }.               
 

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -20,26 +20,28 @@ Require Import ExtLib.Structures.Monads.
 From Cava Require Import Kind.
 From Cava Require Import Types.
 From Cava Require Import Netlist.
+From Cava Require Import SignalType.
 
 (* The Cava class represents circuit graphs with Coq-level inputs and
    outputs, but does not represent the IO ports of circuits. This allows
    us to define both circuit netlist interpretations for the Cava class
    as well as behavioural interpretations for attributing semantics. *)
-Class Cava m `{Monad m} bit := {
+Class Cava (signal : SignalType -> Type) := {
+  m : Type -> Type;     
   (* Constant values. *)
-  zero : m bit; (* This component always returns the value 0. *)
-  one : m bit; (* This component always returns the value 1. *)
-  delayBit : bit -> m bit; (* Cava bit-level unit delay. *)
-  loopBit : forall {A B : Type}, ((A * bit)%type -> m (B * bit)%type) -> A -> m B;
+  zero : m (signal bit); (* This component always returns the value 0. *)
+  one : m (signal bit); (* This component always returns the value 1. *)
+  delayBit : signal bit -> m signal bit; (* Cava bit-level unit delay. *)
+  loopBit : forall {A B : Type}, ((A * bit)%type -> m (B * singal bit)%type) -> A -> m B;
   (* Primitive gates *)
-  inv : bit -> m bit;
-  and2 : bit * bit -> m bit;
-  nand2 : bit * bit -> m bit;
-  or2 : bit * bit -> m bit;
-  nor2 : bit * bit -> m bit;
-  xor2 : bit * bit -> m bit;
-  xnor2 : bit * bit -> m bit;
-  buf_gate : bit -> m bit; (* Corresponds to the SystemVerilog primitive gate 'buf' *)
+  inv : singal bit -> m signal bit;
+  and2 : signal bit * signal bit -> m (signal bit);
+  nand2 : signal bit * signal bit -> m (signal bit);
+  or2 : signal bit * signal bit -> m (signal bit);
+  nor2 : signal bit * signal bit -> m (signal bit);
+  xor2 : signal bit * signal bit -> m (signal bit);
+  xnor2 : signal bit * signal bit -> m (signal bit);
+  buf_gate : signal bit -> m (signal bit); (* Corresponds to the SystemVerilog primitive gate 'buf' *)
   (* Xilinx UNISIM FPGA gates *)
   lut1 : (bool -> bool) -> bit -> m bit; (* 1-input LUT *)
   lut2 : (bool -> bool -> bool) -> (bit * bit) -> m bit; (* 2-input LUT *)

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -29,7 +29,7 @@ Local Open Scope type_scope.
    us to define both circuit netlist interpretations for the Cava class
    as well as behavioural interpretations for attributing semantics. *)
 Class Cava (signal : SignalType -> Type) := {
-  cava : Type -> Type;     
+  cava : Type -> Type;    
   (* Constant values. *)
   zero : cava (signal Bit); (* This component always returns the value 0. *)
   one : cava (signal Bit); (* This component always returns the value 1. *)

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -20,71 +20,74 @@ Require Import ExtLib.Structures.Monads.
 From Cava Require Import Kind.
 From Cava Require Import Types.
 From Cava Require Import Netlist.
-From Cava Require Import SignalType.
+From Cava Require Import Signal.
+
+Local Open Scope type_scope.
 
 (* The Cava class represents circuit graphs with Coq-level inputs and
    outputs, but does not represent the IO ports of circuits. This allows
    us to define both circuit netlist interpretations for the Cava class
    as well as behavioural interpretations for attributing semantics. *)
 Class Cava (signal : SignalType -> Type) := {
-  m : Type -> Type;     
+  cava : Type -> Type;     
   (* Constant values. *)
-  zero : m (signal bit); (* This component always returns the value 0. *)
-  one : m (signal bit); (* This component always returns the value 1. *)
-  delayBit : signal bit -> m signal bit; (* Cava bit-level unit delay. *)
-  loopBit : forall {A B : Type}, ((A * bit)%type -> m (B * singal bit)%type) -> A -> m B;
+  zero : cava (signal Bit); (* This component always returns the value 0. *)
+  one : cava (signal Bit); (* This component always returns the value 1. *)
+  delayBit : signal Bit -> cava (signal Bit); (* Cava bit-level unit delay. *)
+  loopBit : forall {A B : SignalType}, (signal A * signal Bit -> cava (signal B * signal Bit)) -> signal A -> cava (signal B);
   (* Primitive gates *)
-  inv : singal bit -> m signal bit;
-  and2 : signal bit * signal bit -> m (signal bit);
-  nand2 : signal bit * signal bit -> m (signal bit);
-  or2 : signal bit * signal bit -> m (signal bit);
-  nor2 : signal bit * signal bit -> m (signal bit);
-  xor2 : signal bit * signal bit -> m (signal bit);
-  xnor2 : signal bit * signal bit -> m (signal bit);
-  buf_gate : signal bit -> m (signal bit); (* Corresponds to the SystemVerilog primitive gate 'buf' *)
+  inv : signal Bit -> cava (signal Bit);
+  and2 : signal Bit * signal Bit -> cava (signal Bit);
+  nand2 : signal Bit * signal Bit -> cava (signal Bit);
+  or2 : signal Bit * signal Bit -> cava (signal Bit);
+  nor2 : signal Bit * signal Bit -> cava (signal Bit);
+  xor2 : signal Bit * signal Bit -> cava (signal Bit);
+  xnor2 : signal Bit * signal Bit -> cava (signal Bit);
+  buf_gate : signal Bit -> cava (signal Bit); (* Corresponds to the SystemVerilog primitive gate 'buf' *)
   (* Xilinx UNISIM FPGA gates *)
-  lut1 : (bool -> bool) -> bit -> m bit; (* 1-input LUT *)
-  lut2 : (bool -> bool -> bool) -> (bit * bit) -> m bit; (* 2-input LUT *)
-  lut3 : (bool -> bool -> bool -> bool) -> (bit * bit * bit) -> m bit; (* 3-input LUT *)
-  lut4 : (bool -> bool -> bool -> bool -> bool) -> (bit * bit * bit * bit) ->
-         m bit; (* 4-input LUT *)
+  lut1 : (bool -> bool) -> signal Bit -> cava (signal Bit); (* 1-input LUT *)
+  lut2 : (bool -> bool -> bool) -> (signal Bit * signal Bit) -> cava (signal Bit); (* 2-input LUT *)
+  lut3 : (bool -> bool -> bool -> bool) -> signal Bit * signal Bit * signal Bit -> cava (signal Bit); (* 3-input LUT *)
+  lut4 : (bool -> bool -> bool -> bool -> bool) -> (signal Bit * signal Bit * signal Bit * signal Bit) ->
+         cava (signal Bit); (* 4-input LUT *)
   lut5 : (bool -> bool -> bool -> bool -> bool -> bool) ->
-         (bit * bit * bit * bit * bit) -> m bit; (* 5-input LUT *)
+         (signal Bit * signal Bit * signal Bit * signal Bit * signal Bit) -> cava (signal Bit); (* 5-input LUT *)
   lut6 : (bool -> bool -> bool -> bool -> bool -> bool -> bool) ->
-         (bit * bit * bit * bit * bit * bit) -> m bit; (* 6-input LUT *)
-  xorcy : bit * bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
-  muxcy : bit -> bit -> bit -> m bit; (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
-  (* Indexing is currently represented as a "circuit" but we may add features
-     to the SystemVerilog netlist generation back-end to allow these to me
-     functions rather than values in the monad type `m`.
-  *)
+         signal Bit * signal Bit * signal Bit * signal Bit * signal Bit * signal Bit -> cava (signal Bit); (* 6-input LUT *)
+  xorcy : signal Bit * signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, LI *)
+  muxcy : signal Bit -> signal  Bit -> signal Bit -> cava (signal Bit); (* Xilinx fast-carry UNISIM with arguments O, CI, DI, S *)
+  (* Converting to/from Vector.t *)
+  peel : forall {t : SignalType} {s : nat}, signal (Vec t s) -> Vector.t (signal t) s;
+  unpeel : forall {t : SignalType} {s : nat} , Vector.t (signal t) s -> signal (Vec t s);
   (* Dynamic indexing *)
-  indexAt : forall {k: Kind} {sz isz: nat},
-            Vector.t (smashTy bit k) sz -> Vector.t bit isz -> smashTy bit k;
-  indexBitAt : forall {sz isz: nat}, Vector.t bit sz ->
-                                     Vector.t bit isz -> bit;
+  indexAt : forall {t : SignalType} {sz isz: nat},
+            signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
+            signal (Vec Bit isz) ->  (* A bit-vector index of size isz bits *)
+            signal t;                (* The indexed value of type signal t *)
   (* Static indexing *)
-  indexConst : forall {k: Kind} {sz: nat},
-               Vector.t (smashTy bit k) sz -> nat -> smashTy bit k;
-  indexBitConst : forall {sz: nat}, Vector.t bit sz -> nat -> bit;
-  slice : forall {k: Kind}  {sz: nat} (startAt len: nat),
-                 Vector.t (smashTy bit k) sz ->
-                 (startAt + len <= sz) -> Vector.t (smashTy bit k) len ;
+  indexConst : forall {t: SignalType} {sz: nat},
+               signal (Vec t sz) ->     (* A vector of n elements of type signal t *)
+               nat ->                   (* Static index *)
+               signal t;                (* The indexed bit of type signal bit *)
+  slice : forall {t: SignalType} {sz: nat} (startAt len: nat),
+                 signal (Vec t sz) ->
+                 (startAt + len <= sz) ->
+                 signal (Vec t len);
   (* Synthesizable arithmetic operations. *)
-  unsignedAdd : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
-                m (Vector.t bit (1 + max a b));
-  unsignedMult : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
-                m (Vector.t bit (a + b));              
+  unsignedAdd : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
+                cava (signal (Vec Bit (1 + max a b)));
+  unsignedMult : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b)->
+                cava (signal (Vec Bit (a + b)));              
   (* Synthesizable relational operators *)
-  greaterThanOrEqual : forall {a b : nat}, Vector.t bit a -> Vector.t bit b ->
-                       m bit;
-  (* Hierarchy *)
-  doSomethingToOne := smashTy bit;
+  greaterThanOrEqual : forall {a b : nat}, signal (Vec Bit a) -> signal (Vec Bit b) ->
+                       cava (signal Bit);
+  (* Hierarchy 
   instantiate : forall (intf: CircuitInterface),
                  (denote doSomethingToOne (mapShape port_shape (circuitInputs intf)) ->
-                 m (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)))) ->
+                 cava (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)))) ->
                  denote doSomethingToOne (mapShape port_shape (circuitInputs intf)) ->
-                 m (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)));
+                 cava (denote doSomethingToOne (mapShape port_shape (circuitOutputs intf)));
+  *)
 }.               
 
 

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -206,7 +206,7 @@ Definition loopBitBool (A B : SignalType) (f : combType A * bool -> ident (combT
     unsignedAdd m n := @unsignedAddBool m n;
     unsignedMult m n := @unsignedMultBool m n;
     greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
-    (* instantiate _ circuit := circuit; *)
+    instantiate _ circuit := circuit;
 }.
 
 (******************************************************************************)

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -214,4 +214,4 @@ Definition loopBitBool (A B : SignalType) (f : combType A * bool -> ident (combT
 (* behavioural simulation result.                                             *)
 (******************************************************************************)
 
-Definition combinational {a} (circuit : ident a) : a := unIdent circuit.
+Definition combinational {a} (circuit : cava a) : a := unIdent circuit.

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -36,6 +36,26 @@ From Cava Require Import Signal.
 Require Import Cava.Monad.CavaClass.
 
 (******************************************************************************)
+(* Combinational denotion of the SignalType and default values.               *)
+(******************************************************************************)
+
+Fixpoint combType (t: SignalType) : Type :=
+  match t with
+  | Void => unit
+  | Bit => bool
+  | Vec vt sz => Vector.t (combType vt) sz
+  | ExternalType _ => unit (* No semantics for combinational interpretation. *)
+  end.
+
+Fixpoint defaultCombValue (t: SignalType) : combType t :=
+  match t  with
+  | Void => tt
+  | Bit => false
+  | Vec t2 sz => Vector.const (defaultCombValue t2) sz
+  | ExternalType _ => tt
+  end.
+
+(******************************************************************************)
 (* A boolean combinational logic interpretation for the Cava class            *)
 (******************************************************************************)
 
@@ -94,38 +114,30 @@ Definition muxcyBool (s : bool) (ci : bool) (di : bool) : ident bool :=
        | true => ci
        end).
 
-Fixpoint defaultKindBool (k: Kind) : smashTy bool k :=
-  match k return smashTy bool k  with
-  | Void => UndefinedSignal
-  | Bit => false
-  | Vec k2 sz => Vector.const (defaultKindBool k2) sz
-  | ExternalType _ => UninterpretedSignal "XXX"
-  end.
-
-Definition indexAtBool {k: Kind}
+Definition indexAtBool {t: SignalType}
                        {sz isz: nat}
-                       (i : Vector.t (smashTy bool k) sz)
-                       (sel : Bvector isz) : smashTy bool k :=
+                       (i : Vector.t (combType t) sz)
+                       (sel : Bvector isz) : combType t :=
   let selN := Bv2N sel in
   match lt_dec (N.to_nat selN) sz with
   | left H => @Vector.nth_order _ _ i (N.to_nat selN) H
-  | right _ => defaultKindBool k
+  | right _ => defaultCombValue t
   end.
 
-Definition indexConstBool {k: Kind} {sz: nat}
-                          (i : Vector.t (smashTy bool k) sz)
-                          (sel : nat) : smashTy bool k :=
+Definition indexConstBool {t: SignalType} {sz: nat}
+                          (i : Vector.t (combType t) sz)
+                          (sel : nat) : combType t :=
   match lt_dec sel sz with
   | left H => @Vector.nth_order _ _ i sel H
-  | right _ => defaultKindBool k
+  | right _ => defaultCombValue t
   end.
 
-Definition sliceBool {k: Kind}
+Definition sliceBool {t: SignalType}
                      {sz: nat}
                      (startAt len : nat)
-                     (v: Vector.t (smashTy bool k) sz)
+                     (v: Vector.t (combType t) sz)
                      (H: startAt + len <= sz) :
-                     Vector.t (smashTy bool k) len :=
+                     Vector.t (combType t) len :=
   sliceVector v startAt len H.
 
 Definition unsignedAddBool {m n : nat}
@@ -136,7 +148,6 @@ Definition unsignedAddBool {m n : nat}
   let sumSize := 1 + max m n in
   let sum := (a + b)%N in
   ret (N2Bv_sized sumSize sum).
-
 
 Definition unsignedMultBool {m n : nat}
                            (av : Bvector m) (bv : Bvector n) :
@@ -156,7 +167,7 @@ Definition greaterThanOrEqualBool {m n : nat}
 Definition bufBool (i : bool) : ident bool :=
   ret i.
 
-Definition loopBitBool (A B : Type) (f : A * bool -> ident (B * bool)) (a : A) : ident B :=
+Definition loopBitBool (A B : SignalType) (f : combType A * bool -> ident (combType B * bool)) (a : combType A) : ident (combType B) :=
   '(b, _) <- f (a, false) ;;
   ret b.
 
@@ -165,11 +176,12 @@ Definition loopBitBool (A B : Type) (f : A * bool -> ident (B * bool)) (a : A) :
 (* interpretation.                                                            *)
 (******************************************************************************)
 
-Program Instance CavaBool : Cava ident bool :=
-  { zero := ret false;
+ Instance Combinational : Cava combType :=
+  { cava := ident;
+    zero := ret false;
     one := ret true;
     delayBit i := ret i; (* Dummy definition for delayBit for now. *)
-    loopBit a b := loopBitBool a b;
+    loopBit a b := @loopBitBool a b;
     inv := notBool;
     and2 := andBool;
     nand2 := nandBool;
@@ -186,15 +198,15 @@ Program Instance CavaBool : Cava ident bool :=
     lut6 := lut6Bool;
     xorcy := xorcyBool;
     muxcy := muxcyBool;
-    indexAt k sz isz := @indexAtBool k sz isz;
-    indexBitAt sz isz := @indexAtBool Bit sz isz;
-    indexConst k sz := @indexConstBool k sz;
-    indexBitConst sz := @indexConstBool Bit sz;
-    slice k sz := @sliceBool k sz;
+    peel _ _ v := v;
+    unpeel _ _ v := v;
+    indexAt t sz isz := @indexAtBool t sz isz;
+    indexConst t sz := @indexConstBool t sz;
+    slice t sz := @sliceBool t sz;
     unsignedAdd m n := @unsignedAddBool m n;
     unsignedMult m n := @unsignedMultBool m n;
     greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
-    instantiate _ circuit := circuit;
+    (* instantiate _ circuit := circuit; *)
 }.
 
 (******************************************************************************)

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -30,6 +30,7 @@ From Cava Require Import Kind.
 Require Import Cava.Monad.CavaClass.
 Require Import Cava.VectorUtils.
 Require Import Cava.ListUtils.
+Require Import Cava.Signal.
 Require Import Cava.Tactics.
 
 Generalizable All Variables.
@@ -37,379 +38,385 @@ Generalizable All Variables.
 Require Import ExtLib.Structures.MonadLaws.
 
 Local Open Scope monad_scope.
+Local Open Scope type_scope.
+
+Section WithCava.
+  Context {signal} {m : Cava signal}.
+  Context {monad: Monad cava}.
+
+  (****************************************************************************)
+  (* Lava-style circuit combinators.                                          *)
+  (****************************************************************************)
+
+  (* Below combinator
+
+  -----------------------------------------------------------------------------
+  -- Below
+  -----------------------------------------------------------------------------
+  -- below r s
+  --            ^
+  --            |
+  --            f
+  --            ^
+  --            |
+  --          -----
+  --         |     |
+  --     c ->|  s  |-> e
+  --         |     |
+  --          -----
+  --            ^
+  --            |
+  --            g
+  --            ^
+  --            |
+  --          -----
+  --         |     |
+  --     b ->|  r  |-> d
+  --         |     |
+  --          -----
+  --            ^
+  --            |
+  --            a
+  -----------------------------------------------------------------------------
+  *)
+
+  Definition below {A B C D E F G}
+              (r : A * B -> cava (D * G))
+              (s : G * C -> cava (E * F))
+              (abc : A * (B * C)) : cava ((D * E) * F) :=
+    let (a, bc) := abc in
+    let (b, c) := bc in
+    dg <- r (a, b) ;;
+    let (d, g) := dg : D * G in
+    ef <- s (g, c) ;;
+    let (e, f) := ef : E * F in
+    ret ((d, e), f).
+
+  (* The col combinator takes a 4-sided circuit element and replicates it by
+    composing each element in a chain.
+
+  -----------------------------------------------------------------------------
+  -- 4-Sided Tile Combinators
+  -----------------------------------------------------------------------------
+  -- COL r
+  --            a
+  --            ^
+  --            |
+  --          -----
+  --         |     |
+  --     b ->|  r  |-> c
+  --         |     |
+  --          -----
+  --            ^
+  --            |
+  --            a
+  --            ^
+  --            |
+  --          -----
+  --         |     |
+  --     b ->|  r  |-> c
+  --         |     |
+  --          -----
+  --            ^
+  --            |
+  --            a
+  --            ^
+  --            |
+  --          -----
+  --         |     |
+  --     b ->|  r  |-> c
+  --         |     |
+  --          -----
+  --            ^
+  --            |
+  --            a
+  -----------------------------------------------------------------------------
 
 
-(******************************************************************************)
-(* Lava-style circuit combinators.                                            *)
-(******************************************************************************)
+  *)
 
-(* Below combinator
+  (* The below_cons' is a convenient combinator for composing
+    homogenous tiles that are expressed with curried inputs.
+  *)
+  Definition below_cons' {A B C}
+              (r : C -> A -> cava (B * C))
+              (s : C -> list A -> cava (list B * C))
+              (c: C) (a : list A) : cava (list B * C):=
+    match a with
+    | [] => ret ([], c)
+    | a0::ax => '(b0, c1) <- r c a0  ;;
+                '(bx, cOut) <- s c1 ax ;;
+                ret (b0::bx, cOut)
+    end.
 
--------------------------------------------------------------------------------
--- Below
--------------------------------------------------------------------------------
--- below r s
---            ^
---            |
---            f
---            ^
---            |
---          -----
---         |     |
---     c ->|  s  |-> e
---         |     |
---          -----
---            ^
---            |
---            g
---            ^
---            |
---          -----
---         |     |
---     b ->|  r  |-> d
---         |     |
---          -----
---            ^
---            |
---            a
--------------------------------------------------------------------------------
-*)
+  (* col' is a curried version of col which ca be defined
+    recursively because Coq can figure out the decreasing
+    argument i.e. a
+  *)
+  Fixpoint col' {A B C}
+                (circuit : C -> A -> cava (B * C)) (c: C) (a: list A) :
+                cava (list B * C) :=
+    below_cons' circuit (col' circuit) c a.
 
-Definition below `{Monad m} {A B C D E F G}
-             (r : A * B -> m (D * G)%type)
-             (s : G * C -> m (E * F)%type)
-             (abc : A * (B * C)) : m ((D * E) * F)%type :=
-  let (a, bc) := abc in
-  let (b, c) := bc in
-  dg <- r (a, b) ;;
-  let (d, g) := dg : D * G in
-  ef <- s (g, c) ;;
-  let (e, f) := ef : E * F in
-  ret ((d, e), f).
+  (* A useful fact about how a col' of a circuit can be made using one
+    instance of a circuit below a col' that is one smaller.
+  *)
+  Lemma col_cons': forall {A B C} (r : C -> A -> cava (B * C)) (c: C) (a: list A),
+                  col' r c a = below_cons' r (col' r) c a.
+  Proof.
+    intros.
+    destruct a.
+    - simpl. reflexivity.
+    - simpl. reflexivity.
+  Qed.
 
-(* The col combinator takes a 4-sided circuit element and replicates it by
-   composing each element in a chain.
+  (* To define the pair to pair tile variants of col and below_cons
+    it is useful to have some functions for currying and uncurrying,
+    with we borrow from Logical Foundations. *)
 
--------------------------------------------------------------------------------
--- 4-Sided Tile Combinators
--------------------------------------------------------------------------------
--- COL r
---            a
---            ^
---            |
---          -----
---         |     |
---     b ->|  r  |-> c
---         |     |
---          -----
---            ^
---            |
---            a
---            ^
---            |
---          -----
---         |     |
---     b ->|  r  |-> c
---         |     |
---          -----
---            ^
---            |
---            a
---            ^
---            |
---          -----
---         |     |
---     b ->|  r  |-> c
---         |     |
---          -----
---            ^
---            |
---            a
--------------------------------------------------------------------------------
+  Definition prod_curry {X Y Z : Type}
+    (f : X * Y -> Z) (x : X) (y : Y) : Z := f (x, y).
 
+  Definition prod_uncurry {X Y Z : Type}
+    (f : X -> Y -> Z) (p : X * Y) : Z
+    := f (fst p) (snd p).
 
-*)
+  (* Thank you Benjamin. *)
 
-(* The below_cons' is a convenient combinator for composing
-   homogenous tiles that are expressed with curried inputs.
-*)
-Definition below_cons' `{Monad m} {A B C}
-             (r : C -> A -> m (B * C)%type)
-             (s : C -> list A -> m (list B * C)%type)
-             (c: C) (a : list A) : m (list B * C)%type :=
-  match a with
-  | [] => ret ([], c)
-  | a0::ax => '(b0, c1) <- r c a0  ;;
-              '(bx, cOut) <- s c1 ax ;;
-              ret (b0::bx, cOut)
-  end.
+  (* Now we can define the col combinator that works with tiles that
+    map pairs to pairs by using col'.
+  *)
+  Definition col {A B C}
+                (circuit : C * A -> cava (B * C)) :
+                C * list A -> cava (list B * C) :=
+    prod_uncurry (col' (prod_curry circuit)).
 
-(* col' is a curried version of col which ca be defined
-   recursively because Coq can figure out the decreasing
-   argument i.e. a
-*)
-Fixpoint col' `{Monad m} {A B C}
-              (circuit : C -> A -> m (B * C)%type) (c: C) (a: list A) :
-              m (list B * C)%type :=
-  below_cons' circuit (col' circuit) c a.
+  (* Define a version of below_cons' that works on pair to pair tiles *)
 
-(* A useful fact about how a col' of a circuit can be made using one
-   instance of a circuit below a col' that is one smaller.
-*)
-Lemma col_cons': forall `{Monad m} {A B C} (r : C -> A -> m (B * C)%type) (c: C) (a: list A),
-                col' r c a = below_cons' r (col' r) c a.
-Proof.
-  intros.
-  destruct a.
-  - simpl. reflexivity.
-  - simpl. reflexivity.
-Qed.
+  Definition below_cons {A B C}
+              (r : C * A -> cava (B * C))
+              (s : C * list A -> cava (list B * C)) :
+              C * list A -> cava (list B * C) :=
+    prod_uncurry (below_cons' (prod_curry r) (prod_curry s)).
 
-(* To define the pair to pair tile variants of col and below_cons
-   it is useful to have some functions for currying and uncurrying,
-   with we borrow from Logical Foundations. *)
+  (* A useful fact about how a col of a circuit can be made using one
+    instance of a circuit below a col that is one smaller.
+  *)
+  Lemma col_cons: forall {A B C} (r : C * A -> cava (B * C)%type)
+                  (ca: C * list A),
+                  col r ca = below_cons r (col r) ca.
+  Proof.
+    intros.
+    destruct ca.
+    destruct l.
+    - simpl. reflexivity.
+    - simpl. reflexivity.
+  Qed.
 
-Definition prod_curry {X Y Z : Type}
-  (f : X * Y -> Z) (x : X) (y : Y) : Z := f (x, y).
+  Import EqNotations.
 
-Definition prod_uncurry {X Y Z : Type}
-  (f : X -> Y -> Z) (p : X * Y) : Z
-  := f (fst p) (snd p).
+  Local Open Scope vector_scope.
 
-(* Thank you Benjamin. *)
+  Lemma add_S_contra: forall x y, x = S y -> x - 1 <> y -> False.
+  Proof. lia. Qed.
 
-(* Now we can define the col combinator that works with tiles that
-   map pairs to pairs by using col'.
-*)
-Definition col `{Monad m} {A B C}
-              (circuit : C * A -> m (B * C)%type) :
-              C * list A -> m (list B * C)%type :=
-  prod_uncurry (col' (prod_curry circuit)).
+  Lemma S_add_S_contra: forall x y, x = S y -> S (x - 1) <> S y -> False.
+  Proof. lia. Qed.
 
-(* Define a version of below_cons' that works on pair to pair tiles *)
+  Definition vec_dec_rewrite1 {A x y} (H: x = S y) (v: Vector.t A y): Vector.t A (x - 1) :=
+    match Nat.eq_dec (x - 1) y with
+    | left Heq => rew <- Heq in v
+    | right Hneq => match add_S_contra _ _ H Hneq with end
+    end.
 
-Definition below_cons `{Monad m} {A B C}
-             (r : C * A -> m (B * C)%type)
-             (s : C * list A -> m (list B * C)%type) :
-             C * list A -> m (list B * C)%type :=
-  prod_uncurry (below_cons' (prod_curry r) (prod_curry s)).
+  Definition vec_dec_rewrite2 {A x y} (H: x = S y) (v: Vector.t A (S (x - 1))): Vector.t A (S y) :=
+    match Nat.eq_dec (S (x - 1)) (S y) with
+    | left Heq => rew Heq in v
+    | right Hneq => match S_add_S_contra _ _ H Hneq with end
+    end.
 
-(* A useful fact about how a col of a circuit can be made using one
-   instance of a circuit below a col that is one smaller.
-*)
-Lemma col_cons: forall `{Monad m} {A B C} (r : C * A -> m (B * C)%type)
-                (ca: C * list A),
-                col r ca = below_cons r (col r) ca.
-Proof.
-  intros.
-  destruct ca.
-  destruct l.
-  - simpl. reflexivity.
-  - simpl. reflexivity.
-Qed.
+  Program Definition below_consV {A B C} {n: nat}
+                (r : C -> A -> cava (B * C))
+                (s : C -> Vector.t A (n-1) -> cava (Vector.t B (n-1) * C))
+                (ca: C * Vector.t A n) : cava (Vector.t B n * C) :=
+    let '(c, a) := ca in
+    match a in Vector.t _ z return n=z -> cava (Vector.t B z * C)%type with
+    | Vector.nil _ => fun _ => ret ([], c)
+    | Vector.cons _ a0 Z ax => fun H =>
+      '(b0, c1) <- r c a0 ;;
+      '(bx, cOut) <- s c1 (vec_dec_rewrite1 H ax) ;;
+      ret (vec_dec_rewrite2 H (b0 :: bx), cOut)
+    end eq_refl.
 
-Import EqNotations.
+  Definition circuit_dec_rewrite {A B C x y} (H: x = S y)
+    (s: C -> Vector.t A y -> cava (Vector.t B y * C))
+    : C -> Vector.t A (x-1) -> cava (Vector.t B (x-1) * C) :=
+    match Nat.eq_dec (x - 1) y with
+    | left Heq => rew <- [fun z => C -> Vector.t A z -> cava (Vector.t B z * C)] Heq in s
+    | right Hneq => match add_S_contra _ _ H Hneq with end
+    end.
 
-Local Open Scope vector_scope.
+  Fixpoint colV {A B C} (n: nat)
+                (circuit : C -> A -> cava (B * C))
+                (c: C) (a: Vector.t A n) :
+                cava (Vector.t B n * C) :=
+    match n as n' return n=n' -> cava (Vector.t B n' * C) with
+    | O => fun _ => ret ([], c)
+    | S n0 => fun H =>
+      let s :=  circuit_dec_rewrite H (colV n0 circuit) in
+      '(x,c) <- below_consV circuit s (c, a) ;;
+      ret (rew H in x, c)
+    end eq_refl.
 
-Lemma add_S_contra: forall x y, x = S y -> x - 1 <> y -> False.
-Proof. lia. Qed.
+  Local Close Scope vector_scope.
 
-Lemma S_add_S_contra: forall x y, x = S y -> S (x - 1) <> S y -> False.
-Proof. lia. Qed.
+  (****************************************************************************)
+  (* Forks in wires                                                           *)
+  (****************************************************************************)
 
-Definition vec_dec_rewrite1 {A x y} (H: x = S y) (v: Vector.t A y): Vector.t A (x - 1) :=
-  match Nat.eq_dec (x - 1) y with
-  | left Heq => rew <- Heq in v
-  | right Hneq => match add_S_contra _ _ H Hneq with end
-  end.
+  Definition fork2 `{Mondad_m : Monad cava} {A} (a:A) := ret (a, a).
 
-Definition vec_dec_rewrite2 {A x y} (H: x = S y) (v: Vector.t A (S (x - 1))): Vector.t A (S y) :=
-  match Nat.eq_dec (S (x - 1)) (S y) with
-  | left Heq => rew Heq in v
-  | right Hneq => match S_add_S_contra _ _ H Hneq with end
-  end.
+  Definition first `{Mondad_m : Monad cava} {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
+    let '(a, b) := ab in
+    c <- f a ;;
+    ret (c, b).
 
-Program Definition below_consV `{Monad m} {A B C} {n: nat}
-              (r : C -> A -> m (B * C)%type)
-              (s : C -> Vector.t A (n-1) -> m (Vector.t B (n-1) * C)%type)
-              (ca: C * Vector.t A n) : m (Vector.t B n * C)%type :=
-  let '(c, a) := ca in
-  match a in Vector.t _ z return n=z -> m (Vector.t B z * C)%type with
-  | Vector.nil _ => fun _ => ret ([], c)
-  | Vector.cons _ a0 Z ax => fun H =>
-    '(b0, c1) <- r c a0 ;;
-    '(bx, cOut) <- s c1 (vec_dec_rewrite1 H ax) ;;
-    ret (vec_dec_rewrite2 H (b0 :: bx), cOut)
-  end eq_refl.
+  Definition second `{Mondad_m : Monad cava} {A B C} (f : B -> cava C) (ab : A * B) : cava (A * C) :=
+    let '(a, b) := ab in
+    c <- f b ;;
+    ret (a, c).
 
-Definition circuit_dec_rewrite `{Monad m} {A B C x y} (H: x = S y)
-  (s: C -> Vector.t A y -> m (Vector.t B y * C)%type)
-  : C -> Vector.t A (x-1) -> m (Vector.t B (x-1) * C)%type :=
-  match Nat.eq_dec (x - 1) y with
-  | left Heq => rew <- [fun z => C -> Vector.t A z -> m (Vector.t B z * C)%type] Heq in s
-  | right Hneq => match add_S_contra _ _ H Hneq with end
-  end.
+  (****************************************************************************)
+  (* Split a bus into two halves.                                             *)
+  (****************************************************************************)
 
-Fixpoint colV `{Monad m} {A B C} (n: nat)
-              (circuit : C -> A -> m (B * C)%type)
-              (c: C) (a: Vector.t A n) :
-              m (Vector.t B n * C)%type :=
-  match n as n' return n=n' -> m (Vector.t B n' * C)%type with
-  | O => fun _ => ret ([], c)
-  | S n0 => fun H =>
-    let s :=  circuit_dec_rewrite H (colV n0 circuit) in
-    '(x,c) <- below_consV circuit s (c, a) ;;
-    ret (rew H in x, c)
-  end eq_refl.
+  Definition halve {A} (l : list A) : list A * list A :=
+    let mid := (length l) / 2 in
+    (firstn mid l, skipn mid l).
 
-Local Close Scope vector_scope.
+  (****************************************************************************)
+  (* A binary tree combinator, list version.                                                *)
+  (****************************************************************************)
 
-(******************************************************************************)
-(* Forks in wires                                                             *)
-(******************************************************************************)
+  Fixpoint treeList {T: Type} {m} `{Monad m}
+                    (circuit: T -> T -> m T) (def: T)
+                    (n : nat) (v: list T) : m T :=
+    match n with
+    | O => match v return m T with
+          | [a; b]=> circuit a b
+          | _ => ret def
+          end
+    | S n' => let '(vL, vH) := halve v in
+            aS <- treeList circuit def n' vL ;;
+            bS <- treeList circuit def n' vH ;;
+            circuit aS bS
+    end.
 
-Definition fork2 `{Mondad_m : Monad m} {A} (a:A) := ret (a, a).
+  Definition treeWithList {T: Type}
+                          (circuit: T -> T -> cava T) (def: T)
+                          (n : nat) (v: Vector.t T (2^(n+1))) : cava T :=
+    treeList circuit def n (to_list v).
 
-Definition first `{Mondad_m : Monad m} {A B C} (f : A -> m C) (ab : A * B) : m (C * B)%type :=
-  let '(a, b) := ab in
-  c <- f a ;;
-  ret (c, b).
+  Lemma treeList_equiv
+        {T} {cava} {monad' : Monad cava}
+        {monad_laws : MonadLaws monad'}
+        (id : T)
+        (op : T -> T -> T)
+        (op_id_left : forall a : T, op id a = a)
+        (op_id_right : forall a : T, op a id = a)
+        (op_assoc :
+          forall a b c : T,
+            op a (op b c) = op (op a b) c)
+        (circuit : T -> T -> cava T)
+        (circuit_equiv :
+          forall a b : T, circuit a b = ret (op a b))
+        (def : T) (n : nat) :
+    forall v,
+      length v = 2 ^ (S n) ->
+      treeList circuit def n v = ret (List.fold_left op v id).
+  Proof.
+    induction n; intros; [ | ].
+    { (* n = 0 *)
+      change (2 ^ 1) with 2 in *.
+      destruct_lists_by_length. cbn [treeList fold_left].
+      rewrite op_id_left, circuit_equiv.
+      reflexivity. }
+    { (* n = S n' *)
+      cbn [treeList halve]. rewrite !Nat.pow_succ_r in * by lia.
+      erewrite <-Nat.div_unique_exact by eauto.
+      rewrite !IHn by (rewrite ?firstn_length, ?skipn_length; lia).
+      rewrite !bind_of_return, circuit_equiv by typeclasses eauto.
+      rewrite <-fold_left_assoc, <-fold_left_app by eauto.
+      rewrite firstn_skipn. reflexivity. }
+  Qed.
 
-Definition second `{Mondad_m : Monad m} {A B C} (f : B -> m C) (ab : A * B) : m (A * C)%type :=
-  let '(a, b) := ab in
-  c <- f b ;;
-  ret (a, c).
+  (****************************************************************************)
+  (* A binary tree combinator, Vector version.                                                  *)
+  (****************************************************************************)
 
-(******************************************************************************)
-(* Split a bus into two halves.                                               *)
-(******************************************************************************)
+  Definition divide {A n} (default : A) (v : Vector.t A (2 ^ (S n))) :
+    Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
+    splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
 
-Definition halve {A} (l : list A) : list A * list A :=
-  let mid := (length l) / 2 in
-  (firstn mid l, skipn mid l).
+  Fixpoint tree {T: Type} (default : T) (n : nat)
+                          (circuit: T -> T -> cava T)
+                          (v : Vector.t T (2^(S n))) :
+                          cava T :=
+    match n, v return cava T with
+    | O, v2 => circuit (@Vector.nth_order _ 2 v2 0 (ltac:(lia)))
+                      (@Vector.nth_order _ 2 v2 1 (ltac:(lia)))
+    | S n', vR => let '(vL, vH) := divide default vR in
+                  aS <- tree default n' circuit vL ;;
+                  bS <- tree default n' circuit vH ;;
+                  circuit aS bS
+    end.
 
-(******************************************************************************)
-(* A binary tree combinator, list version.                                                  *)
-(******************************************************************************)
+  Lemma append_divide {A} d n H (v : t A (2 ^ (S n))) :
+    (fst (divide d v) ++ snd (divide d v))%vector = resize _ H v.
+  Proof.
+    cbv [divide].
+    let H := fresh in
+    match goal with
+    | |- context [splitat ?n ?v] =>
+      pose proof (surjective_pairing (splitat n v)) as H
+    end;
+      apply append_splitat in H;
+      rewrite <-H; clear H.
+    rewrite resize_default_eq with (d0:=d).
+    reflexivity.
+  Qed.
 
-Fixpoint treeList {T: Type} {m} `{Monad m}
-                  (circuit: T -> T -> m T) (def: T)
-                  (n : nat) (v: list T) : m T :=
-  match n with
-  | O => match v return m T with
-        | [a; b]=> circuit a b
-        | _ => ret def
-        end
-  | S n' => let '(vL, vH) := halve v in
-           aS <- treeList circuit def n' vL ;;
-           bS <- treeList circuit def n' vH ;;
-           circuit aS bS
-  end.
+  Local Open Scope nat_scope.
 
-Definition treeWithList {T: Type} {m bit} `{Cava m bit}
-                      (circuit: T -> T -> m T) (def: T)
-                      (n : nat) (v: Vector.t T (2^(n+1))) : m T :=
-  treeList circuit def n (to_list v).
+  Lemma tree_equiv
+        {T}  {monad_laws : MonadLaws monad}
+        (id : T)
+        (op : T -> T -> T)
+        (op_id_left : forall a : T, op id a = a)
+        (op_id_right : forall a : T, op a id = a)
+        (op_assoc :
+          forall a b c : T,
+            op a (op b c) = op (op a b) c)
+        (circuit : T -> T -> cava T)
+        (circuit_equiv :
+          forall a b : T, circuit a b = ret (op a b))
+        (default : T) (n : nat) :
+    forall v,
+      tree default n circuit v = ret (Vector.fold_left op id v).
+  Proof.
+    induction n; intros.
+    { change (2 ^ 1) with 2 in *.
+      cbn [tree]. autorewrite with push_vector_fold vsimpl.
+      rewrite circuit_equiv, op_id_left. reflexivity. }
+    { cbn [tree]. destruct_pair_let.
+      rewrite !IHn by eauto.
+      rewrite !bind_of_return by eauto.
+      rewrite circuit_equiv by eauto.
+      rewrite <-fold_left_S_assoc, <-fold_left_append by auto.
+      assert (2 ^ S (S n) = 2 ^ S n + 2 ^ S n)
+        by (rewrite Nat.pow_succ_r'; lia).
+      rewrite (append_divide _ _ ltac:(eassumption)).
+      rewrite fold_left_resize. reflexivity. }
+  Qed.
 
-Lemma treeList_equiv
-      {T} {m} {monad : Monad m}
-      {monad_laws : MonadLaws monad}
-      (id : T)
-      (op : T -> T -> T)
-      (op_id_left : forall a : T, op id a = a)
-      (op_id_right : forall a : T, op a id = a)
-      (op_assoc :
-         forall a b c : T,
-           op a (op b c) = op (op a b) c)
-      (circuit : T -> T -> m T)
-      (circuit_equiv :
-         forall a b : T, circuit a b = ret (op a b))
-      (def : T) (n : nat) :
-  forall v,
-    length v = 2 ^ (S n) ->
-    treeList circuit def n v = ret (List.fold_left op v id).
-Proof.
-  induction n; intros; [ | ].
-  { (* n = 0 *)
-    change (2 ^ 1) with 2 in *.
-    destruct_lists_by_length. cbn [treeList fold_left].
-    rewrite op_id_left, circuit_equiv.
-    reflexivity. }
-  { (* n = S n' *)
-    cbn [treeList halve]. rewrite !Nat.pow_succ_r in * by lia.
-    erewrite <-Nat.div_unique_exact by eauto.
-    rewrite !IHn by (rewrite ?firstn_length, ?skipn_length; lia).
-    rewrite !bind_of_return, circuit_equiv by typeclasses eauto.
-    rewrite <-fold_left_assoc, <-fold_left_app by eauto.
-    rewrite firstn_skipn. reflexivity. }
-Qed.
-
-(******************************************************************************)
-(* A binary tree combinator, Vector version.                                                  *)
-(******************************************************************************)
-
-Definition divide {A n} (default : A) (v : Vector.t A (2 ^ (S n))) :
-  Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
-  splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
-
-Fixpoint tree {T: Type} {m bit} `{Cava m bit}
-                                (default : T) (n : nat)
-                                (circuit: T -> T -> m T)
-                                (v : Vector.t T (2^(S n))) :
-                                m T :=
-  match n, v return m T with
-  | O, v2 => circuit (@Vector.nth_order _ 2 v2 0 (ltac:(lia)))
-                     (@Vector.nth_order _ 2 v2 1 (ltac:(lia)))
-  | S n', vR => let '(vL, vH) := divide default vR in
-                aS <- tree default n' circuit vL ;;
-                bS <- tree default n' circuit vH ;;
-                circuit aS bS
-  end.
-
-Lemma append_divide {A} d n H (v : t A (2 ^ (S n))) :
-  (fst (divide d v) ++ snd (divide d v))%vector = resize _ H v.
-Proof.
-  cbv [divide].
-  let H := fresh in
-  match goal with
-  | |- context [splitat ?n ?v] =>
-    pose proof (surjective_pairing (splitat n v)) as H
-  end;
-    apply append_splitat in H;
-    rewrite <-H; clear H.
-  rewrite resize_default_eq with (d0:=d).
-  reflexivity.
-Qed.
-
-Lemma tree_equiv
-      {T} {m bit} {monad : Monad m}
-      {cava : Cava m bit} {monad_laws : MonadLaws monad}
-      (id : T)
-      (op : T -> T -> T)
-      (op_id_left : forall a : T, op id a = a)
-      (op_id_right : forall a : T, op a id = a)
-      (op_assoc :
-         forall a b c : T,
-           op a (op b c) = op (op a b) c)
-      (circuit : T -> T -> m T)
-      (circuit_equiv :
-         forall a b : T, circuit a b = ret (op a b))
-      (default : T) (n : nat) :
-  forall v,
-    tree default n circuit v = ret (Vector.fold_left op id v).
-Proof.
-  induction n; intros.
-  { change (2 ^ 1) with 2 in *.
-    cbn [tree]. autorewrite with push_vector_fold vsimpl.
-    rewrite circuit_equiv, op_id_left. reflexivity. }
-  { cbn [tree]. destruct_pair_let.
-    rewrite !IHn by eauto.
-    rewrite !bind_of_return by eauto.
-    rewrite circuit_equiv by eauto.
-    rewrite <-fold_left_S_assoc, <-fold_left_append by auto.
-    assert (2 ^ S (S n) = 2 ^ S n + 2 ^ S n)
-      by (rewrite Nat.pow_succ_r'; lia).
-    rewrite (append_divide _ _ ltac:(eassumption)).
-    rewrite fold_left_resize. reflexivity. }
-Qed.
+ End WithCava.

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -312,9 +312,9 @@ Section WithCava.
             circuit aS bS
     end.
 
-  Definition treeWithList {T: Type}
-                          (circuit: T -> T -> cava T) (def: T)
-                          (n : nat) (v: Vector.t T (2^(n+1))) : cava T :=
+  Definition treeWithList {T: Type} {m} `{Monad m}
+                          (circuit: T -> T -> m T) (def: T)
+                          (n : nat) (v: Vector.t T (2^(n+1))) : m T :=
     treeList circuit def n (to_list v).
 
   Lemma treeList_equiv
@@ -358,11 +358,12 @@ Section WithCava.
     Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
     splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
 
-  Fixpoint tree {T: Type} (default : T) (n : nat)
-                          (circuit: T -> T -> cava T)
+  Fixpoint tree {T: Type} {m} `{Monad m}
+                          (default : T) (n : nat)
+                          (circuit: T -> T -> m T)
                           (v : Vector.t T (2^(S n))) :
-                          cava T :=
-    match n, v return cava T with
+                          m T :=
+    match n, v return m T with
     | O, v2 => circuit (@Vector.nth_order _ 2 v2 0 (ltac:(lia)))
                       (@Vector.nth_order _ 2 v2 1 (ltac:(lia)))
     | S n', vR => let '(vL, vH) := divide default vR in

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -41,7 +41,7 @@ Local Open Scope monad_scope.
 Local Open Scope type_scope.
 
 Section WithCava.
-  Context {signal} {m : Cava signal}.
+  Context {signal} `{m: Cava signal}.
   Context {monad: Monad cava}.
 
   (****************************************************************************)

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -282,5 +282,5 @@ Instance CavaNet : Cava denoteSignal :=
     unsignedAdd m n := @unsignedAddNet m n;
     unsignedMult m n := @unsignedMultNet m n;
     greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
-    (* instantiate := instantiateNet; *)
+    instantiate := instantiateNet;
 }.

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -28,7 +28,6 @@ Require Import Cava.Cava.
 Require Import Cava.VectorUtils.
 Require Import Cava.Monad.CavaClass.
 
-From Cava Require Import Kind.
 From Cava Require Import Signal.
 
 (******************************************************************************)
@@ -239,10 +238,10 @@ Definition loopBitNet (A B : SignalType) (f : (Signal A * Signal Bit)%type -> st
   ret b.
 
 Definition instantiateNet (intf : CircuitInterface)
-                          (circuit : tupleInterface (circuitInputs intf) ->
-                                    state CavaState (tupleInterface (circuitOutputs intf)))
-                          (a : tupleInterface (circuitInputs intf))
-                          : state CavaState (tupleInterface (circuitOutputs intf)) :=
+                          (circuit : tupleNetInterface (circuitInputs intf) ->
+                                    state CavaState (tupleNetInterface (circuitOutputs intf)))
+                          (a : tupleNetInterface (circuitInputs intf))
+                          : state CavaState (tupleNetInterface (circuitOutputs intf)) :=
   let cs := makeNetlist intf circuit in
   addModule intf (module cs) ;;
   x <- blackBox intf a ;;

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -191,66 +191,58 @@ Definition muxcyNet (s ci di : Signal Bit) : state CavaState (Signal Bit) :=
   addInstance (Component "MUXCY" [] [("O", USignal o); ("S", USignal s); ("CI", USignal ci); ("DI", USignal di)]) ;;
   ret o.
 
+Definition peelNet {t : SignalType} {s : nat} (v : Signal (Vec t s)) : Vector.t (Signal t) s :=
+  Vector.map (IndexConst v) (vseq 0 s).
+
+Definition unpeelNet {t : SignalType} {s : nat} (v: Vector.t (Signal t) s) : Signal (Vec t s) :=
+  VecLit v.
+
+Definition sliceNet {t: SignalType} {sz: nat}
+                    (startAt len: nat)
+                    (v: Signal (Vec t sz))
+                    (H: startAt + len <= sz) :
+                    Signal (Vec t len) :=
+  unpeelNet (sliceVector (peelNet v) startAt len H).
+
 Definition unsignedAddNet {m n : nat}
-                          (a : Vector.t (Signal Bit) m)
-                          (b : Vector.t (Signal Bit) n) :
-                          state CavaState (Vector.t (Signal Bit) (1 + max m n)) :=
+                          (a : Signal (Vec Bit m))
+                          (b : Signal (Vec Bit n)) :
+                          state CavaState (Signal (Vec Bit (1 + max m n))) :=
   sum <- newVector Bit (1 + max m n) ;;
-  addInstance (UnsignedAdd (VecLit a) (VecLit b) sum) ;;
-  let smashedSum := Vector.map (fun i => IndexConst sum i) (vseq 0 (1 + (max m n))) in
-  ret smashedSum.
+  addInstance (UnsignedAdd a b sum) ;;
+  ret sum.
 
 Definition unsignedMultNet {m n : nat}
-                          (a : Vector.t (Signal Bit) m)
-                          (b : Vector.t (Signal Bit) n) :
-                          state CavaState (Vector.t (Signal Bit) (m + n)) :=
+                           (a : Signal (Vec Bit m))
+                           (b : Signal (Vec Bit n)) :
+                           state CavaState (Signal (Vec Bit (m + n))) :=
   product <- newVector Bit (m + n) ;;
-  addInstance (UnsignedMultiply (VecLit a) (VecLit b) product) ;;
-  let smashedMult := Vector.map (fun i => IndexConst product i) (vseq 0 (m + n)) in
-  ret smashedMult.
+  addInstance (UnsignedMultiply a b product) ;;
+  ret product.
+
+Definition greaterThanOrEqualNet {m n : nat}
+                                 (a : Signal (Vec Bit m)) (b : Signal (Vec Bit n)) :
+                                 state CavaState (Signal Bit) :=
+  comparison <- newWire ;;
+  addInstance (GreaterThanOrEqual a b comparison) ;;
+  ret comparison.
 
 Definition delayBitNet (i : Signal Bit) : state CavaState (Signal Bit) :=
   o <- newWire ;;
   addInstance (DelayBit i o) ;;
   ret o.
 
-Definition loopBitNet (A B : Type) (f : (A * Signal Bit)%type -> state CavaState (B * Signal Bit)%type) (a : A) : state CavaState B :=
+Definition loopBitNet (A B : SignalType) (f : (Signal A * Signal Bit)%type -> state CavaState (Signal B * Signal Bit)) (a : Signal A) : state CavaState (Signal B) :=
   o <- newWire ;;
   '(b, cOut) <- f (a, o) ;;
   assignSignal o cOut ;;
   ret b.
 
-Definition indexAtNet {k: Kind} {sz isz: nat}
-                      (v: Vector.t (smashTy (Signal Bit) k) sz)
-                      (i: Vector.t (Signal Bit) isz) :
-                      smashTy (Signal Bit) k :=
-  smash (IndexAt (VecLit (Vector.map vecLitS v)) (VecLit i)).
-
-Definition indexConstNet {k: Kind} {sz: nat}
-                         (v: Vector.t (smashTy (Signal Bit) k) sz)
-                         (i: nat) :
-                         smashTy (Signal Bit) k :=
-  smash (IndexConst (VecLit(Vector.map vecLitS v)) i).
-
-Definition sliceNet {k: Kind} {sz: nat}
-                    (startAt len: nat)
-                    (v: Vector.t (smashTy (Signal Bit) k) sz)
-                    (H: startAt + len <= sz) :
-                    Vector.t (smashTy (Signal Bit) k) len :=
-  sliceVector v startAt len H.
-
-Definition greaterThanOrEqualNet {m n : nat}
-                                 (a : Vector.t (Signal Bit) m) (b : Vector.t (Signal Bit) n) :
-                                 state CavaState (Signal Bit) :=
-  comparison <- newWire ;;
-  addInstance (GreaterThanOrEqual (VecLit a) (VecLit b) comparison) ;;
-  ret comparison.
-
 Definition instantiateNet (intf : CircuitInterface)
-                          (circuit : signalSmashTy (mapShape port_shape (circuitInputs intf)) ->
-                                     state CavaState (signalSmashTy (mapShape port_shape (circuitOutputs intf))))
-                          (a : signalSmashTy (mapShape port_shape (circuitInputs intf)))
-                          : state CavaState (signalSmashTy (mapShape port_shape (circuitOutputs intf))) :=
+                          (circuit : tupleInterface (circuitInputs intf) ->
+                                    state CavaState (tupleInterface (circuitOutputs intf)))
+                          (a : tupleInterface (circuitInputs intf))
+                          : state CavaState (tupleInterface (circuitOutputs intf)) :=
   let cs := makeNetlist intf circuit in
   addModule intf (module cs) ;;
   x <- blackBox intf a ;;
@@ -260,8 +252,10 @@ Definition instantiateNet (intf : CircuitInterface)
 (* Instantiate the Cava class for CavaNet which describes circuits without    *)
 (* any top-level pins or other module-level data                              *)
 (******************************************************************************)
-Instance CavaNet : Cava (state CavaState) (Signal _) :=
-  { zero := ret Gnd;
+
+Instance CavaNet : Cava denoteSignal :=
+  { cava := state CavaState;
+    zero := ret Gnd;
     one := ret Vcc;
     delayBit := delayBitNet;
     loopBit a b := loopBitNet a b;
@@ -281,13 +275,13 @@ Instance CavaNet : Cava (state CavaState) (Signal _) :=
     lut6 := lut6Net;
     xorcy := xorcyNet;
     muxcy := muxcyNet;
-    indexBitAt sz isz := @indexAtNet Bit sz isz;
-    indexAt k sz isz := @indexAtNet k sz isz;
-    indexConst k sz := indexConstNet;
-    indexBitConst sz := @indexConstNet Bit sz;
-    slice k sz start len v h := @sliceNet k sz start len v h;
+    peel := @peelNet;
+    unpeel := @unpeelNet;
+    indexAt k sz isz := IndexAt;
+    indexConst k sz := IndexConst;
+    slice k sz := @sliceNet k sz;
     unsignedAdd m n := @unsignedAddNet m n;
     unsignedMult m n := @unsignedMultNet m n;
     greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
-    instantiate := instantiateNet;
+    (* instantiate := instantiateNet; *)
 }.

--- a/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/Cava/Monad/UnsignedAdders.v
@@ -23,8 +23,7 @@ From Cava Require Import Kind.
 Require Import Cava.Monad.CavaMonad.
 
 Section WithCava.
-  Context {signal} {m : Cava signal}.
-  Context {monad: Monad cava}.
+  Context {signal} `{Cava signal} `{Monad cava}.
 
   (****************************************************************************)
   (* An adder with two inputs of the same size and no bit-growth              *)

--- a/cava/Cava/Monad/UnsignedAdders.v
+++ b/cava/Cava/Monad/UnsignedAdders.v
@@ -22,44 +22,50 @@ Require Import Cava.Cava.
 From Cava Require Import Kind.
 Require Import Cava.Monad.CavaMonad.
 
-(******************************************************************************)
-(* An adder with two inputs of the same size and no bit-growth                *)
-(******************************************************************************)
+Section WithCava.
+  Context {signal} {m : Cava signal}.
+  Context {monad: Monad cava}.
 
-Lemma n_le_n_plus_1 : forall n, 0 + n <= 1 + n.
-Proof. auto. Defined.
+  (****************************************************************************)
+  (* An adder with two inputs of the same size and no bit-growth              *)
+  (****************************************************************************)
 
-Lemma max_n_n : forall n, max n n = n.
-Proof.
-  intros.
-  induction n.
-  - reflexivity.
-  - simpl. rewrite IHn. reflexivity.
-Defined.
+  Lemma n_le_n_plus_1 : forall n, 0 + n <= 1 + n.
+  Proof. auto. Defined.
 
-Definition deMax {m bit} `{Cava m bit} {n} (v: Vector.t bit (1 + max n n)) :
-                 Vector.t (smashTy bit Bit) (1+n).
-Proof.
-  rewrite max_n_n in v.
-  unfold smashTy. apply v.
-Defined.
+  Lemma max_n_n : forall n, max n n = n.
+  Proof.
+    intros.
+    induction n.
+    - reflexivity.
+    - simpl. rewrite IHn. reflexivity.
+  Defined.
 
-Definition addN {m bit} `{Cava m bit} {n}
-                (a: Vector.t bit n) (b: Vector.t bit n) : m (Vector.t bit n) :=
-  s <- unsignedAdd a b ;;
-  ret (slice 0 n (deMax s) (n_le_n_plus_1 _)).
+  Definition deMax {n} (v: signal (Vec Bit (1 + max n n))) :
+                       signal (Vec Bit (1+n)).
+  Proof.
+    rewrite max_n_n in v.
+    apply v.
+  Defined.
 
-(******************************************************************************)
-(* A three input adder.                                                       *)
-(******************************************************************************)
+  Definition addN {n: nat}
+                  (a b: signal (Vec Bit n))
+                  : cava (signal (Vec Bit n)) :=
+    s <- unsignedAdd a b ;;
+    ret (slice 0 n (deMax s) (n_le_n_plus_1 _)).
 
-Definition adder_3input {m bit} `{Cava m bit}
-                        {aSize bSize cSize}
-                        (a : Vector.t bit aSize)
-                        (b : Vector.t bit bSize)
-                        (c : Vector.t bit cSize) :
-                        m (Vector.t bit (1 + max (1 + max aSize bSize) cSize))
-                        :=
-  a_plus_b <- unsignedAdd a b ;;
-  sum <- unsignedAdd a_plus_b c ;;
-  ret sum.
+  (****************************************************************************)
+  (* A three input adder.                                                     *)
+  (****************************************************************************)
+
+  Definition adder_3input {aSize bSize cSize}
+                          (a : signal (Vec Bit aSize))
+                          (b : signal (Vec Bit bSize))
+                          (c : signal (Vec Bit cSize)) :
+                          cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize)))
+                          :=
+    a_plus_b <- unsignedAdd a b ;;
+    sum <- unsignedAdd a_plus_b c ;;
+    ret sum.
+
+ End WithCava.

--- a/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/Cava/Monad/XilinxAdder.v
@@ -33,66 +33,78 @@ Local Open Scope string_scope.
 Local Open Scope list_scope.
 Local Open Scope type_scope.
 
-(******************************************************************************)
-(* Build a full-adder with explicit use of Xilinx FPGA fast carry logic       *)
-(******************************************************************************)
+Section WithCava.
+  Context {signal} {m : Cava signal}.
+  Context {monad: Monad cava}.
 
-Definition xilinxFullAdder {m bit} `{Cava m bit}
-          (cin: bit)
-          (ab: bit * bit)
-  : m (bit * bit)%type :=
-  let (a, b) := ab in
-  part_sum <- xor2 (a, b) ;;
-  sum <- xorcy (part_sum, cin) ;;
-  cout <- muxcy part_sum cin a  ;;
-  ret (sum, cout).
+  (****************************************************************************)
+  (* Build a full-adder with explicit use of Xilinx FPGA fast carry logic     *)
+  (****************************************************************************)
 
-(* A proof that the the full-adder is correct. *)
-Lemma xilinxFullAdder_behaviour :
-  forall (a : bool) (b : bool) (cin : bool),
-         combinational (xilinxFullAdder cin (a, b))
-         = (xorb cin (xorb a b),
-           (a && b) || (b && cin) || (a && cin)).
-Proof.
-  intros.
-  unfold combinational.
-  unfold fst.
-  simpl.
-  case a, b, cin.
-  all : reflexivity.
-Qed.
+  Definition xilinxFullAdder
+            (cin: signal Bit)
+            (ab: signal Bit * signal Bit)
+    : cava (signal Bit * signal Bit) :=
+    let (a, b) := ab in
+    part_sum <- xor2 (a, b) ;;
+    sum <- xorcy (part_sum, cin) ;;
+    cout <- muxcy part_sum cin a  ;;
+    ret (sum, cout).
 
-(******************************************************************************)
-(* An unsigned adder built using the fast carry full-adder.                   *)
-(******************************************************************************)
+  (******************************************************************************)
+  (* An unsigned adder built using the fast carry full-adder.                   *)
+  (******************************************************************************)
 
-Definition xilinxAdderWithCarry {m bit} `{Cava m bit} {n: nat}
-            (cinab : bit * (Vector.t bit n * Vector.t bit n))
-           : m (Vector.t bit n * bit)
-  := let '(cin, (a, b)) := cinab in
-     '(sum, cout) <- colV n xilinxFullAdder cin (vcombine a b) ;;
-     ret (sum, cout).
+  Definition xilinxAdderWithCarry {n: nat}
+              (cinab : signal Bit * (signal (Vec Bit n) * signal (Vec Bit n)))
+            : cava (signal (Vec Bit n) * signal Bit)
+    := let '(cin, (a, b)) := cinab in
+      let a0 := peel a in
+      let b0 := peel b in
+      '(sum, cout) <- colV n xilinxFullAdder cin (vcombine a0 b0) ;;
+      ret (unpeel sum, cout).
 
-(* A quick sanity check of the Xilinx adder with carry in and out *)
-Example xilinx_add_17_52:
-  combinational (xilinxAdderWithCarry
-                (false, (N2Bv_sized 8 17, N2Bv_sized 8 52))) =
-                (N2Bv_sized 8 69, false).
-Proof. reflexivity. Qed.
+  (******************************************************************************)
+  (* An unsigned adder with no bit-growth and no carry in                       *)
+  (******************************************************************************)
 
-(******************************************************************************)
-(* An unsigned adder with no bit-growth and no carry in                       *)
-(******************************************************************************)
+  Definition xilinxAdder {n: nat}
+              (a b: signal (Vec Bit n))
+              : cava (signal (Vec Bit n)) :=
+    z <- zero ;;
+    '(sum, carry) <- xilinxAdderWithCarry (z, (a, b)) ;;
+    ret sum.
 
-Definition xilinxAdder {m bit} `{Cava m bit} {n: nat}
-            (a: Vector.t bit n) (b: Vector.t bit n)
-           : m (Vector.t bit n) :=
-  z <- zero ;;
-  '(sum, carry) <- xilinxAdderWithCarry (z, (a, b)) ;;
-  ret sum.
+End WithCava.
 
-(* A quick sanity check of the Xilinx adder with no bit-growth *)
-Example xilinx_no_growth_add_17_52:
-  combinational (xilinxAdder (N2Bv_sized 8 17) (N2Bv_sized 8 52)) =
-                 N2Bv_sized 8 69.
-Proof. reflexivity. Qed.
+Section WithCombinational.
+
+  (* A quick sanity check of the Xilinx adder with carry in and out *)
+  Example xilinx_add_17_52:
+    combinational (xilinxAdderWithCarry
+                  (false, (N2Bv_sized 8 17, N2Bv_sized 8 52))) =
+                  (N2Bv_sized 8 69, false).
+  Proof. reflexivity. Qed.
+
+  (* A quick sanity check of the Xilinx adder with no bit-growth *)
+  Example xilinx_no_growth_add_17_52:
+    combinational (xilinxAdder (N2Bv_sized 8 17) (N2Bv_sized 8 52)) =
+                  N2Bv_sized 8 69.
+  Proof. reflexivity. Qed.
+
+  (* A proof that the the full-adder is correct. *)
+  Lemma xilinxFullAdder_behaviour :
+    forall (a : bool) (b : bool) (cin : bool),
+          combinational (xilinxFullAdder cin (a, b))
+          = (xorb cin (xorb a b),
+            (a && b) || (b && cin) || (a && cin)).
+  Proof.
+    intros.
+    unfold combinational.
+    unfold fst.
+    simpl.
+    case a, b, cin.
+    all : reflexivity.
+  Qed.
+
+End WithCombinational.  

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -21,11 +21,39 @@ From Coq Require Import Vectors.Vector.
 From Cava Require Import Kind.
 From Cava Require Import VectorUtils.
 
+(******************************************************************************)
+(* The types of signals that can flow over wires, used to index signal        *)
+(******************************************************************************)
+
 Inductive SignalType :=
   | Void : SignalType                              (* An empty type *)
   | Bit : SignalType                               (* A single wire *)
   | Vec : SignalType -> nat -> SignalType          (* Vectors, possibly nested *)
   | ExternalType : string -> SignalType.           (* An uninterpreted type *)
+
+(******************************************************************************)
+(* Combinational denotion of the SignalType and default values.               *)
+(******************************************************************************)
+
+Fixpoint combType (t: SignalType) : Type :=
+  match t with
+  | Void => unit
+  | Bit => bool
+  | Vec vt sz => Vector.t (combType vt) sz
+  | ExternalType _ => unit (* No semantics for combinational interpretation. *)
+  end.
+
+Fixpoint defaultCombValue (t: SignalType) : combType t :=
+  match t  with
+  | Void => tt
+  | Bit => false
+  | Vec t2 sz => Vector.const (defaultCombValue t2) sz
+  | ExternalType _ => tt
+  end.
+
+(******************************************************************************)
+(* Netlist AST representation for signal expressions.                         *)
+(******************************************************************************)
 
 Inductive Signal : SignalType -> Type :=
   | UndefinedSignal : Signal Void

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -21,38 +21,49 @@ From Coq Require Import Vectors.Vector.
 From Cava Require Import Kind.
 From Cava Require Import VectorUtils.
 
-Inductive Signal : Kind -> Type :=
+Inductive SignalType :=
+  | Void : SignalType                              (* An empty type *)
+  | Bit : SignalType                               (* A single wire *)
+  | Vec : SignalType -> nat -> SignalType          (* Vectors, possibly nested *)
+  | ExternalType : string -> SignalType            (* An uninterpreted type *)
+  | Pair : SignalType -> SignalType -> SignalType. (* A tuple *)
+
+Inductive Signal : SignalType -> Type :=
   | UndefinedSignal : Signal Void
   | UninterpretedSignal: forall {t: string}, string -> Signal (ExternalType t)
   | UninterpretedSignalIndex: forall (t: string), N -> Signal (ExternalType t)
-  | SelectField: forall {k1: Kind} (k2: Kind), Signal k1 -> string -> Signal k2
+  | SelectField: forall {t1: SignalType} (t2: SignalType), Signal t1 -> string -> Signal t2
   | Gnd: Signal Bit
   | Vcc: Signal Bit
   | Wire: N -> Signal Bit
   | NamedWire: string -> Signal Bit
-  | NamedVector: forall k s, string -> Signal (Vec k s)
-  | LocalVec: forall k s, N -> Signal (Vec k s)
-  | VecLit: forall {k s}, Vector.t (Signal k) s -> Signal (Vec k s)
+  | NamedVector: forall t s, string -> Signal (Vec t s)
+  | LocalVec: forall t s, N -> Signal (Vec t s)
+  | VecLit: forall {t s}, Vector.t (Signal t) s -> Signal (Vec t s)
+  | MkPair : forall {A B : SignalType}, Signal A -> Signal B -> Signal (Pair A B)
   (* Dynamic index *)
-  | IndexAt:  forall {k sz isz}, Signal (Vec k sz) ->
-              Signal (Vec Bit isz) -> Signal k
+  | IndexAt:  forall {t sz isz}, Signal (Vec t sz) ->
+              Signal (Vec Bit isz) -> Signal t
   (* Static indexing *)
-  | IndexConst: forall {k sz}, Signal (Vec k sz) -> nat -> Signal k
+  | IndexConst: forall {t sz}, Signal (Vec t sz) -> nat -> Signal t
   (* Static slice *)
-  | Slice: forall {k sz} (start len: nat), Signal (Vec k sz) ->
-                                           Signal (Vec k len).
+  | Slice: forall {t sz} (start len: nat), Signal (Vec t sz) ->
+                                           Signal (Vec t len).
 
-(* A default unsmashed value for a given Kind. *)
-Fixpoint defaultKindSignal (k: Kind) : Signal k :=
-  match k with
+Definition denoteSignal (t : SignalType) : Type := Signal t.
+
+(* A default value for a given SignalType. *)
+Fixpoint defaultSignal (t: SignalType) : Signal t :=
+  match t with
   | Void => UndefinedSignal
   | Bit => Gnd
-  | Vec k s => VecLit (Vector.const (defaultKindSignal k) s)
-  | ExternalType s => UninterpretedSignal "default-error"
+  | Vec vt s => VecLit (Vector.const (defaultSignal vt) s)
+  | ExternalType s => UninterpretedSignal "default-defaultSignal"
+  | Pair t1 t2 => MkPair (defaultSignal t1) (defaultSignal t2)
   end.
 
-(* To allow us to represent a heterogenous list of Signal k values where
-   the Kind k varies we make a wrapper that erase the Kind index type.
+(* To allow us to represent a heterogenous list of Signal t values where
+   the Signal t varies we make a wrapper that erase the Kind index type.
 *)
 Inductive UntypedSignal := USignal : forall {Kind}, Signal Kind -> UntypedSignal.
 

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -25,8 +25,7 @@ Inductive SignalType :=
   | Void : SignalType                              (* An empty type *)
   | Bit : SignalType                               (* A single wire *)
   | Vec : SignalType -> nat -> SignalType          (* Vectors, possibly nested *)
-  | ExternalType : string -> SignalType            (* An uninterpreted type *)
-  | Pair : SignalType -> SignalType -> SignalType. (* A tuple *)
+  | ExternalType : string -> SignalType.           (* An uninterpreted type *)
 
 Inductive Signal : SignalType -> Type :=
   | UndefinedSignal : Signal Void
@@ -40,7 +39,6 @@ Inductive Signal : SignalType -> Type :=
   | NamedVector: forall t s, string -> Signal (Vec t s)
   | LocalVec: forall t s, N -> Signal (Vec t s)
   | VecLit: forall {t s}, Vector.t (Signal t) s -> Signal (Vec t s)
-  | MkPair : forall {A B : SignalType}, Signal A -> Signal B -> Signal (Pair A B)
   (* Dynamic index *)
   | IndexAt:  forall {t sz isz}, Signal (Vec t sz) ->
               Signal (Vec Bit isz) -> Signal t
@@ -59,11 +57,9 @@ Fixpoint defaultSignal (t: SignalType) : Signal t :=
   | Bit => Gnd
   | Vec vt s => VecLit (Vector.const (defaultSignal vt) s)
   | ExternalType s => UninterpretedSignal "default-defaultSignal"
-  | Pair t1 t2 => MkPair (defaultSignal t1) (defaultSignal t2)
   end.
 
 (* To allow us to represent a heterogenous list of Signal t values where
    the Signal t varies we make a wrapper that erase the Kind index type.
 *)
 Inductive UntypedSignal := USignal : forall {Kind}, Signal Kind -> UntypedSignal.
-

--- a/monad-examples/FullAdder.v
+++ b/monad-examples/FullAdder.v
@@ -101,7 +101,7 @@ Definition fullAdder_tb_inputs :=
 ].
 
 Definition fullAdder_tb_expected_outputs
-   := map (fun (i : bool * bool * bool) => combinational (fullAdderTop i)) fullAdder_tb_inputs.
+   := map (fun i => combinational (fullAdderTop i)) fullAdder_tb_inputs.
 
 Definition fullAdder_tb
   := testBench "fullAdder_tb" fullAdderInterface

--- a/monad-examples/Multiplexers.v
+++ b/monad-examples/Multiplexers.v
@@ -32,125 +32,66 @@ From Coq Require Import NArith.Ndigits.
 
 Local Open Scope vector_scope.
 
-Definition mux2_1 {m bit} `{Cava m bit} (sab: bit * (bit * bit)) : m bit :=
-  let '(sel, (a, b)) := sab in
-  ret (indexBitAt ([a; b]) [sel]).
+Section WithCava.
+  Context {signal} `{Cava signal} `{Monad cava}.
+
+Definition mux2_1 (sab: signal Bit * signal Bit * signal Bit) : cava (signal Bit) :=
+  let '(sel, a, b) := sab in
+  ret (indexAt (unpeel [a; b]) (unpeel [sel])).
+
+  (* Mux between input buses *)
+
+  Definition muxBus {dsz sz isz: nat}
+                     (vsel: signal (Vec (Vec Bit dsz) sz) *
+                           signal (Vec Bit isz)) :
+                      cava (signal (Vec Bit dsz)) :=
+    let (v, sel) := vsel in
+    ret (indexAt v sel).
+
+End WithCava.
 
 Local Close Scope vector_scope.
 
-Example m1: combinational (mux2_1 (false, (false, true))) = false.
+(******************************************************************************)
+(* mux2_1                                                                     *)
+(******************************************************************************)
+
+Example m1: combinational (mux2_1 (false, false, true)) = false.
 Proof. reflexivity. Qed.
 
-Example m2: combinational (mux2_1 (false, (true, false))) = true.
+Example m2: combinational (mux2_1 (false, true, false)) = true.
 Proof. reflexivity. Qed.
 
-Example m3: combinational (mux2_1 (true, (false, true))) = true.
+Example m3: combinational (mux2_1 (true, false, true)) = true.
 Proof. reflexivity. Qed.
 
-Example m4: combinational (mux2_1 (true, (true, false))) = false.
+Example m4: combinational (mux2_1 (true, true, false)) = false.
 Proof. reflexivity. Qed.
 
 Definition mux2_1_Interface
   := combinationalInterface "mux2_1"
-     (mkPort "sel" Bit, (mkPort "i0" Bit, mkPort "i1" Bit))
-     (mkPort "o" Bit)
+     [mkPort "sel" Bit; mkPort "i0" Bit; mkPort "i1" Bit]
+     [mkPort "o" Bit]
      [].
 
 Definition mux2_1Netlist := makeNetlist mux2_1_Interface mux2_1.
 
 Definition mux2_1_tb_inputs :=
-  [(false, (false, true));
-   (false, (true, false));
-   (true, (false, true));
-    (true, (true, false))].
+  [(false, false, true);
+   (false, true,  false);
+   (true,  false, true);
+   (true,  true,  false)].
 
 Definition mux2_1_tb_expected_outputs
-  := map (fun i => combinational (mux2_1 i)) mux2_1_tb_inputs.
+  := map (fun (i : bool * bool * bool) => combinational (mux2_1 i)) mux2_1_tb_inputs.
 
 Definition mux2_1_tb
   := testBench "mux2_1_tb" mux2_1_Interface
      mux2_1_tb_inputs mux2_1_tb_expected_outputs.
 
- Section index_at_test.
-
-  (* Check the indexBitAt special case *)
-
-  Definition mux2_1_bit {m bit} `{Cava m bit} {sz isz: nat}
-                        (vsel: Vector.t bit sz * Vector.t bit isz) : m bit :=
-  let (v, sel) := vsel in
-  ret (indexBitAt v sel).
-
-   Definition v := N2Bv_sized 4  11.
-   (*
-   Bit pattern for 11:
-   -- 3 2 1 0 (bit position)
-   -- 8 4 2 1 (power)
-   -- 1 0 1 1 (bit pattern for 11)
-   *)
-
-   Definition i0 := N2Bv_sized 2 0.
-   Definition i1 := N2Bv_sized 2 1.
-   Definition i2 := N2Bv_sized 2 2.
-   Definition i3 := N2Bv_sized 2 3.
-
-   Example index_bit_0 : combinational (mux2_1_bit (v, i0)) = true.
-   Proof. reflexivity. Qed.
-
-   Example index_bit_1 : combinational (mux2_1_bit (v, i1)) = true.
-   Proof. reflexivity. Qed.
-
-   Example index_bit_2 : combinational (mux2_1_bit (v, i2)) = false.
-   Proof. reflexivity. Qed.
-
-   Example index_bit_3 : combinational (mux2_1_bit (v, i3)) = true.
-   Proof. reflexivity. Qed.
-
-  Definition mux2_1_bit_Interface
-    := combinationalInterface "mux2_1_bit"
-       (mkPort "v" (Vec Bit 4),
-        mkPort "sel" (Vec Bit 2))
-       (mkPort "o" Bit)
-       [].
-
-  Definition mux2_1_bit_Netlist := makeNetlist mux2_1_bit_Interface mux2_1_bit.
-
-  Definition mux2_1_bit_tb_inputs :=
-    [(v, i0);
-     (v, i1);
-     (v, i2);
-     (v, i3)].
-
-  Definition mux2_1_bit_tb_expected_outputs
-  := map (fun i => combinational (mux2_1_bit i)) mux2_1_bit_tb_inputs.
-
- Definition mux2_1_bit_tb
-  := testBench "mux2_1_bit_tb" mux2_1_bit_Interface
-     mux2_1_bit_tb_inputs mux2_1_bit_tb_expected_outputs.
-
- End index_at_test.
-
-(* Mux between input buses *)
-
-Definition muxBusAlt {m bit} `{Cava m bit} {k} {sz isz: nat}
-                     (vsel: smashTy bit (Vec k sz) *
-                            Vector.t bit isz) :
-                     m (smashTy bit k) :=
-  let (v, sel) := vsel in
-  ret (indexAt v sel).
-
-Definition muxBus {m bit} `{Cava m bit} {sz isz dsz: nat}
-                     (vsel: Vector.t (smashTy bit (Vec Bit dsz)) sz *
-                            Vector.t bit isz) :
-                     m (smashTy bit (Vec Bit dsz)) :=
-  let (v, sel) := vsel in
-  ret (indexAt v sel).
-
-Definition muxBus4_8 {m bit} `{Cava m bit}
-                     (vsel: Vector.t (smashTy bit (Vec Bit 8)) 4 *
-                            Vector.t bit 2) :
-                     m (smashTy bit (Vec Bit 8)) :=
-  let (v, sel) := vsel in
-  ret (indexAt v sel).
+(******************************************************************************)
+(* muxBus                                                                     *)
+(******************************************************************************)
 
 Local Open Scope vector_scope.
 Definition v0 := N2Bv_sized 8   5.
@@ -175,21 +116,22 @@ Local Close Scope vector_scope.
 
 Definition muxBus4_8Interface
   := combinationalInterface "muxBus4_8"
-     (mkPort "i" (Vec (Vec Bit 8) 4), mkPort "sel" (Vec Bit 2))
-     (mkPort "o" (Vec Bit 8))
+     [mkPort "i" (Vec (Vec Bit 8) 4); mkPort "sel" (Vec Bit 2)]
+     [mkPort "o" (Vec Bit 8)]
      [].
 
-Definition muxBus4_8Netlist := makeNetlist muxBus4_8Interface muxBus4_8.
+Definition muxBus4_8Netlist := makeNetlist muxBus4_8Interface muxBus.
 
-Definition muxBus4_8_tb_inputs :=
+Definition muxBus4_8_tb_inputs : list (Vector.t (Bvector 8) 4 * Vector.t bool 2) :=
   [(v0to3, [false; false]%vector);
    (v0to3, [true;  false]%vector);
    (v0to3, [false; true]%vector);
    (v0to3, [true; true]%vector)
   ].
 
-Definition muxBus4_8_tb_expected_outputs
-  := map (fun i => combinational (muxBus i)) muxBus4_8_tb_inputs.
+Definition muxBus4_8_tb_expected_outputs : list (Bvector 8)
+  := map (fun (i : Vector.t (Bvector 8) 4 * Vector.t bool 2) =>
+          combinational (muxBus i)) muxBus4_8_tb_inputs.
 
 Definition muxBus4_8_tb
   := testBench "muxBus4_8_tb" muxBus4_8Interface

--- a/monad-examples/Multiplexers.v
+++ b/monad-examples/Multiplexers.v
@@ -83,7 +83,7 @@ Definition mux2_1_tb_inputs :=
    (true,  true,  false)].
 
 Definition mux2_1_tb_expected_outputs
-  := map (fun (i : bool * bool * bool) => combinational (mux2_1 i)) mux2_1_tb_inputs.
+  := map (fun i => combinational (mux2_1 i)) mux2_1_tb_inputs.
 
 Definition mux2_1_tb
   := testBench "mux2_1_tb" mux2_1_Interface
@@ -130,8 +130,7 @@ Definition muxBus4_8_tb_inputs : list (Vector.t (Bvector 8) 4 * Vector.t bool 2)
   ].
 
 Definition muxBus4_8_tb_expected_outputs : list (Bvector 8)
-  := map (fun (i : Vector.t (Bvector 8) 4 * Vector.t bool 2) =>
-          combinational (muxBus i)) muxBus4_8_tb_inputs.
+  := map (fun i => combinational (muxBus i)) muxBus4_8_tb_inputs.
 
 Definition muxBus4_8_tb
   := testBench "muxBus4_8_tb" muxBus4_8Interface

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -35,7 +35,7 @@ Local Open Scope string_scope.
 Section WithCava.
   Context {signal} `{Cava signal} `{Monad cava}.
 
-  (* NAND gate example. Fist, let's define an overloaded NAND gate
+  (* NAND gate example. First, let's define an overloaded NAND gate
      description. *)
   Definition nand2_gate : signal Bit * signal Bit -> cava (signal Bit) :=
      and2 >=> inv.

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -89,7 +89,7 @@ Definition nand_tb_inputs : list (bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition nand_tb_expected_outputs : list bool :=
-  map (fun (i : bool * bool) => combinational (nand2_gate i)) nand_tb_inputs.
+  map (fun i => combinational (nand2_gate i)) nand_tb_inputs.
 
 Definition nand2_tb :=
   testBench "nand2_tb" nand2Interface nand_tb_inputs nand_tb_expected_outputs.

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -32,17 +32,34 @@ Local Open Scope list_scope.
 Local Open Scope monad_scope.
 Local Open Scope string_scope.
 
-(* NAND gate example. Fist, let's define an overloaded NAND gate
-   description. *)
+Section WithCava.
+  Context {signal} `{Cava signal} `{Monad cava}.
+
+  (* NAND gate example. Fist, let's define an overloaded NAND gate
+     description. *)
+  Definition nand2_gate : signal Bit * signal Bit -> cava (signal Bit) :=
+     and2 >=> inv.
+
+ (* A nand-gate with registers after the AND gate and the INV gate. *)
+  Definition pipelinedNAND :=
+    nand2_gate >=> delayBit >=> inv >=> delayBit.
+
+ (* An contrived example of loopBit *)     
+  Definition loopedNAND :=
+    loopBit (second delayBit >=> nand2 >=> fork2).
+
+End WithCava.
+
+(******************************************************************************)
+(* NAND-gate netlist with tests.                                              *)
+(******************************************************************************)
 
 Definition nand2Interface
   := combinationalInterface
-     "nand2"
-     (mkPort "a" Bit, mkPort "b" Bit)
-     (mkPort "c" Bit)
-     [].
-
-Definition nand2_gate {m t} `{Cava m t} := and2 >=> inv.
+    "nand2"
+    [mkPort "a" Bit; mkPort "b" Bit]
+    [mkPort "c" Bit]
+    [].
 
 Definition nand2Netlist := makeNetlist nand2Interface nand2_gate.
 
@@ -72,23 +89,20 @@ Definition nand_tb_inputs : list (bool * bool) :=
 
 (* Compute expected outputs. *)
 Definition nand_tb_expected_outputs : list bool :=
-  map (fun i => combinational (nand2_gate i)) nand_tb_inputs.
+  map (fun (i : bool * bool) => combinational (nand2_gate i)) nand_tb_inputs.
 
 Definition nand2_tb :=
   testBench "nand2_tb" nand2Interface nand_tb_inputs nand_tb_expected_outputs.
 
 (******************************************************************************)
-(* A nand-gate with registers after the AND gate and the INV gate.            *)
+(* Netlist for a nand-gate with registers plus tests.                         *)
 (******************************************************************************)
-
-Definition pipelinedNAND {m t} `{Cava m t}
-  := nand2_gate >=> delayBit >=> inv >=> delayBit.
 
 Definition pipelinedNANDInterface
   := sequentialInterface "pipelinedNAND"
      "clk" PositiveEdge "rst" PositiveEdge
-     (mkPort "a" Bit, mkPort "b" Bit)
-     (mkPort "c"  Bit)
+     [mkPort "a" Bit; mkPort "b" Bit]
+     [mkPort "c"  Bit]
      [].
 
 Definition pipelinedNANDNetlist :=
@@ -114,14 +128,11 @@ Definition pipelinedNAND_tb
 (* An contrived example of loopBit                                            *)
 (******************************************************************************)
 
-Definition loopedNAND {m bit} `{Cava m bit}
-  := loopBit (second delayBit >=> nand2 >=> fork2).
-
 Definition loopedNANDInterface
   := sequentialInterface "loopedNAND"
      "clk" PositiveEdge "rst" PositiveEdge
-     (mkPort "a" Bit)
-     (mkPort "b" Bit)
+     [mkPort "a" Bit]
+     [mkPort "b" Bit]
      [].
 
 Definition loopedNANDNetlist := makeNetlist loopedNANDInterface loopedNAND.
@@ -182,3 +193,4 @@ Definition loopedNAND_tb
                  110 a = 1, b = 1
                  120 a = 1, b = 0
 *)
+

--- a/monad-examples/Sorter.v
+++ b/monad-examples/Sorter.v
@@ -89,4 +89,3 @@ Definition twoSorterSpec {bw: nat} (ab : Vector.t (Bvector bw) 2) :
     [b; a]
   else
     [a; b].
-

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -57,15 +57,27 @@ Proof. reflexivity. Qed.
 Example add15_1 : combinational (addN bv4_15 bv4_1) = bv4_0.
 Proof. reflexivity. Qed.
 
-(******************************************************************************)
-(* Unsigned addition with growth examples.                                                *)
-(******************************************************************************)
+Section WithCava.
+  Context {signal} `{Cava signal} `{Monad cava}.
 
-Definition adderGrowth {m bit} `{Cava m bit} {aSize bSize: nat}
-                       (ab: Vector.t bit aSize * Vector.t bit bSize) :
-                       m (Vector.t bit (1 + max aSize bSize)) :=
-  let (a, b) := ab in
-  unsignedAdd a b.
+  (****************************************************************************)
+  (* Unsigned addition with growth examples.                                              *)
+  (****************************************************************************)
+
+  Definition adderGrowth {aSize bSize: nat}
+                        (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)) :
+                        cava (signal (Vec Bit (1 + max aSize bSize))) :=
+    let (a, b) := ab in
+    unsignedAdd a b.
+
+  Definition add3InputTuple (aSize bSize cSize: nat)
+                            (abc: signal (Vec Bit aSize) *
+                                  signal (Vec Bit bSize)*
+                                  signal (Vec Bit cSize)) :
+                           cava (signal (Vec Bit (1 + max (1 + max aSize bSize) cSize))) :=
+  let '(a, b, c) := abc in adder_3input a b c.
+
+End WithCava.
 
 (* Check 0 + 0 = 0 *)
 Example add5_0_0 : combinational (adderGrowth (bv4_0, bv4_0)) = bv5_0.
@@ -91,8 +103,8 @@ Local Open Scope nat_scope.
 
 Definition adder4Interface
   := combinationalInterface "adder4"
-     (mkPort "a" (Vec Bit 4), mkPort "b" (Vec Bit 4))
-     (mkPort "sum" (Vec Bit 5))
+     [mkPort "a" (Vec Bit 4); mkPort "b" (Vec Bit 4)]
+     [mkPort "sum" (Vec Bit 5)]
      [].
 
 Definition adder4Netlist
@@ -101,8 +113,13 @@ Definition adder4Netlist
 Definition adder4_tb_inputs
   := [(bv4_0, bv4_0); (bv4_1, bv4_2); (bv4_15, bv4_1); (bv4_15, bv4_15)].
 
+Section WithCava.
+  Context {signal} `{Cava signal} `{Monad ident}.
+
 Definition adder4_tb_expected_outputs
   := map (fun '(a, b) => combinational (unsignedAdd a b)) adder4_tb_inputs.
+
+End WithCava.
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface
@@ -114,17 +131,11 @@ Definition adder4_tb
 
 Definition adder8_3inputInterface
   := combinationalInterface "adder8_3input"
-     (mkPort "a" (Vec Bit 8), mkPort "b" (Vec Bit 8), mkPort "c" (Vec Bit 8))
-     (mkPort "sum" (Vec Bit 10))
+     [mkPort "a" (Vec Bit 8); mkPort "b" (Vec Bit 8); mkPort "c" (Vec Bit 8)]
+     [mkPort "sum" (Vec Bit 10)]
      [].
 
-Definition add3InputTuple {m bit} `{Cava m bit}
-                          (aSize bSize cSize: nat)
-                          (abc: Vector.t bit aSize *
-                                Vector.t bit bSize *
-                                Vector.t bit cSize) :
-                          m (Vector.t bit (1 + max (1 + max aSize bSize) cSize)) :=
-  let '(a, b, c) := abc in adder_3input a b c.
+
 
 Definition adder8_3inputNetlist
   := makeNetlist adder8_3inputInterface (add3InputTuple 8 8 8).

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -113,13 +113,8 @@ Definition adder4Netlist
 Definition adder4_tb_inputs
   := [(bv4_0, bv4_0); (bv4_1, bv4_2); (bv4_15, bv4_1); (bv4_15, bv4_15)].
 
-Section WithCava.
-  Context {signal} `{Cava signal} `{Monad ident}.
-
 Definition adder4_tb_expected_outputs
   := map (fun '(a, b) => combinational (unsignedAdd a b)) adder4_tb_inputs.
-
-End WithCava.
 
 Definition adder4_tb
   := testBench "adder4_tb" adder4Interface
@@ -134,8 +129,6 @@ Definition adder8_3inputInterface
      [mkPort "a" (Vec Bit 8); mkPort "b" (Vec Bit 8); mkPort "c" (Vec Bit 8)]
      [mkPort "sum" (Vec Bit 10)]
      [].
-
-
 
 Definition adder8_3inputNetlist
   := makeNetlist adder8_3inputInterface (add3InputTuple 8 8 8).

--- a/monad-examples/xilinx/NandLUT.v
+++ b/monad-examples/xilinx/NandLUT.v
@@ -25,15 +25,16 @@ Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Monad.XilinxAdder.
 
-Definition lutNAND {m bit} `{Cava m bit} (i0i1 : bit * bit) : m bit :=
+Definition lutNAND {signal} `{Cava signal} `{Monad cava}
+           (i0i1 : signal Bit * signal Bit) : cava (signal Bit) :=
   x <- lut2 (andb) i0i1 ;;
   z <- lut1 (negb) x ;;
   ret z.
 
 Definition lutNANDInterface
   := combinationalInterface "lutNAND"
-     (mkPort "a"  Bit, mkPort "b" Bit)
-     (mkPort "c" Bit)
+     [mkPort "a"  Bit; mkPort "b" Bit]
+     [mkPort "c" Bit]
      [].
 
 Definition lutNANDNetlist := makeNetlist lutNANDInterface lutNAND.

--- a/silveroak-opentitan/aes/Arrow/netlists.v
+++ b/silveroak-opentitan/aes/Arrow/netlists.v
@@ -23,21 +23,21 @@ From Aes Require Import pkg sbox unrolled_opentitan_cipher.
 Require Import Cava.Types.
 Require Import Cava.Netlist.
 
-Definition sbox_canright_interface
-  := combinationalInterface "sbox_canright"
-     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8))
-     (mkPort "data_o" (Kind.Vec Kind.Bit 8))
-     nil.
+(* Definition sbox_canright_interface *)
+(*   := combinationalInterface "sbox_canright" *)
+(*      (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8)) *)
+(*      (mkPort "data_o" (Kind.Vec Kind.Bit 8)) *)
+(*      nil. *)
 
-Definition sbox_canright_netlist :=
-  makeNetlist sbox_canright_interface (build_netlist (closure_conversion (aes_sbox SboxCanright))).
+(* Definition sbox_canright_netlist := *)
+(*   makeNetlist sbox_canright_interface (build_netlist (closure_conversion (aes_sbox SboxCanright))). *)
 
-Definition sbox_lut_interface
-  := combinationalInterface "sbox_lut"
-     (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8))
-     (mkPort "data_o" (Kind.Vec Kind.Bit 8))
-     nil.
+(* Definition sbox_lut_interface *)
+(*   := combinationalInterface "sbox_lut" *)
+(*      (mkPort "op_i" Kind.Bit, mkPort "data_i" (Kind.Vec Kind.Bit 8)) *)
+(*      (mkPort "data_o" (Kind.Vec Kind.Bit 8)) *)
+(*      nil. *)
 
-Definition sbox_lut_netlist :=
-  makeNetlist sbox_lut_interface (build_netlist (closure_conversion (aes_sbox SboxLut))).
+(* Definition sbox_lut_netlist := *)
+(*   makeNetlist sbox_lut_interface (build_netlist (closure_conversion (aes_sbox SboxLut))). *)
 

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -31,6 +31,19 @@ Require Import Omega.
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
 
+Section WithCava.
+  Context {signal} `{Cava signal} `{Monad cava}.
+
+  (* A top-level multiplier circuit that can be compiled to a top-level
+    SystemVerilog circuit. *)
+  Definition multiplier {aSize bSize: nat}
+                        (ab: signal (Vec Bit aSize) * signal (Vec Bit bSize)):
+                        cava (signal (Vec Bit (aSize + bSize))) :=
+    let (a, b) := ab in
+    unsignedMult a b.
+
+End WithCava.
+
 Definition bv2_0  := N2Bv_sized 2  0.
 Definition bv2_3  := N2Bv_sized 2  3.
 Definition bv3_0  := N2Bv_sized 3  0.
@@ -41,14 +54,6 @@ Definition bv5_15 := N2Bv_sized 5 15.
 (* Check 3 * 5 = 30 *)
 Example mult3_5 : combinational (unsignedMult bv2_3 bv3_5) = bv5_15.
 Proof. reflexivity. Qed.
-
-(* A top-level multiplier circuit that can be compiled to a top-level
-   SystemVerilog circuit. *)
-Definition multiplier {m bit} `{Cava m bit} {aSize bSize: nat}
-                      (ab: Vector.t bit aSize * Vector.t bit bSize) :
-                      m (Vector.t bit (aSize + bSize)) :=
-  let (a, b) := ab in
-  unsignedMult a b.
 
 (* Check 3 * 5 = 30 *)
 Example mult3_5_top : combinational (multiplier (bv2_3, bv3_5)) = bv5_15.
@@ -62,8 +67,8 @@ Local Open Scope nat_scope.
 
 Definition mult2_3_5Interface
   := combinationalInterface "mult2_3_5"
-     (mkPort "a" (Vec Bit 2), mkPort "b" (Vec Bit 3))
-     (mkPort "product" (Vec Bit 5))
+     [mkPort "a" (Vec Bit 2); mkPort "b" (Vec Bit 3)]
+     [mkPort "product" (Vec Bit 5)]
      [].
 
 Definition mult2_3_5Netlist


### PR DESCRIPTION
This is a major overhaul of how the circuit interface descriptions work for the Acorn monad-kernel for Cava. Changes include:

* A different representation for the circuit's input and output ports, which are now expressed with a *list* of port declarations. The corresponding circuit works over inputs and outputs that correspond to a flat _n_-tuple that matches the length port specification _n_-list.
* The types for netlist generation, testbench generation, hierarchical instantiation and black box components are impact as a result.
* The type changes do away with vector smashing and all top-level circuits.