### PR TITLE
Acorn add round key equivalence

### DIFF
--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -1,0 +1,71 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Vectors.Vector.
+Require Import ExtLib.Structures.Monad.
+Require Import Cava.Acorn.Combinational.
+Require Import Cava.Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornCombinators.
+Require Import Cava.Acorn.Lib.AcornVectors.
+Require Import Cava.Tactics.
+Require Import Cava.VectorUtils.
+
+Existing Instance Combinational.
+
+(* Lemmas about combinators specialized to the identity monad *)
+Section Combinators.
+  Lemma zipWith_unIdent {A B C : SignalType} n f va vb :
+    unIdent (@zipWith _ _ Monad_ident A B C n f va vb)
+    = map2 (fun a b => unIdent (f (a,b))) va vb.
+  Proof.
+    cbv [zipWith Traversable.mapT Traversable_vector].
+    cbn [peel unpeel Combinational].
+    revert va vb; induction n; intros; [ apply nil_eq | ].
+    cbn [vcombine]. rewrite (eta va), (eta vb).
+    autorewrite with push_vector_map vsimpl.
+    rewrite <-IHn. reflexivity.
+  Qed.
+End Combinators.
+
+
+Section Vectors.
+  Lemma xorV_unIdent n ab :
+    unIdent (@xorV _ _ Monad_ident n ab) = map2 xorb (fst ab) (snd ab).
+  Proof.
+    cbv [xorV Traversable.mapT Traversable_vector].
+    cbn [peel unpeel Combinational]. destruct ab as [a b].
+    revert a b; induction n; intros; [ apply nil_eq | ].
+    cbn [vcombine]. rewrite (eta a), (eta b).
+    autorewrite with push_vector_map vsimpl.
+    cbn [fst snd] in *.
+    rewrite <-IHn. reflexivity.
+  Qed.
+End Vectors.
+
+(* Automation to help simplify expressions using the identity monad *)
+Create HintDb simpl_ident discriminated.
+Hint Rewrite @zipWith_unIdent @xorV_unIdent
+     using solve [eauto]: simpl_ident.
+Ltac simpl_ident :=
+  repeat
+    first [ progress autorewrite with simpl_ident
+          | erewrite map2_ext; [ | intros; progress simpl_ident;
+                                   instantiate_app_by_reflexivity ]
+          | erewrite map_ext; [ | intros; progress simpl_ident;
+                                  instantiate_app_by_reflexivity ]
+          | erewrite fold_left_ext; [ | intros; progress simpl_ident;
+                                        instantiate_app_by_reflexivity ]
+          | progress cbn [fst snd mcompose bind ret Monad_ident unIdent] ].

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -568,6 +568,32 @@ Section VectorFacts.
     rewrite IHn. reflexivity.
   Qed.
 
+  Lemma map2_append {A B C} (f : A -> B -> C) n m
+        (va1 : t A n) (va2 : t A m) vb1 vb2 :
+    (map2 f (va1 ++ va2) (vb1 ++ vb2) = map2 f va1 vb1 ++ map2 f va2 vb2)%vector.
+  Proof.
+    revert m va1 va2 vb1 vb2. induction n; intros.
+    { eapply case0 with (v:=va1).
+      eapply case0 with (v:=vb1).
+      reflexivity. }
+    { cbn [Nat.add]. rewrite (eta va1), (eta vb1).
+      rewrite <-!append_comm_cons.
+      rewrite !map2_cons, ?hd_cons, ?tl_cons.
+      rewrite IHn. reflexivity. }
+  Qed.
+
+  Lemma map2_flatten {A B C} (f : A -> B -> C) n m
+        (va : t (t A n) m) (vb : t (t B n) m) :
+    map2 f (flatten va) (flatten vb) = flatten (map2 (map2 f) va vb).
+  Proof.
+    revert va vb; induction m; intros; [ apply nil_eq | ].
+    cbn [flatten Nat.mul]. rewrite (eta va), (eta vb).
+    rewrite !uncons_cons.
+    rewrite !map2_cons, ?hd_cons, ?tl_cons.
+    rewrite map2_append.
+    rewrite IHm. reflexivity.
+  Qed.
+
   Lemma hd_snoc {A} n (v : t A (S n)) x :
     hd (snoc v x) = hd v.
   Proof. rewrite (eta v). reflexivity. Qed.
@@ -761,11 +787,11 @@ Hint Rewrite @tl_0 @hd_0 @tl_cons @hd_cons @last_tl
      using solve [eauto] : push_vector_tl_hd_last vsimpl.
 Hint Rewrite @nth_order_hd @nth_order_last
      using solve [eauto] : push_vector_nth_order vsimpl.
-Hint Rewrite @map2_0 @map_0 @map_to_const
+Hint Rewrite @map2_0 @map_0 @map_to_const @map2_append
      using solve [eauto] : push_vector_map vsimpl.
 Hint Rewrite @resize_default_id @Vector.map_id
      using solve [eauto] : vsimpl.
-Hint Rewrite @to_list_cons @to_list_nil
+Hint Rewrite @to_list_cons @to_list_nil @uncons_cons
      using solve [eauto] : vsimpl.
 
 
@@ -781,7 +807,7 @@ Hint Rewrite @map_cons @map2_cons
    databases *)
 Hint Rewrite <- @reverse_map2 @snoc_map2 @unsnoc_map2 @snoc_map @unsnoc_map
      using solve [eauto] : push_vector_map.
-Hint Rewrite  @nth_map @map_to_const
+Hint Rewrite  @nth_map @map_to_const @map2_flatten
      using solve [eauto] : push_vector_map.
 
 (* [eauto] might not solve map_id_ext, so add more power to the strategy *)

--- a/cava/_CoqProject
+++ b/cava/_CoqProject
@@ -17,6 +17,7 @@ Cava/Tactics.v
 Cava/Acorn/AcornSignal.v
 Cava/Acorn/AcornCavaClass.v
 Cava/Acorn/Combinational.v
+Cava/Acorn/Identity.v
 Cava/Acorn/AcornNetlist.v
 Cava/Acorn/AcornState.v
 Cava/Acorn/AcornNetlistGeneration.v

--- a/silveroak-opentitan/aes/Acorn/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKey.v
@@ -1,0 +1,43 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Vectors.Vector.
+
+Require Import ExtLib.Structures.Monads.
+
+From Cava Require Import VectorUtils.
+From Cava Require Import Acorn.Acorn.
+From Cava Require Import Acorn.Lib.AcornVectors.
+From AcornAes Require Import Common.
+Import Common.Notations.
+
+Section WithCava.
+  Context {signal} {cava : Cava signal}.
+  Context {monad: Monad m}.
+
+  (* Perform the bitwise XOR of two 4-element vectors of 8-bit values. *)
+  Definition xor4xV
+      (ab : signal (Vec (Vec Bit 8) 4) * signal (Vec (Vec Bit 8) 4))
+      : m (signal (Vec (Vec Bit 8) 4)) :=
+    zipWith xorV (fst ab) (snd ab).
+
+  (* Perform the bitwise XOR of two 4x4 matrices of 8-bit values. *)
+  Definition xor4x4V (a b : signal state) : m (signal state) :=
+    zipWith xor4xV a b.
+
+  Definition add_round_key (k : signal key) (st : signal state)
+    : m (signal state) := xor4x4V k st.
+End WithCava.

--- a/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKeyEquivalence.v
@@ -30,9 +30,9 @@ Require Import AcornAes.AddRoundKey.
 Existing Instance Combinational.
 
 Section Equivalence.
-  Local Notation byte := (t bool 8).
-  Local Notation state := (t (t byte 4) 4) (only parsing).
-  Local Notation key := (t (t byte 4) 4) (only parsing).
+  Local Notation byte := (Vector.t bool 8).
+  Local Notation state := (Vector.t (Vector.t byte 4) 4) (only parsing).
+  Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
 
   Lemma add_round_key_equiv (k : key) (st : state) :
     let to_words : state -> AddRoundKey.state 32 4 := map flatten in

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -36,8 +36,8 @@ Section WithSubroutines.
   Local Notation key := (t (t byte 4) 4) (only parsing).
   Context (sub_bytes:     state -> ident state)
           (shift_rows:    state -> ident state)
-          (mix_columns:   state -> ident state).
-  Let add_round_key : key -> state -> ident state := xor4x4V.
+          (mix_columns:   state -> ident state)
+          (add_round_key : key -> state -> ident state).
 
   Let sub_bytes' : state -> state := (fun st => unIdent (sub_bytes st)).
   Let shift_rows' : state -> state := (fun st => unIdent (shift_rows st)).
@@ -54,24 +54,8 @@ Section WithSubroutines.
     unIdent (cipher first_key last_key middle_keys input)
     = cipher_spec first_key last_key middle_keys input.
   Proof.
-    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key' add_round_key.
-    cbv [cipher cipher_round Cipher.cipher]. cbn [bind ret Monad_ident unIdent].
-    repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
-    eapply fold_left_preserves_relation; [ reflexivity | ].
-    intros; subst. reflexivity.
-  Qed.
-
-  Lemma cipher_alt_equiv
-        (first_key last_key : key) (middle_keys : list key) (input : state) :
-    let cipher := (cipher_alt sub_bytes shift_rows mix_columns add_round_key) in
-    let cipher_spec := (Cipher.cipher _ _ add_round_key'
-                                      sub_bytes' shift_rows' mix_columns') in
-    unIdent (cipher first_key last_key middle_keys input)
-    = cipher_spec first_key last_key middle_keys input.
-  Proof.
-    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key' add_round_key.
-    cbv [cipher_alt cipher_round Cipher.cipher].
-    cbn [bind ret Monad_ident unIdent mcompose].
+    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key'.
+    cbv [cipher cipher_round Cipher.cipher]. cbn [mcompose bind ret Monad_ident unIdent].
     repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
     eapply fold_left_preserves_relation; [ reflexivity | ].
     intros; subst. reflexivity.

--- a/silveroak-opentitan/aes/Acorn/Common.v
+++ b/silveroak-opentitan/aes/Acorn/Common.v
@@ -1,0 +1,22 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Cava Require Import Acorn.Acorn.
+
+Module Notations.
+  Notation state := (Vec (Vec (Vec Bit 8) 4) 4) (only parsing).
+  Notation key := (Vec (Vec (Vec Bit 8) 4) 4) (only parsing).
+End Notations.

--- a/silveroak-opentitan/aes/Acorn/_CoqProject
+++ b/silveroak-opentitan/aes/Acorn/_CoqProject
@@ -6,3 +6,5 @@ INSTALLDEFAULTROOT = AcornAes
 -R ../../../third_party/bedrock2/deps/coqutil/src/coqutil coqutil
 CipherRound.v
 CipherEquivalence.v
+AddRoundKey.v
+Common.v


### PR DESCRIPTION
Before doing the Acorn-based inverse cipher equivalence proof for #334, I did some cleanup of the forward proof. I separated out the add-round-key/xor part, and used our brand-new add-round-key spec to prove equivalence for that part of the cipher.