### PR TITLE
Add generation of interface tuple default values

### DIFF
--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -89,4 +89,8 @@ Class Cava (signal : SignalType -> Type) := {
                   cava (tupleInterface signal (map port_type (circuitOutputs intf)))) ->
                  tupleInterface signal (map port_type (circuitInputs intf)) ->
                  cava (tupleInterface signal ((map port_type (circuitOutputs intf))));
+  (* Instantiation of black-box components which return default values. *)
+  blackBox : forall (intf: CircuitInterface),
+             tupleInterface signal (map port_type (circuitInputs intf)) ->
+             cava (tupleInterface signal ((map port_type (circuitOutputs intf))));
 }.               

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -180,7 +180,7 @@ Definition loopBitBool (A B : SignalType) (f : combType A * bool -> ident (combT
   { cava := ident;
     zero := ret false;
     one := ret true;
-    defaultSignal := defaultCombValue;
+    defaultSignal t := @defaultCombValue t;
     delayBit i := ret i; (* Dummy definition for delayBit for now. *)
     loopBit a b := @loopBitBool a b;
     inv := notBool;
@@ -208,6 +208,7 @@ Definition loopBitBool (A B : SignalType) (f : combType A * bool -> ident (combT
     unsignedMult m n := @unsignedMultBool m n;
     greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
     instantiate _ circuit := circuit;
+    blackBox intf _ := ret (tupleInterfaceDefault (map port_type (circuitOutputs intf)));
 }.
 
 (******************************************************************************)

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -244,7 +244,7 @@ Definition instantiateNet (intf : CircuitInterface)
                           : state CavaState (tupleNetInterface (circuitOutputs intf)) :=
   let cs := makeNetlist intf circuit in
   addModule intf (module cs) ;;
-  x <- blackBox intf a ;;
+  x <- blackBoxNet intf a ;;
   ret x.
 
 (******************************************************************************)
@@ -284,4 +284,5 @@ Instance CavaNet : Cava denoteSignal :=
     unsignedMult m n := @unsignedMultNet m n;
     greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
     instantiate := instantiateNet;
+    blackBox := blackBoxNet;
 }.

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -520,9 +520,9 @@ Definition wireUpReset (c : option (Signal Bit)) (rstArgName: string) : list (st
   | Some rst => [(rstArgName, USignal rst)]
   end.
 
-Definition blackBox (intf : CircuitInterface)
-                    (inputs: tupleNetInterface (circuitInputs intf)) :
-                    state CavaState (tupleNetInterface (circuitOutputs intf)) :=
+Definition blackBoxNet (intf : CircuitInterface)
+                       (inputs: tupleNetInterface (circuitInputs intf)) :
+                       state CavaState (tupleNetInterface (circuitOutputs intf)) :=
   let inputPorts : list (string * UntypedSignal) := driveArguments (circuitInputs intf) inputs in
   '((optClk, _), (optRst, _)) <- getClockAndReset ;;
   outputSignals <- declareOutputs (circuitOutputs intf) ;;

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -65,7 +65,6 @@ Fixpoint tupleInterfaceR (signal: SignalType -> Type) (v : list SignalType) : Ty
   | x :: pds => signal x * tupleInterfaceR signal pds
   end.
 
-
 (* Left-associative tuples with no trailing unit. **)
 Fixpoint tupleInterface' (signal: SignalType -> Type) accum (l : list SignalType) : Type :=
   match l with
@@ -116,6 +115,17 @@ Definition unbalance (signal: SignalType -> Type)
   | [] => fun _ => tt
   | x::xs => unbalance' signal xs
   end.
+
+Local Open Scope type_scope.
+
+Fixpoint tupleInterfaceDefaultR (v : list SignalType) : tupleInterfaceR combType v :=
+  match v return tupleInterfaceR combType v with
+  | [] => tt
+  | x::xs => (defaultCombValue x, tupleInterfaceDefaultR xs)
+  end.
+
+Definition tupleInterfaceDefault (v : list SignalType) : tupleInterface combType v :=
+  rebalance combType v (tupleInterfaceDefaultR v).
 
 (******************************************************************************)
 (* Netlist AST representation for signal expressions.                         *)

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -116,7 +116,7 @@ Definition pinmux (inputs: Signal (ExternalType "tlul_pkg::tl_h2d_t") *
   let '(tl_i, periph_to_mio_i, periph_to_mio_oe_i, mio_in_i) := inputs in
   let const0 := Gnd in
   let const1 := Vcc in
-  '(tl_o, reg2hw) <- blackBox pinmux_reg_top_Interface (tl_i, const1) ;;
+  '(tl_o, reg2hw) <- blackBoxNet pinmux_reg_top_Interface (tl_i, const1) ;;
   (* Input Mux *)
   let data_in_mux := VecLit ([const0; const1] ++ peel mio_in_i) in
   let mio_to_periph_o :=


### PR DESCRIPTION
Needed for blackBox module instantiation to become an overloaded operation, with the combinational and sequential instantiations yielding default values for the behaviour of an unspecified external block (as currently used in the pinmux).