### PR TITLE
Absolutize imports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/bedrock2"]
 	path = third_party/bedrock2
 	url = https://github.com/mit-plv/bedrock2
+[submodule "third_party/coq-tools"]
+	path = third_party/coq-tools
+	url = https://github.com/JasonGross/coq-tools.git

--- a/arrow-examples/ArrowAdderTutorial.v
+++ b/arrow-examples/ArrowAdderTutorial.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Arrow.ArrowExport.
+Require Import Cava.Arrow.ArrowExport.
 
 Require Import Coq.Strings.String.
 Local Open Scope string_scope.
 
-From Coq Require Import Lists.List NArith.NArith micromega.Lia.
+Require Import Coq.Lists.List Coq.NArith.NArith Coq.micromega.Lia.
 Import ListNotations.
 
 Section notation.

--- a/arrow-examples/ArrowExtraction.v
+++ b/arrow-examples/ArrowExtraction.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Require Import coqutil.Z.HexNotation.
 

--- a/arrow-examples/Counter.v
+++ b/arrow-examples/Counter.v
@@ -15,8 +15,8 @@
 (****************************************************************************)
 
 
-From Cava Require Import Arrow.ArrowExport.
-From Coq Require Import Lists.List NArith.NArith Strings.String.
+Require Import Cava.Arrow.ArrowExport.
+Require Import Coq.Lists.List Coq.NArith.NArith Coq.Strings.String.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/Fir.v
+++ b/arrow-examples/Fir.v
@@ -14,8 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Arrow.ArrowExport.
-From Coq Require Import Lists.List NArith.NArith Strings.String Bool.Bvector.
+Require Import Cava.Arrow.ArrowExport.
+Require Import Coq.Lists.List Coq.NArith.NArith Coq.Strings.String Coq.Bool.Bvector.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/Mux2_1.v
+++ b/arrow-examples/Mux2_1.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Arrow.ArrowExport.
+Require Import Cava.Arrow.ArrowExport.
 
 Require Import Coq.Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/SignalingCounter.v
+++ b/arrow-examples/SignalingCounter.v
@@ -15,8 +15,8 @@
 (****************************************************************************)
 
 
-From Cava Require Import Arrow.ArrowExport.
-From Coq Require Import Lists.List NArith.NArith Strings.String.
+Require Import Cava.Arrow.ArrowExport.
+Require Import Coq.Lists.List Coq.NArith.NArith Coq.Strings.String.
 Import ListNotations.
 
 Local Open Scope string_scope.

--- a/arrow-examples/SyntaxExamples.v
+++ b/arrow-examples/SyntaxExamples.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Arrow.ArrowExport.
+Require Import Cava.Arrow.ArrowExport.
 
 Require Import Coq.Strings.String.
 Local Open Scope string_scope.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Section notation.

--- a/arrow-examples/UnsignedAdder.v
+++ b/arrow-examples/UnsignedAdder.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Arrow.ArrowExport.
+Require Import Cava.Arrow.ArrowExport.
 
-From Coq Require Import Strings.String Bool.Bvector Lists.List NArith.NArith
-     Init.Nat micromega.Lia Arith.Plus.
+Require Import Coq.Strings.String Coq.Bool.Bvector Coq.Lists.List Coq.NArith.NArith
+     Coq.Init.Nat Coq.micromega.Lia Coq.Arith.Plus.
 Import ListNotations.
 Import EqNotations.
 

--- a/cava/Cava/Acorn/Acorn.v
+++ b/cava/Cava/Acorn/Acorn.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-Require Export Acorn.AcornSignal.
-Require Export Acorn.AcornCavaClass.
-Require Export Acorn.AcornNetlist.
-Require Export Acorn.AcornState.
-Require Export Acorn.Combinational.
-Require Export Acorn.AcornNetlistGeneration.
-Require Export Acorn.Combinational.
-Require Export Acorn.AcornCombinators.
+Require Export Cava.Acorn.AcornSignal.
+Require Export Cava.Acorn.AcornCavaClass.
+Require Export Cava.Acorn.AcornNetlist.
+Require Export Cava.Acorn.AcornState.
+Require Export Cava.Acorn.Combinational.
+Require Export Cava.Acorn.AcornNetlistGeneration.
+Require Export Cava.Acorn.Combinational.
+Require Export Cava.Acorn.AcornCombinators.

--- a/cava/Cava/Acorn/AcornCavaClass.v
+++ b/cava/Cava/Acorn/AcornCavaClass.v
@@ -16,7 +16,7 @@
 
 Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornSignal.
 
 Open Scope type_scope.
 

--- a/cava/Cava/Acorn/AcornCombinators.v
+++ b/cava/Cava/Acorn/AcornCombinators.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 Local Open Scope vector_scope.
 Require Import ExtLib.Structures.Monads.
@@ -25,10 +25,10 @@ Require Import ExtLib.Structures.Traversable.
 Import MonadNotation.
 Open Scope monad_scope.
 
-Require Export Acorn.AcornSignal.
-Require Export Acorn.AcornCavaClass.
-From Cava Require Import VectorUtils.
-From Cava Require Import Monad.MonadFacts.
+Require Export Cava.Acorn.AcornSignal.
+Require Export Cava.Acorn.AcornCavaClass.
+Require Import Cava.VectorUtils.
+Require Import Cava.Monad.MonadFacts.
 
 Open Scope type_scope.
 

--- a/cava/Cava/Acorn/AcornNetlist.v
+++ b/cava/Cava/Acorn/AcornNetlist.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornSignal.
 
 Inductive AcornInstance : Type :=
   | Inv : Signal Bit -> Signal Bit -> AcornInstance

--- a/cava/Cava/Acorn/AcornNetlistGeneration.v
+++ b/cava/Cava/Acorn/AcornNetlistGeneration.v
@@ -17,12 +17,12 @@
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.StateMonad.
 
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
-From Cava Require Import Acorn.AcornSignal.
-From Cava Require Import Acorn.AcornCavaClass.
-From Cava Require Import Acorn.AcornNetlist.
-From Cava Require Import Acorn.AcornState.
+Require Import Cava.Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornCavaClass.
+Require Import Cava.Acorn.AcornNetlist.
+Require Import Cava.Acorn.AcornState.
 
 Import MonadNotation.
 Local Open Scope monad_scope.

--- a/cava/Cava/Acorn/AcornSignal.v
+++ b/cava/Cava/Acorn/AcornSignal.v
@@ -14,14 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Strings.String.
-From Coq Require Import Vectors.Vector.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Strings.String.
+Require Import Coq.Vectors.Vector.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
 Inductive SignalType :=
   | Void : SignalType                             (* An empty type *)

--- a/cava/Cava/Acorn/AcornState.v
+++ b/cava/Cava/Acorn/AcornState.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Lists.List.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
 Import ListNotations.
 Open Scope list_scope.
 Require Import ExtLib.Structures.Monads.
@@ -24,8 +24,8 @@ Require Export ExtLib.Data.Monads.StateMonad.
 Import MonadNotation.
 Open Scope monad_scope.
 
-From Cava Require Import Acorn.AcornSignal.
-From Cava Require Import Acorn.AcornNetlist.
+Require Import Cava.Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornNetlist.
 
 
 Record AcornModule : Type := mkAcornModule{

--- a/cava/Cava/Acorn/Combinational.v
+++ b/cava/Cava/Acorn/Combinational.v
@@ -14,13 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import String.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.String.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 
-From Cava Require Import Acorn.AcornSignal.
-From Cava Require Import Acorn.AcornCavaClass.
+Require Import Cava.Acorn.AcornSignal.
+Require Import Cava.Acorn.AcornCavaClass.
 
 Fixpoint denoteCombinaional (t : SignalType) : Type :=
   match t with

--- a/cava/Cava/Acorn/Lib/AcornFullAdder.v
+++ b/cava/Cava/Acorn/Lib/AcornFullAdder.v
@@ -14,14 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
+Require Import Coq.Bool.Bool.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 Import MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
-From Cava Require Import Acorn.Acorn.
+Require Import Cava.Acorn.Acorn.
 
 Section WithCava.
   Context {signal} {cava : Cava signal}.

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdderProofs.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.NArith.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
@@ -32,12 +32,12 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Classes.Morphisms.
 
-From Cava Require Import BitArithmetic ListUtils VectorUtils.
+Require Import Cava.BitArithmetic Cava.ListUtils Cava.VectorUtils.
 Require Import Cava.Monad.MonadFacts.
 
-From Cava Require Import Acorn.Acorn.
-From Cava Require Import Acorn.Lib.AcornFullAdder.
-From Cava Require Import Acorn.Lib.AcornUnsignedAdders.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornFullAdder.
+Require Import Cava.Acorn.Lib.AcornUnsignedAdders.
 
 Local Open Scope N_scope.
 

--- a/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
+++ b/cava/Cava/Acorn/Lib/AcornUnsignedAdders.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
@@ -26,9 +26,9 @@ Import MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
-From Cava Require Import VectorUtils.
-From Cava Require Import Acorn.Acorn.
-From Cava Require Import Acorn.Lib.AcornFullAdder.
+Require Import Cava.VectorUtils.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornFullAdder.
 
 Local Open Scope vector_scope.
 

--- a/cava/Cava/Acorn/Lib/AcornVectors.v
+++ b/cava/Cava/Acorn/Lib/AcornVectors.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 Local Open Scope vector_scope.
 
@@ -23,9 +23,9 @@ Require Import ExtLib.Structures.Traversable.
 Export MonadNotation.
 Open Scope monad_scope.
 
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
-From Cava Require Import Acorn.Acorn.
+Require Import Cava.Acorn.Acorn.
 
 (* xor two bit-vectors *)
 Definition xorV {signal} `{Cava signal} `{Monad m} 

--- a/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
+++ b/cava/Cava/Acorn/Tests/UnsignedAdderTests.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.NArith.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
@@ -27,8 +27,8 @@ Import MonadNotation.
 Open Scope monad_scope.
 Open Scope type_scope.
 
-From Cava Require Import Acorn.Acorn.
-From Cava Require Import Acorn.Lib.AcornUnsignedAdders.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornUnsignedAdders.
 
 (* Test vector based adder *)
 

--- a/cava/Cava/Arrow/ArrowKind.v
+++ b/cava/Cava/Arrow/ArrowKind.v
@@ -14,15 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List Numbers.NaryFunctions Arith.Arith
-     NArith.NArith Vectors.Vector Logic.Eqdep_dec.
-From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
+Require Import Coq.Lists.List Coq.Numbers.NaryFunctions Coq.Arith.Arith
+     Coq.NArith.NArith Coq.Vectors.Vector Coq.Logic.Eqdep_dec.
+Require Import Cava.Arrow.Classes.Category Cava.Arrow.Classes.Arrow.
 
 Import ListNotations.
 Import VectorNotations.
 Import CategoryNotations.
 
-From Cava Require Import Types.
+Require Import Cava.Types.
 
 Inductive Kind : Set :=
 | Tuple: Kind -> Kind -> Kind

--- a/cava/Cava/Arrow/CavaNotation.v
+++ b/cava/Cava/Arrow/CavaNotation.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Lists.List micromega.Lia
-     NArith.NArith Strings.String.
-From Cava Require Import Arrow.Classes.Category.
-From Cava Require Import BitArithmetic Arrow.CircuitArrow Arrow.ExprSyntax.
-From Cava Require Import Arrow.ArrowKind.
-From Cava Require Import Arrow.Primitives.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Lists.List Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String.
+Require Import Cava.Arrow.Classes.Category.
+Require Import Cava.BitArithmetic Cava.Arrow.CircuitArrow Cava.Arrow.ExprSyntax.
+Require Import Cava.Arrow.ArrowKind.
+Require Import Cava.Arrow.Primitives.
 
 Import ListNotations.
 Import EqNotations.

--- a/cava/Cava/Arrow/CircuitArrow.v
+++ b/cava/Cava/Arrow/CircuitArrow.v
@@ -14,16 +14,16 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List.
-From Coq Require Import Numbers.NaryFunctions.
-From Coq Require Import Strings.String.
-From Coq Require Import Arith.Arith.
-From Coq Require Import NArith.NArith.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import micromega.Lia.
-From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
-From Cava Require Import Arrow.ArrowKind.
-From Cava Require Import Arrow.Primitives.
+Require Import Coq.Lists.List.
+Require Import Coq.Numbers.NaryFunctions.
+Require Import Coq.Strings.String.
+Require Import Coq.Arith.Arith.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.micromega.Lia.
+Require Import Cava.Arrow.Classes.Category Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.ArrowKind.
+Require Import Cava.Arrow.Primitives.
 
 Import ListNotations.
 Import VectorNotations.

--- a/cava/Cava/Arrow/CircuitLowering.v
+++ b/cava/Cava/Arrow/CircuitLowering.v
@@ -14,15 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool ZArith.ZArith Numbers.NaryFunctions
-     Vectors.Vector Strings.String Lists.List Numbers.DecimalString
-     micromega.Lia.
-From Cava Require Import Arrow.Classes.Arrow.
-From Cava Require Import Arrow.Classes.Category.
-From Cava Require Import Arrow.Classes.Kleisli.
-From Cava Require Import Arrow.Primitives.
-From Cava Require Import Arrow.CircuitArrow VectorUtils BitArithmetic Types Signal Netlist.
-From Cava Require Import Arrow.ArrowKind.
+Require Import Coq.Bool.Bool Coq.ZArith.ZArith Coq.Numbers.NaryFunctions
+     Coq.Vectors.Vector Coq.Strings.String Coq.Lists.List Coq.Numbers.DecimalString
+     Coq.micromega.Lia.
+Require Import Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.Classes.Category.
+Require Import Cava.Arrow.Classes.Kleisli.
+Require Import Cava.Arrow.Primitives.
+Require Import Cava.Arrow.CircuitArrow Cava.VectorUtils Cava.BitArithmetic Cava.Types Cava.Signal Cava.Netlist.
+Require Import Cava.Arrow.ArrowKind.
 
 Import NilZero.
 
@@ -31,10 +31,10 @@ Import EqNotations.
 Import ListNotations.
 Import CategoryNotations.
 
-From ExtLib Require Import Structures.Monads.
-From ExtLib Require Import Structures.Applicative.
-From ExtLib Require Import Structures.Traversable.
-From ExtLib Require Export Data.Monads.StateMonad.
+Require Import ExtLib.Structures.Monads.
+Require Import ExtLib.Structures.Applicative.
+Require Import ExtLib.Structures.Traversable.
+Require Export ExtLib.Data.Monads.StateMonad.
 
 Import MonadNotation.
 

--- a/cava/Cava/Arrow/CircuitProp.v
+++ b/cava/Cava/Arrow/CircuitProp.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool ZArith NaryFunctions Vector.
-From Cava Require Import Arrow.Classes.Category.
-From Cava Require Import Arrow.Classes.Arrow.
-From Cava Require Import Arrow.CircuitArrow Arrow.CircuitSemantics.
-From Cava Require Import Arrow.ArrowKind Arrow.Primitives.
+Require Import Coq.Bool.Bool Coq.ZArith.ZArith Coq.Numbers.NaryFunctions Coq.Vectors.Vector.
+Require Import Cava.Arrow.Classes.Category.
+Require Import Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.CircuitArrow Cava.Arrow.CircuitSemantics.
+Require Import Cava.Arrow.ArrowKind Cava.Arrow.Primitives.
 
 Import VectorNotations.
 Import CategoryNotations.

--- a/cava/Cava/Arrow/CircuitSemantics.v
+++ b/cava/Cava/Arrow/CircuitSemantics.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool ZArith.ZArith NArith.NArith
-     Numbers.NaryFunctions Vectors.Vector micromega.Lia Lists.List.
-From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
-From Cava Require Import Arrow.CircuitArrow Arrow.ArrowKind Arrow.Primitives.
+Require Import Coq.Bool.Bool Coq.ZArith.ZArith Coq.NArith.NArith
+     Coq.Numbers.NaryFunctions Coq.Vectors.Vector Coq.micromega.Lia Coq.Lists.List.
+Require Import Cava.Arrow.Classes.Category Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.CircuitArrow Cava.Arrow.ArrowKind Cava.Arrow.Primitives.
 
 Import ListNotations.
 Import VectorNotations.

--- a/cava/Cava/Arrow/Classes/Arrow.v
+++ b/cava/Cava/Arrow/Classes/Arrow.v
@@ -1,4 +1,4 @@
-From Cava Require Import Arrow.Classes.Category.
+Require Import Cava.Arrow.Classes.Category.
 
 Import CategoryNotations.
 

--- a/cava/Cava/Arrow/Classes/Category.v
+++ b/cava/Cava/Arrow/Classes/Category.v
@@ -1,4 +1,4 @@
-From Coq Require Import Setoid Classes.Morphisms.
+Require Import Coq.Setoids.Setoid Coq.Classes.Morphisms.
 
 (* Reserved Notation "x ~> y" (at level 90). *)
 

--- a/cava/Cava/Arrow/Classes/Coq.v
+++ b/cava/Cava/Arrow/Classes/Coq.v
@@ -1,5 +1,5 @@
-From ExtLib Require Import Structures.Monads.
-From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
+Require Import ExtLib.Structures.Monads.
+Require Import Cava.Arrow.Classes.Category Cava.Arrow.Classes.Arrow.
 
 Import MonadNotation.
 Import CategoryNotations.

--- a/cava/Cava/Arrow/Classes/Kleisli.v
+++ b/cava/Cava/Arrow/Classes/Kleisli.v
@@ -1,5 +1,5 @@
-From ExtLib Require Import Structures.Monads.
-From Cava Require Import Arrow.Classes.Category Arrow.Classes.Arrow.
+Require Import ExtLib.Structures.Monads.
+Require Import Cava.Arrow.Classes.Category Cava.Arrow.Classes.Arrow.
 
 Import MonadNotation.
 Import CategoryNotations.

--- a/cava/Cava/Arrow/Combinators.v
+++ b/cava/Cava/Arrow/Combinators.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.String Bool.Bvector Lists.List NArith.NArith
-     Init.Nat micromega.Lia Arith.Plus.
-From Cava.Arrow Require Import ArrowKind CavaNotation ExprSyntax Primitives.
+Require Import Coq.Strings.String Coq.Bool.Bvector Coq.Lists.List Coq.NArith.NArith
+     Coq.Init.Nat Coq.micromega.Lia Coq.Arith.Plus.
+Require Import Cava.Arrow.ArrowKind Cava.Arrow.CavaNotation Cava.Arrow.ExprSyntax Cava.Arrow.Primitives.
 
 Import ListNotations.
 Import EqNotations.

--- a/cava/Cava/Arrow/ExprEquiv.v
+++ b/cava/Cava/Arrow/ExprEquiv.v
@@ -1,5 +1,5 @@
-From Coq Require Import Lists.List Arith.PeanoNat Arith.Peano_dec.
-From Cava Require Import Arrow.ArrowKind Arrow.ExprSyntax.
+Require Import Coq.Lists.List Coq.Arith.PeanoNat Coq.Arith.Peano_dec.
+Require Import Cava.Arrow.ArrowKind Cava.Arrow.ExprSyntax.
 
 Import ListNotations.
 

--- a/cava/Cava/Arrow/ExprSemantics.v
+++ b/cava/Cava/Arrow/ExprSemantics.v
@@ -14,17 +14,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith NArith.NArith micromega.Lia
-     Numbers.NaryFunctions Lists.List.
+Require Import Coq.Arith.Arith Coq.NArith.NArith Coq.micromega.Lia
+     Coq.Numbers.NaryFunctions Coq.Lists.List.
 
-From Cava Require Import Arrow.Classes.Category.
-From Cava Require Import Arrow.Classes.Arrow.
-From Cava Require Import Arrow.CircuitArrow.
-From Cava Require Import Arrow.CircuitSemantics.
-From Cava Require Import Arrow.ExprSyntax.
-From Cava Require Import Arrow.ExprLowering.
-From Cava Require Import Arrow.ArrowKind.
-From Cava Require Import Arrow.Primitives.
+Require Import Cava.Arrow.Classes.Category.
+Require Import Cava.Arrow.Classes.Arrow.
+Require Import Cava.Arrow.CircuitArrow.
+Require Import Cava.Arrow.CircuitSemantics.
+Require Import Cava.Arrow.ExprSyntax.
+Require Import Cava.Arrow.ExprLowering.
+Require Import Cava.Arrow.ArrowKind.
+Require Import Cava.Arrow.Primitives.
 
 Import EqNotations.
 Import ListNotations.

--- a/cava/Cava/Arrow/ExprSyntax.v
+++ b/cava/Cava/Arrow/ExprSyntax.v
@@ -1,9 +1,9 @@
-From Coq Require Import Strings.String.
-From Coq Require Import Lists.List.
-From Coq Require Import Arith.Peano_dec.
-From Cava Require Import Arrow.ArrowKind.
-From Cava Require Import Arrow.Primitives.
-From Cava Require Import Arrow.Classes.Category.
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.Arith.Peano_dec.
+Require Import Cava.Arrow.ArrowKind.
+Require Import Cava.Arrow.Primitives.
+Require Import Cava.Arrow.Classes.Category.
 
 Import ListNotations.
 

--- a/cava/Cava/Arrow/Primitives.v
+++ b/cava/Cava/Arrow/Primitives.v
@@ -14,18 +14,18 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Numbers.NaryFunctions Arith.Arith NArith.NArith.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bool.
-From Coq Require Import ZArith.ZArith.
-From Cava Require Import VectorUtils.
-From Cava Require Import BitArithmetic.
+Require Import Coq.Numbers.NaryFunctions Coq.Arith.Arith Coq.NArith.NArith.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bool.
+Require Import Coq.ZArith.ZArith.
+Require Import Cava.VectorUtils.
+Require Import Cava.BitArithmetic.
 
 Import VectorNotations.
 
 (* Module PrimitiveNotations. *)
 
-From Cava Require Export Arrow.ArrowKind.
+Require Export Cava.Arrow.ArrowKind.
 
 Notation vec_index n := (Vector Bit (Nat.log2_up n)).
 

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -16,21 +16,21 @@
 
 (* Bit-vector arithmetic operations for Cava. *)
 
-From Coq Require Import Init.Byte.
-From Coq Require Import Bool.Bool.
-From Coq Require Import Lists.List.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
-From Coq Require Import NArith.Ndigits.
-From Coq Require Import NArith.Nnat.
-From Coq Require Import Init.Nat.
-From Coq Require Import omega.Omega.
-From Coq Require Import micromega.Lia.
-From Coq Require Import btauto.Btauto.
-From Coq Require Import Arith.PeanoNat.
-From Coq Require Strings.HexString.
+Require Import Coq.Init.Byte.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
+Require Import Coq.NArith.Ndigits.
+Require Import Coq.NArith.Nnat.
+Require Import Coq.Init.Nat.
+Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
+Require Import Coq.btauto.Btauto.
+Require Import Coq.Arith.PeanoNat.
+Require Coq.Strings.HexString.
 
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
 Import ListNotations.
 

--- a/cava/Cava/Extraction.v
+++ b/cava/Cava/Extraction.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 Set Extraction KeepSingleton.
@@ -47,11 +47,11 @@ Recursive Extraction Library CombinationalMonad.
 Recursive Extraction Library Combinators.
 Recursive Extraction Library NetlistGeneration.
 
-From Cava.Arrow Require Import ArrowExport.
-From Cava.Arrow Require Classes.Category.
-From Cava.Arrow Require Classes.Arrow.
-From Cava.Arrow Require Classes.Coq.
-From Cava.Arrow Require Classes.Kleisli.
+Require Import Cava.Arrow.ArrowExport.
+Require Cava.Arrow.Classes.Category.
+Require Cava.Arrow.Classes.Arrow.
+Require Cava.Arrow.Classes.Coq.
+Require Cava.Arrow.Classes.Kleisli.
 
 Recursive Extraction Library Arrow.
 Recursive Extraction Library Category.

--- a/cava/Cava/Kind.v
+++ b/cava/Cava/Kind.v
@@ -14,10 +14,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.String.
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Strings.String.
+Require Import Coq.Vectors.Vector.
 
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
 (******************************************************************************)
 (* Values of Kind can occur as the type of signals on a circuit interface *)

--- a/cava/Cava/Lib/BitVectorOps.v
+++ b/cava/Cava/Lib/BitVectorOps.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 Local Open Scope vector_scope.
 
@@ -25,7 +25,7 @@ Open Scope monad_scope.
 
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
 Section WithCava.
   Context {signal} `{Cava signal} `{Monad cava}.

--- a/cava/Cava/Lib/FullAdder.v
+++ b/cava/Cava/Lib/FullAdder.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
+Require Import Coq.Bool.Bool.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 Import MonadNotation.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
@@ -29,7 +29,7 @@ Open Scope type_scope.
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Lib.FullAdder.
-From Cava Require Import VectorUtils.
+Require Import Cava.VectorUtils.
 
 Local Open Scope vector_scope.
 

--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -14,13 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Vector.
+Require Coq.Vectors.Vector.
 Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import Kind.
-From Cava Require Import Types.
-From Cava Require Import Netlist.
-From Cava Require Import Signal.
+Require Import Cava.Kind.
+Require Import Cava.Types.
+Require Import Cava.Netlist.
+Require Import Cava.Signal.
 
 Local Open Scope type_scope.
 

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -14,25 +14,25 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
 Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 Export MonadNotation.
 
-Require Vector.
-From Coq Require Import Bool.Bvector.
-From Coq Require Import Fin.
-From Coq Require Import NArith.Ndigits.
-From Coq Require Import ZArith.ZArith.
+Require ExtLib.Data.Vector.
+Require Import Coq.Bool.Bvector.
+Require Import Coq.Vectors.Fin.
+Require Import Coq.NArith.Ndigits.
+Require Import Coq.ZArith.ZArith.
 
-From Coq Require Import micromega.Lia.
+Require Import Coq.micromega.Lia.
 
 Require Import Cava.Cava.
-From Cava Require Import Kind.
-From Cava Require Import Signal.
+Require Import Cava.Kind.
+Require Import Cava.Signal.
 Require Import Cava.Monad.CavaClass.
 
 (******************************************************************************)

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -14,20 +14,20 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 
-From Coq Require Import Lists.List micromega.Lia.
+Require Import Coq.Lists.List Coq.micromega.Lia.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Traversable.
 Require Import ExtLib.Structures.MonadFix.
-From Coq Require Import Arith.PeanoNat.
+Require Import Coq.Arith.PeanoNat.
 
 Export MonadNotation.
 
-From Cava Require Import Kind.
+Require Import Cava.Kind.
 Require Import Cava.Monad.CavaClass.
 Require Import Cava.VectorUtils.
 Require Import Cava.ListUtils.

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -14,21 +14,21 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Import Vectors.Vector.
-From Coq Require Import ZArith.ZArith.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.ZArith.ZArith.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import Cava.Cava.
 Require Import Cava.VectorUtils.
 Require Import Cava.Monad.CavaClass.
 
-From Cava Require Import Signal.
+Require Import Cava.Signal.
 
 (******************************************************************************)
 (* Netlist implementations for the Cava class.                                *)

--- a/cava/Cava/Monad/XilinxAdder.v
+++ b/cava/Cava/Monad/XilinxAdder.v
@@ -13,14 +13,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.NArith.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.NArith.NArith.
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/cava/Cava/Netlist.v
+++ b/cava/Cava/Netlist.v
@@ -20,17 +20,17 @@
 *)
 
 Require Import Coq.Program.Basics.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Lists.List.
-From Coq Require Import Bool.Bool.
-From Coq Require Import Numbers.NaryFunctions.
-From Coq Require Import Init.Datatypes.
-From Coq Require Vector.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Numbers.NaryFunctions.
+Require Import Coq.Init.Datatypes.
+Require Coq.Vectors.Vector.
 Require Import ExtLib.Structures.Monads.
 Require Export ExtLib.Data.Monads.StateMonad.
 Require Export ExtLib.Data.List.
-From ExtLib Require Import Structures.Traversable.
+Require Import ExtLib.Structures.Traversable.
 
 Import ListNotations.
 Import MonadNotation.
@@ -38,11 +38,11 @@ Open Scope string_scope.
 Open Scope list_scope.
 Open Scope monad_scope.
 
-From Cava Require Import Kind.
-From Cava Require Import Signal.
-From Cava Require Import Types.
-From Cava Require Import BitArithmetic.
-From Cava Require Import VectorUtils.
+Require Import Cava.Kind.
+Require Import Cava.Signal.
+Require Import Cava.Types.
+Require Import Cava.BitArithmetic.
+Require Import Cava.VectorUtils.
 
 (******************************************************************************)
 (* Make it possible to convert certain types to bool shape values             *)

--- a/cava/Cava/Signal.v
+++ b/cava/Cava/Signal.v
@@ -14,14 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
 Import ListNotations.
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Vectors.Vector.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Vectors.Vector.
 
-From Cava Require Import Kind.
-From Cava Require Import VectorUtils.
+Require Import Cava.Kind.
+Require Import Cava.VectorUtils.
 
 (******************************************************************************)
 (* The types of signals that can flow over wires, used to index signal        *)

--- a/cava/Cava/Types.v
+++ b/cava/Cava/Types.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 Require Import Coq.Program.Basics.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Lists.List.
-From Coq Require Import Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+Require Import Coq.Bool.Bool.
 (* From Coq Require Import Numbers.NaryFunctions.
 From Coq Require Import Init.Datatypes. *)
 Require Import ExtLib.Structures.Monads.
@@ -28,9 +28,9 @@ Import MonadNotation.
 Open Scope list_scope.
 Open Scope monad_scope.
 
-From Cava Require Import Kind.
-From Cava Require Import Signal.
-From Cava Require Import VectorUtils.
+Require Import Cava.Kind.
+Require Import Cava.Signal.
+Require Import Cava.VectorUtils.
 
 Require Import Coq.Program.Program.
 Require Import Coq.Init.Nat Coq.Arith.Arith Coq.micromega.Lia.

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -14,20 +14,20 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 
-From Coq Require Import ZArith.ZArith.
-From Coq Require Import Init.Nat Arith.Arith micromega.Lia.
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Init.Nat Coq.Arith.Arith Coq.micromega.Lia.
 
-From ExtLib Require Import Structures.Applicative.
-From ExtLib Require Import Structures.Traversable.
+Require Import ExtLib.Structures.Applicative.
+Require Import ExtLib.Structures.Traversable.
 Require Export ExtLib.Data.Monads.IdentityMonad.
 
-From Cava Require ListUtils.
+Require Cava.ListUtils.
 
 Section traversable.
   Universe u v vF.

--- a/monad-examples/AdderTree.v
+++ b/monad-examples/AdderTree.v
@@ -14,16 +14,16 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Program.Basics.
-From Coq Require Import Bool.Bool Init.Nat.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.NArith.
+Require Import Coq.Program.Basics.
+Require Import Coq.Bool.Bool Coq.Init.Nat.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.NArith.NArith.
 
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/FullAdderExample.v
+++ b/monad-examples/FullAdderExample.v
@@ -13,9 +13,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/MonadExtraction.v
+++ b/monad-examples/MonadExtraction.v
@@ -21,11 +21,11 @@ Require Import MonadExamples.FullAdderExample.
 Require Import MonadExamples.UnsignedAdderExamples.
 Require Import MonadExamples.AdderTree.
 Require Import MonadExamples.Sorter.
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 

--- a/monad-examples/Multiplexers.v
+++ b/monad-examples/Multiplexers.v
@@ -13,10 +13,10 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool NArith.NArith.
-From Coq Require Import Strings.Ascii Strings.String.
+Require Import Coq.Bool.Bool Coq.NArith.NArith.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
@@ -24,11 +24,11 @@ Require Import ExtLib.Structures.Monads.
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.
 
-From Coq Require Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import Vector.VectorNotations.
 
-From Coq Require Import NArith.Ndigits.
+Require Import Coq.NArith.Ndigits.
 
 Local Open Scope vector_scope.
 

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 Require Import Coq.Program.Basics.
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
-From Coq Require Import ZArith.ZArith.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.ZArith.ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/Sorter.v
+++ b/monad-examples/Sorter.v
@@ -16,21 +16,21 @@
 
 Require Import ExtLib.Structures.Monads.
 
-From Coq Require Import Strings.Ascii Strings.String.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 
-From Coq Require Import Arith.PeanoNat NArith.Ndigits NArith.NArith.
+Require Import Coq.Arith.PeanoNat Coq.NArith.Ndigits Coq.NArith.NArith.
 Require Import Cava.Cava.
 Require Import Cava.VectorUtils.
 Require Import Cava.Monad.CavaMonad.
 
-From Coq Require Import micromega.Lia.
+Require Import Coq.micromega.Lia.
 
 Local Open Scope vector_scope.
 

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -14,17 +14,17 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.NArith.
-From Coq Require Import Lists.List.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Bool.Bool.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.

--- a/monad-examples/xilinx/NandLUT.v
+++ b/monad-examples/xilinx/NandLUT.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/xilinx/XilinxAdderExamples.v
+++ b/monad-examples/xilinx/XilinxAdderExamples.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.NArith.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
-From Coq Require Import ZArith.ZArith.
+Require Import Coq.Bool.Bool.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.ZArith.ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/xilinx/XilinxAdderTree.v
+++ b/monad-examples/xilinx/XilinxAdderTree.v
@@ -14,15 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Bool.Bool Init.Nat.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import NArith.NArith.
+Require Import Coq.Bool.Bool Coq.Init.Nat.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.NArith.NArith.
 
-From Coq Require Import Lists.List.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vectors.Vector.
-From Coq Require Import Bool.Bvector.
+Require Import Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/monad-examples/xilinx/XilinxExtraction.v
+++ b/monad-examples/xilinx/XilinxExtraction.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 

--- a/silveroak-opentitan/aes/Acorn/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Acorn/AddRoundKey.v
@@ -14,16 +14,16 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 
 Require Import ExtLib.Structures.Monads.
 
-From Cava Require Import VectorUtils.
-From Cava Require Import Acorn.Acorn.
-From Cava Require Import Acorn.Lib.AcornVectors.
-From AcornAes Require Import Common.
-From AesSpec Require Import Tests.CipherTest.
-From AesSpec Require Import Tests.Common.
+Require Import Cava.VectorUtils.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornVectors.
+Require Import AcornAes.Common.
+Require Import AesSpec.Tests.CipherTest.
+Require Import AesSpec.Tests.Common.
 Import Common.Notations.
 
 Section WithCava.

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -17,16 +17,16 @@
 Require Import Coq.Lists.List.
 Import ListNotations.
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 
 Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Traversable.
 Import MonadNotation.
 
-From Cava Require Import VectorUtils.
-From Cava Require Import Acorn.Acorn.
-From Cava Require Import Acorn.Lib.AcornVectors.
+Require Import Cava.VectorUtils.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Lib.AcornVectors.
 
 Local Open Scope vector_scope.
 

--- a/silveroak-opentitan/aes/Acorn/Common.v
+++ b/silveroak-opentitan/aes/Acorn/Common.v
@@ -14,7 +14,7 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Cava Require Import Acorn.Acorn.
+Require Import Cava.Acorn.Acorn.
 
 Module Notations.
   Notation state := (Vec (Vec (Vec Bit 8) 4) 4) (only parsing).

--- a/silveroak-opentitan/aes/Arrow/CipherRoundProperties.v
+++ b/silveroak-opentitan/aes/Arrow/CipherRoundProperties.v
@@ -14,14 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import derive.Derive.
-From coqutil Require Import Tactics.Tactics.
-From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Coq.derive.Derive.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Arrow.ArrowExport Cava.Arrow.DeriveSpec
+     Cava.Arrow.CombinatorProperties Cava.BitArithmetic Cava.VectorUtils.
 Require Import Cava.Tactics.
 
-From Aes Require Import PkgProperties cipher_round
-     mix_columns sbox sub_bytes shift_rows.
+Require Import Aes.PkgProperties Aes.cipher_round
+     Aes.mix_columns Aes.sbox Aes.sub_bytes Aes.shift_rows.
 
 Section Wf.
   Context (aes_sub_bytes_Wf : forall sbox_impl, Wf (aes_sub_bytes sbox_impl))

--- a/silveroak-opentitan/aes/Arrow/Extraction.v
+++ b/silveroak-opentitan/aes/Arrow/Extraction.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Require Import coqutil.Z.HexNotation.
 
@@ -26,7 +26,7 @@ Set Extraction Optimize.
 
 Extraction Language Haskell.
 
-From Cava Require Import Arrow.ArrowExport.
+Require Import Cava.Arrow.ArrowExport.
 Extraction Library CavaNotation.
 Extraction Library HexNotation.
 

--- a/silveroak-opentitan/aes/Arrow/NaiveCipherProperties.v
+++ b/silveroak-opentitan/aes/Arrow/NaiveCipherProperties.v
@@ -14,13 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import derive.Derive.
-From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Coq.derive.Derive.
+Require Import Cava.Arrow.ArrowExport Cava.Arrow.DeriveSpec
+     Cava.Arrow.CombinatorProperties Cava.BitArithmetic Cava.VectorUtils.
 Require Import Cava.Tactics.
 
-From Aes Require Import PkgProperties CipherRoundProperties
-     pkg cipher_round unrolled_naive_cipher.
+Require Import Aes.PkgProperties Aes.CipherRoundProperties
+     Aes.pkg Aes.cipher_round Aes.unrolled_naive_cipher.
 
 Section Wf.
   Context (aes_256_naive_key_expansion_Wf :

--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
@@ -30,9 +30,9 @@ Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherRepresentationChange.
 Require Import AesSpec.ExpandAllKeys.
 Require Import AesSpec.InterleavedCipher.
-From Aes Require Import CipherEquivalenceCommon
-     OpenTitanCipherProperties CipherRoundProperties
-     unrolled_opentitan_cipher.
+Require Import Aes.CipherEquivalenceCommon
+     Aes.OpenTitanCipherProperties Aes.CipherRoundProperties
+     Aes.unrolled_opentitan_cipher.
 Import VectorNotations ListNotations.
 Import CipherEquivalenceCommon.Notations.
 

--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherProperties.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherProperties.v
@@ -14,14 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import derive.Derive.
-From coqutil Require Import Tactics.Tactics.
-From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Coq.derive.Derive.
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.Arrow.ArrowExport Cava.Arrow.DeriveSpec
+     Cava.Arrow.CombinatorProperties Cava.BitArithmetic Cava.VectorUtils.
 Require Import Cava.Tactics.
 
-From Aes Require Import PkgProperties CipherRoundProperties
-     cipher_round unrolled_opentitan_cipher.
+Require Import Aes.PkgProperties Aes.CipherRoundProperties
+     Aes.cipher_round Aes.unrolled_opentitan_cipher.
 
 Section Wf.
   Context (aes_key_expand_Wf :

--- a/silveroak-opentitan/aes/Arrow/OpenTitanInverseCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanInverseCipherEquivalence.v
@@ -30,9 +30,9 @@ Require Import AesSpec.Cipher.
 Require Import AesSpec.CipherRepresentationChange.
 Require Import AesSpec.ExpandAllKeys.
 Require Import AesSpec.InterleavedInverseCipher.
-From Aes Require Import CipherEquivalenceCommon
-     OpenTitanCipherProperties CipherRoundProperties
-     unrolled_opentitan_cipher.
+Require Import Aes.CipherEquivalenceCommon
+     Aes.OpenTitanCipherProperties Aes.CipherRoundProperties
+     Aes.unrolled_opentitan_cipher.
 Import VectorNotations ListNotations.
 Import CipherEquivalenceCommon.Notations.
 

--- a/silveroak-opentitan/aes/Arrow/PkgProperties.v
+++ b/silveroak-opentitan/aes/Arrow/PkgProperties.v
@@ -15,12 +15,12 @@
 (****************************************************************************)
 
 Require Import Coq.Strings.String.
-From Coq Require Import derive.Derive.
-From Cava Require Import Arrow.ArrowExport Arrow.DeriveSpec
-     Arrow.CombinatorProperties BitArithmetic VectorUtils.
+Require Import Coq.derive.Derive.
+Require Import Cava.Arrow.ArrowExport Cava.Arrow.DeriveSpec
+     Cava.Arrow.CombinatorProperties Cava.BitArithmetic Cava.VectorUtils.
 Require Import Cava.Tactics.
 
-From Aes Require Import pkg.
+Require Import Aes.pkg.
 
 Section Wf.
   Lemma aes_transpose_Wf n m : Wf (@aes_transpose n m).

--- a/silveroak-opentitan/aes/Arrow/aes_test.v
+++ b/silveroak-opentitan/aes/Arrow/aes_test.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith ZArith.ZArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic VectorUtils.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.ZArith.ZArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic Cava.VectorUtils.
 
-From AesSpec Require Import Tests.CipherTest Tests.Common.
-From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.
+Require Import AesSpec.Tests.CipherTest AesSpec.Tests.Common.
+Require Import Aes.pkg Aes.mix_columns Aes.sbox Aes.sub_bytes Aes.shift_rows Aes.cipher_round.
 
 Require Import coqutil.Z.HexNotation.
 

--- a/silveroak-opentitan/aes/Arrow/cipher_round.v
+++ b/silveroak-opentitan/aes/Arrow/cipher_round.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows.
+Require Import Aes.pkg Aes.mix_columns Aes.sbox Aes.sub_bytes Aes.shift_rows.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/key_expand.v
+++ b/silveroak-opentitan/aes/Arrow/key_expand.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox.
+Require Import Aes.pkg Aes.sbox.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/mix_columns.v
+++ b/silveroak-opentitan/aes/Arrow/mix_columns.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox mix_single_column.
+Require Import Aes.pkg Aes.sbox Aes.mix_single_column.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/mix_single_column.v
+++ b/silveroak-opentitan/aes/Arrow/mix_single_column.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox.
+Require Import Aes.pkg Aes.sbox.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/netlists.v
+++ b/silveroak-opentitan/aes/Arrow/netlists.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox unrolled_opentitan_cipher.
+Require Import Aes.pkg Aes.sbox Aes.unrolled_opentitan_cipher.
 
 Require Import Cava.Types.
 Require Import Cava.Netlist.

--- a/silveroak-opentitan/aes/Arrow/pkg.v
+++ b/silveroak-opentitan/aes/Arrow/pkg.v
@@ -14,9 +14,9 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/sbox.v
+++ b/silveroak-opentitan/aes/Arrow/sbox.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox_canright_pkg sbox_canright sbox_canright_masked_noreuse sbox_lut.
+Require Import Aes.pkg Aes.sbox_canright_pkg Aes.sbox_canright Aes.sbox_canright_masked_noreuse Aes.sbox_lut.
 
 Section notation.
 Import VectorNotations.

--- a/silveroak-opentitan/aes/Arrow/sbox_canright.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright.v
@@ -14,13 +14,13 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport
-     BitArithmetic VectorUtils.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport
+     Cava.BitArithmetic Cava.VectorUtils.
 Require Import Cava.Tactics.
 
-From Aes Require Import pkg sbox_canright_pkg.
+Require Import Aes.pkg Aes.sbox_canright_pkg.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/sbox_canright_masked_noreuse.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright_masked_noreuse.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox_canright_pkg.
+Require Import Aes.pkg Aes.sbox_canright_pkg.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/sbox_canright_pkg.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_canright_pkg.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg.
+Require Import Aes.pkg.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/sbox_lut.v
+++ b/silveroak-opentitan/aes/Arrow/sbox_lut.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg.
+Require Import Aes.pkg.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/shift_rows.v
+++ b/silveroak-opentitan/aes/Arrow/shift_rows.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox.
+Require Import Aes.pkg Aes.sbox.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/sub_bytes.v
+++ b/silveroak-opentitan/aes/Arrow/sub_bytes.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg sbox.
+Require Import Aes.pkg Aes.sbox.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_naive_cipher.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import BitArithmetic VectorUtils Arrow.ArrowExport.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.BitArithmetic Cava.VectorUtils Cava.Arrow.ArrowExport.
 
-From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.
-From Aes Require Import aes_test.
+Require Import Aes.pkg Aes.mix_columns Aes.sbox Aes.sub_bytes Aes.shift_rows Aes.cipher_round.
+Require Import Aes.aes_test.
 
 Require Import coqutil.Z.HexNotation.
 

--- a/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
+++ b/silveroak-opentitan/aes/Arrow/unrolled_opentitan_cipher.v
@@ -14,12 +14,12 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Arith.Arith Logic.Eqdep_dec Vectors.Vector micromega.Lia
-     NArith.NArith Strings.String NArith.Ndigits.
-From Cava Require Import Arrow.ArrowExport BitArithmetic.
+Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec Coq.Vectors.Vector Coq.micromega.Lia
+     Coq.NArith.NArith Coq.Strings.String Coq.NArith.Ndigits.
+Require Import Cava.Arrow.ArrowExport Cava.BitArithmetic.
 
-From Aes Require Import pkg mix_columns sbox sub_bytes shift_rows cipher_round.
-From Aes Require Import aes_test.
+Require Import Aes.pkg Aes.mix_columns Aes.sbox Aes.sub_bytes Aes.shift_rows Aes.cipher_round.
+Require Import Aes.aes_test.
 
 Import VectorNotations.
 Import KappaNotation.

--- a/silveroak-opentitan/pinmux/Pinmux.v
+++ b/silveroak-opentitan/pinmux/Pinmux.v
@@ -14,15 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
 
-From Coq Require Lists.List.
+Require Coq.Lists.List.
 Import List.ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Import Vectors.Vector.
+Require Import Coq.Vectors.Vector.
 Import VectorNotations.
 
 Open Scope monad_scope.

--- a/silveroak-opentitan/pinmux/PinmuxExtraction.v
+++ b/silveroak-opentitan/pinmux/PinmuxExtraction.v
@@ -16,11 +16,11 @@
 
 Require Import Pinmux.Pinmux.
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 

--- a/tests/Instantiate.v
+++ b/tests/Instantiate.v
@@ -15,10 +15,10 @@
 (****************************************************************************)
 
 Require Import Coq.Program.Basics.
-From Coq Require Import Bool.Bool.
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
-From Coq Require Import ZArith.ZArith.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Coq.ZArith.ZArith.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/tests/TestMultiply.v
+++ b/tests/TestMultiply.v
@@ -14,19 +14,19 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Ascii String.
-From Coq Require Import Bool.Bool.
-From Coq Require Import NArith.
-From Coq Require Import Lists.List.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Bool.Bool.
+Require Import Coq.NArith.NArith.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-From Coq Require Vector.
-From Coq Require Import Bool.Bvector.
+Require Coq.Vectors.Vector.
+Require Import Coq.Bool.Bvector.
 
-Require Import Omega.
+Require Import Coq.omega.Omega.
 
 Require Import Cava.Cava.
 Require Import Cava.Monad.CavaMonad.

--- a/tests/TestsExtraction.v
+++ b/tests/TestsExtraction.v
@@ -14,15 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 
-Require Import Instantiate.
-Require Import TestMultiply.
+Require Import Tests.Instantiate.
+Require Import Tests.TestMultiply.
 Extraction Library Instantiate.
 Extraction Library TestMultiply.

--- a/tests/xilinx/LUTTests.v
+++ b/tests/xilinx/LUTTests.v
@@ -14,8 +14,8 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import Strings.Ascii Strings.String.
-From Coq Require Import Lists.List.
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Require Import Coq.Lists.List.
 Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.

--- a/tests/xilinx/VivadoExtraction.v
+++ b/tests/xilinx/VivadoExtraction.v
@@ -14,11 +14,11 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
-From Coq Require Import extraction.Extraction.
-From Coq Require Import extraction.ExtrHaskellZInteger.
-From Coq Require Import extraction.ExtrHaskellString.
-From Coq Require Import extraction.ExtrHaskellBasic.
-From Coq Require Import extraction.ExtrHaskellNatInteger.
+Require Import Coq.extraction.Extraction.
+Require Import Coq.extraction.ExtrHaskellZInteger.
+Require Import Coq.extraction.ExtrHaskellString.
+Require Import Coq.extraction.ExtrHaskellBasic.
+Require Import Coq.extraction.ExtrHaskellNatInteger.
 
 Extraction Language Haskell.
 

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -16,10 +16,13 @@
 
 .PHONY:	all
 
-all: coqutil bedrock2 extlib
+all: coqutil coqtools bedrock2 extlib
 
 update:
 	git submodule update --init --recursive
+
+# coq-tools is just python scripts; nothing to make
+coqtools: update
 
 coqutil: update
 	$(MAKE) -C bedrock2/deps/coqutil all

--- a/tools/absolutize-requires.sh
+++ b/tools/absolutize-requires.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2020 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+TOPLEVEL=$(git rev-parse --show-toplevel)
+
+# Use python2 because absolutize-imports.py is not executable
+ABSOLUTIZE="python2 $TOPLEVEL/third_party/coq-tools/absolutize-imports.py --in-place -v"
+
+COQPROJECTS=$(git ls-files --full-name $TOPLEVEL/*/ | grep _CoqProject | grep -v "^investigations/" | grep -v "^third_party")
+
+
+# absolutize-imports script pulls absolute names from .glob files, so we need to fully build first
+echo "Building Coq files before absolutizing..."
+make -j4 coq
+
+for f in $COQPROJECTS;
+do
+	cd "$TOPLEVEL/$(dirname $f)";
+	
+	LIBS=$(grep "^\s*-[RIQ]" _CoqProject | xargs echo) # get library arguments from _CoqProject
+	FILES=$(grep "\.v$" _CoqProject | xargs echo) # get .v files from _CoqProject
+
+	echo "Absolutizing imports in $PWD...";
+	echo "$ABSOLUTIZE $LIBS $FILES"; # print command being executed (helpful for debugging)
+	$ABSOLUTIZE $LIBS $FILES;
+done;


### PR DESCRIPTION
Partially addresses https://github.com/project-oak/oak-hardware/issues/338

Best reviewed commit-by-commit -- the first two add coq-tools dependency, the third adds a script `tools/absolutize-requires.sh` to call the coq-tools scripts on our repo safely, and the last commit is the huge change that results from running the script.