### PR TITLE
Trying out some sequential proofs

### DIFF
--- a/arrow-examples/SignalingCounter.v
+++ b/arrow-examples/SignalingCounter.v
@@ -17,6 +17,8 @@
 
 From Cava Require Import Arrow.ArrowExport.
 From Coq Require Import Lists.List NArith.NArith Strings.String.
+
+Require Import Cava.Tactics.
 Import ListNotations.
 
 Local Open Scope string_scope.
@@ -59,10 +61,59 @@ Definition signaling_counter_tb_inputs : list (bool * Bvector.Bvector 4) :=
 Definition signaling_counter_tb_expected_outputs : list (Bvector.Bvector 4) :=
   unroll_circuit_evaluation (closure_conversion counter) signaling_counter_tb_inputs.
 
+Definition first_order_counter := to_skappa' (counter : Kappa _ _).
+Goal wf_indexing [] first_order_counter.
+Proof. cbn; tauto. Qed.
+
 Lemma arrow_and_expr_counter_semantics_agree:
   (map Bv2N signaling_counter_tb_expected_outputs) =
   (map Bv2N (interp_sequential ((counter : Kappa _ _) _) signaling_counter_tb_inputs)).
 Proof. vm_compute; reflexivity. Qed.
+
+Lemma expr_single_step_counter_semantics_agree:
+  (map Bv2N signaling_counter_tb_expected_outputs) =
+  (map Bv2N (unroll_sequential_step first_order_counter signaling_counter_tb_inputs)).
+Proof. vm_compute; reflexivity. Qed.
+
+(* perhaps the structured state is actually not useful, as you then need to find
+* it in the tupled structure ... *)
+Definition proj_state_counter (state: skappa_state first_order_counter)
+  : Bvector.Bvector 4
+  := fst state.
+
+Lemma state_increases_on_input s i s':
+  i = (true, (N2Bv_sized _ 1, tt)) ->
+  N.to_nat (Bv2N (proj_state_counter s)) < 15 ->
+  (* exists o s', *)
+  fst (sequential_step' first_order_counter s i) = s'
+  ->
+  S (N.to_nat (Bv2N (proj_state_counter s))) = N.to_nat (Bv2N (proj_state_counter s')).
+Proof.
+  intros.
+  rewrite H in H1.
+  rewrite <- H1.
+  destruct s.
+  Ltac reduce := cbn [
+    unroll_sequential_step'
+    sequential_step' sequential_step
+    denote_apply_rightmost_tt
+    first_order_counter fst snd
+    sequential_step first_order_counter to_skappa' to_skappa counter module_body module_to_expr
+    app index_env denote_kind primitive_output nth_error
+    fst snd
+    proj_state_counter
+    ].
+  reduce; repeat destruct_pair_let.
+  cbn [proj_state_counter fst snd].
+
+  (* next steps ?????
+    context [(sequential_step
+              match mux_item with
+              ...]
+    is equal to some gallina function effectively (+1)
+    which should reduce to prove the goal
+    *)
+Admitted.
 
 Definition signaling_counter_tb :=
   testBench "signaling_counter_tb" signaling_counter_Interface


### PR DESCRIPTION
Testing out single step semantics (semantics on list exists already).

@jadephilipoom :
- The structured state is perhaps less useful as (without attempting to reduce the structure) its large with lots of `unit` values. A state based on lists might be more accessible when writing proofs.
- I added a small example lemma `state_increases_on_input` in the `signalingcounter` without finishing the proof. I wonder if providing some invariant in gallina that you can compute might be cleaner (or any other ideas you have!)