### PR TITLE
Count by proofs

### DIFF
--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -22,9 +22,12 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
+Require Import Cava.Acorn.Identity.
 Require Import Cava.Cava.
+Require Import Cava.Tactics.
 Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Lib.UnsignedAdders.
+
 
 From Coq Require Vector.
 From Coq Require Import Bool.Bvector.
@@ -142,7 +145,7 @@ bit-growth i.e. it computes (a + b) mod 256.
 *)
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} {semantics:Cava signal} `{Monad cava}.
 
   Definition countFork (i : signal (Vec Bit 8) * signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
@@ -159,16 +162,57 @@ Proof. reflexivity. Qed.
 
 Local Open Scope N_scope.
 
-Fixpoint countBySpec' (state: N) (i : list (Bvector 8)) 
+Fixpoint countBySpec' (state: Bvector 8) (i : list (Bvector 8))
                       : list (Bvector 8) :=
   match i with
   | [] => []
-  | x::xs => let newState := (Bv2N x + state) mod 256 in
-             N2Bv_sized 8 newState :: countBySpec' newState xs 
+  | x::xs =>
+    let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
+    newState :: countBySpec' newState xs
   end.
 
-Definition countBySpec := countBySpec' 0.
+Definition countBySpec := countBySpec' (N2Bv_sized 8 0).
+
+(* TODO: addN sequential seems to only return one result; shouldn't it be a map2? *)
+Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
+  match a,b with
+  | a :: _, b :: _ => [N2Bv_sized n ((Bv2N a + Bv2N b))]
+  | _,_ => []
+  end.
+
+(* TODO: rename typeclass arguments *)
+Lemma addNCorrect n (a b : list (Bvector n)) :
+  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
+Admitted.
+
+Lemma countForkStep:
+  forall (i : Bvector 8) (s : Bvector 8),
+    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
+    = (countBySpec' s [i], countBySpec' s [i]).
+Proof.
+  intros. cbv [countFork countBySpec']. cbn [fst snd].
+  simpl_ident. rewrite addNCorrect. cbn [hd].
+  reflexivity.
+Qed.
+
+Lemma countForkCorrect:
+  forall (i : list (Bvector 8)) (s : Bvector 8),
+    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
+    = countBySpec' s i.
+Proof.
+  cbv [sequential]; induction i; intros; [ reflexivity | ].
+  cbn [loopSeq' countBySpec' fst snd].
+  simpl_ident. destruct_pair_let. simpl_ident.
+  rewrite countForkStep. cbn [fst snd].
+  cbn [countBySpec']. rewrite IHi. cbn [hd].
+  reflexivity.
+Qed.
 
 Lemma countByCorrect: forall (i : list (Bvector 8)),
                       sequential (countBy i) = countBySpec i.
-Abort.                      
+Proof.
+  intros. cbv [countBy countBySpec].
+  cbn [loop SequentialCombSemantics].
+  cbv [loopSeq]. rewrite countForkCorrect.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Progress on #371 

With a minor modification (using a bitvector as the state instead of an `N`), and depending on an admitted proof that `addN` is correct, I was able to take the counter and spec in #367 and prove that they correspond. I put in a little automation as well -- review commit-by-commit to see the proofs before I sprinkled tactic magic on them.

Next step is to prove the admitted `addN` lemma, but I thought it was worth getting feedback on this step first.