### PR TITLE
Vector counter

### DIFF
--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -1,0 +1,142 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import NArith.NArith Lists.List.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+
+Require Import Cava.Acorn.Identity.
+Require Import Cava.Cava.
+Require Import Cava.Tactics.
+Require Import Cava.Monad.CavaMonad.
+Require Import Cava.Lib.UnsignedAdders.
+
+From Coq Require Import Bool.Bvector.
+
+
+(******************************************************************************)
+(* countBy                                                                    *)
+(******************************************************************************) 
+
+(*
+
+The countBy circuit takes the current 8-bit input (in) and the current
+state value represented by the register (delay) which is output in the
+current cycle as the output of the circuit, and this value is also the
+next state value for the delay. The adder is an 8-bit adder with no
+bit-growth i.e. it computes (a + b) mod 256.
+
+        _______
+    ---| delay |------------
+   |   |_______|            |
+   |   ___                  |
+    --| + ---------------------- out
+ in --|___|
+
+*)
+
+Section WithCava.
+  Context {signal} {semantics:Cava signal} `{Monad cava}.
+
+  Definition countFork (i : signal (Vec Bit 8) * signal (Vec Bit 8))
+                       : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
+    newCount <- addN (fst i) (snd i) ;;
+    ret (newCount, newCount).
+
+  Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
+    := loop countFork.
+
+End WithCava.
+
+(* Convenience notations for certain bytes *)
+Definition b0 := N2Bv_sized 8 0.
+Definition b3 := N2Bv_sized 8 3.
+Definition b7 := N2Bv_sized 8 7.
+Definition b14 := N2Bv_sized 8 14.
+Definition b18 := N2Bv_sized 8 18.
+Definition b21 := N2Bv_sized 8 21.
+Definition b24 := N2Bv_sized 8 24.
+Definition b250 := N2Bv_sized 8 250.
+
+Local Open Scope list_scope.
+
+
+Example countBy_ex1: sequential (countBy [b14; b7; b3; b250]) = [b14; b21; b24; b18].
+Proof. reflexivity. Qed.
+
+Local Open Scope N_scope.
+
+Fixpoint countBySpec' (state: Bvector 8) (i : list (Bvector 8))
+                      : list (Bvector 8) :=
+  match i with
+  | [] => []
+  | x::xs =>
+    let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
+    newState :: countBySpec' newState xs
+  end.
+
+Definition countBySpec := countBySpec' (N2Bv_sized 8 0).
+
+(* TODO: addN sequential seems to only return one result; shouldn't it be a map2? *)
+Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
+  match a,b with
+  | a :: _, b :: _ => [N2Bv_sized n ((Bv2N a + Bv2N b))]
+  | _,_ => []
+  end.
+
+Local Ltac seqsimpl_step :=
+  first [ progress cbn beta iota delta
+                   [fst snd hd sequential loopSeq' loop SequentialCombSemantics]
+        | progress cbv beta iota delta [loopSeq]; seqsimpl_step
+        | progress autorewrite with seqsimpl
+        | progress destruct_pair_let
+        | progress simpl_ident ].
+Local Ltac seqsimpl := repeat seqsimpl_step.
+
+(* TODO: rename typeclass arguments *)
+Lemma addNCorrect n (a b : list (Bvector n)) :
+  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
+Admitted.
+Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+
+Lemma countForkStep:
+  forall (i : Bvector 8) (s : Bvector 8),
+    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
+    = (countBySpec' s [i], countBySpec' s [i]).
+Proof.
+  intros; cbv [countFork countBySpec'].
+  seqsimpl; reflexivity.
+Qed.
+Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
+
+Lemma countForkCorrect:
+  forall (i : list (Bvector 8)) (s : Bvector 8),
+    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
+    = countBySpec' s i.
+Proof.
+  cbv [sequential]; induction i; intros; [ reflexivity | ].
+  seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.
+Qed.
+Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
+
+Lemma countByCorrect: forall (i : list (Bvector 8)),
+                      sequential (countBy i) = countBySpec i.
+Proof.
+  intros; cbv [countBy countBySpec].
+  seqsimpl; reflexivity.
+Qed.

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -26,9 +26,6 @@ Require Import Cava.Tactics.
 Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Lib.UnsignedAdders.
 
-From Coq Require Import Bool.Bvector.
-
-
 (******************************************************************************)
 (* countBy                                                                    *)
 (******************************************************************************) 
@@ -75,68 +72,5 @@ Definition b250 := N2Bv_sized 8 250.
 
 Local Open Scope list_scope.
 
-
 Example countBy_ex1: sequential (countBy [b14; b7; b3; b250]) = [b14; b21; b24; b18].
 Proof. reflexivity. Qed.
-
-Local Open Scope N_scope.
-
-Fixpoint countBySpec' (state: Bvector 8) (i : list (Bvector 8))
-                      : list (Bvector 8) :=
-  match i with
-  | [] => []
-  | x::xs =>
-    let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
-    newState :: countBySpec' newState xs
-  end.
-
-Definition countBySpec := countBySpec' (N2Bv_sized 8 0).
-
-(* TODO: addN sequential seems to only return one result; shouldn't it be a map2? *)
-Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
-  match a,b with
-  | a :: _, b :: _ => [N2Bv_sized n ((Bv2N a + Bv2N b))]
-  | _,_ => []
-  end.
-
-Local Ltac seqsimpl_step :=
-  first [ progress cbn beta iota delta
-                   [fst snd hd sequential loopSeq' loop SequentialCombSemantics]
-        | progress cbv beta iota delta [loopSeq]; seqsimpl_step
-        | progress autorewrite with seqsimpl
-        | progress destruct_pair_let
-        | progress simpl_ident ].
-Local Ltac seqsimpl := repeat seqsimpl_step.
-
-(* TODO: rename typeclass arguments *)
-Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
-Admitted.
-Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
-
-Lemma countForkStep:
-  forall (i : Bvector 8) (s : Bvector 8),
-    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
-    = (countBySpec' s [i], countBySpec' s [i]).
-Proof.
-  intros; cbv [countFork countBySpec'].
-  seqsimpl; reflexivity.
-Qed.
-Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
-
-Lemma countForkCorrect:
-  forall (i : list (Bvector 8)) (s : Bvector 8),
-    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
-    = countBySpec' s i.
-Proof.
-  cbv [sequential]; induction i; intros; [ reflexivity | ].
-  seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.
-Qed.
-Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
-
-Lemma countByCorrect: forall (i : list (Bvector 8)),
-                      sequential (countBy i) = countBySpec i.
-Proof.
-  intros; cbv [countBy countBySpec].
-  seqsimpl; reflexivity.
-Qed.

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -1,0 +1,90 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import NArith.NArith Lists.List.
+Require Import Coq.Bool.Bvector.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+
+Require Import Cava.Acorn.Identity.
+Require Import Cava.Cava.
+Require Import Cava.Tactics.
+Require Import Cava.Monad.CavaMonad.
+Require Import Cava.Lib.UnsignedAdders.
+
+Require Import Tests.CountBy.CountBy.
+
+Fixpoint countBySpec' (state: Bvector 8) (i : list (Bvector 8))
+                      : list (Bvector 8) :=
+  match i with
+  | [] => []
+  | x::xs =>
+    let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
+    newState :: countBySpec' newState xs
+  end.
+
+Definition countBySpec := countBySpec' (N2Bv_sized 8 0).
+
+(* TODO: addN sequential seems to only return one result; shouldn't it be a map2? *)
+Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
+  match a,b with
+  | a :: _, b :: _ => [N2Bv_sized n ((Bv2N a + Bv2N b))]
+  | _,_ => []
+  end.
+
+Local Ltac seqsimpl_step :=
+  first [ progress cbn beta iota delta
+                   [fst snd hd sequential loopSeq' loop SequentialCombSemantics]
+        | progress cbv beta iota delta [loopSeq]; seqsimpl_step
+        | progress autorewrite with seqsimpl
+        | progress destruct_pair_let
+        | progress simpl_ident ].
+Local Ltac seqsimpl := repeat seqsimpl_step.
+
+(* TODO: rename typeclass arguments *)
+Lemma addNCorrect n (a b : list (Bvector n)) :
+  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
+Admitted.
+Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+
+Lemma countForkStep:
+  forall (i : Bvector 8) (s : Bvector 8),
+    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
+    = (countBySpec' s [i], countBySpec' s [i]).
+Proof.
+  intros; cbv [countFork countBySpec'].
+  seqsimpl; reflexivity.
+Qed.
+Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
+
+Lemma countForkCorrect:
+  forall (i : list (Bvector 8)) (s : Bvector 8),
+    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
+    = countBySpec' s i.
+Proof.
+  cbv [sequential]; induction i; intros; [ reflexivity | ].
+  seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.
+Qed.
+Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
+
+Lemma countByCorrect: forall (i : list (Bvector 8)),
+                      sequential (countBy i) = countBySpec i.
+Proof.
+  intros; cbv [countBy countBySpec].
+  seqsimpl; reflexivity.
+Qed.

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -17,7 +17,6 @@
 From Coq Require Import NArith.NArith Vectors.Vector.
 Require Import Coq.Bool.Bvector.
 Import VectorNotations.
-Local Open Scope vector_scope.
 
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
@@ -31,6 +30,8 @@ Require Import Cava.Lib.UnsignedAdders.
 
 Require Import Tests.CountBy.CountBy.
 
+Local Open Scope vector_scope.
+
 Fixpoint countBySpec' {ticks : nat} (state: Bvector 8)
   : Vector.t (Bvector 8) ticks -> Vector.t (Bvector 8) ticks :=
   match ticks as ticks0 return _ ticks0 -> _ ticks0 with
@@ -40,7 +41,7 @@ Fixpoint countBySpec' {ticks : nat} (state: Bvector 8)
       let x := Vector.hd i in
       let xs := Vector.tl i in
       let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
-      (newState :: countBySpec' newState xs)%vector
+      (newState :: countBySpec' newState xs)
   end.
 
 Definition countBySpec {ticks} := @countBySpec' ticks (N2Bv_sized 8 0).

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -1,0 +1,104 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import NArith.NArith Vectors.Vector.
+Require Import Coq.Bool.Bvector.
+Import VectorNotations.
+Local Open Scope vector_scope.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+
+Require Import Cava.Acorn.Identity.
+Require Import Cava.Cava.
+Require Import Cava.Tactics.
+Require Import Cava.Monad.CavaClass.
+Require Import Cava.Monad.SequentialV.
+Require Import Cava.Lib.UnsignedAdders.
+
+Require Import Tests.CountBy.CountBy.
+
+Fixpoint countBySpec' {ticks : nat} (state: Bvector 8)
+  : Vector.t (Bvector 8) ticks -> Vector.t (Bvector 8) ticks :=
+  match ticks as ticks0 return _ ticks0 -> _ ticks0 with
+  | 0 => fun _ => []
+  | S ticks' =>
+    fun i =>
+      let x := Vector.hd i in
+      let xs := Vector.tl i in
+      let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
+      (newState :: countBySpec' newState xs)%vector
+  end.
+
+Definition countBySpec {ticks} := @countBySpec' ticks (N2Bv_sized 8 0).
+
+Definition addNSpec {ticks : nat} {n} (a b : Vector.t (Bvector n) ticks)
+  : Vector.t (Bvector n) ticks :=
+  map2 (fun a b => N2Bv_sized n (Bv2N a + Bv2N b)) a b.
+
+Local Ltac seqsimpl_step :=
+  first [ progress cbn beta iota delta
+                   [fst snd hd loopSeqV' loop SequentialVectorSemantics]
+        | progress cbv beta iota delta [loopSeqV]; seqsimpl_step
+        | progress autorewrite with seqsimpl
+        | progress destruct_pair_let
+        | progress simpl_ident ].
+Local Ltac seqsimpl := repeat seqsimpl_step.
+
+(* TODO: because sequentialV ignores the ticks argument, using sequentialV
+   instead of unIdent means autorewrite doesn't work without explicit ticks. *)
+
+(* TODO: rename typeclass arguments *)
+Lemma addNCorrect ticks n (a b : Vector.t (Bvector n) ticks) :
+  unIdent (addN (H:=SequentialVectorSemantics) a b) = addNSpec a b.
+Admitted.
+Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+
+Lemma countForkStepOnce (ticks: nat) (i s : Vector.t (Bvector 8) 1) :
+  unIdent
+    (stepOnce
+       (ticks:=ticks)
+       (countFork (semantics:=SequentialVectorSemantics))
+       (i, s))
+  = (countBySpec' (Vector.hd s) i, countBySpec' (Vector.hd s) i).
+Proof.
+  intros; cbv [countFork countBySpec' stepOnce].
+  seqsimpl. reflexivity.
+Qed.
+Hint Rewrite countForkStepOnce using solve [eauto] : seqsimpl.
+
+Lemma countForkCorrect ticks :
+  forall(i : Vector.t (Bvector 8) ticks) (s : Vector.t (Bvector 8) 1),
+    unIdent
+      (loopSeqV' ticks (stepOnce (ticks:=ticks)
+                                 (countFork (semantics:=SequentialVectorSemantics)))
+                 i s)
+    = countBySpec' (Vector.hd s) i.
+Proof.
+  cbv [sequentialV]; induction ticks; intros; [ reflexivity | ].
+  seqsimpl. cbn [countBySpec']; rewrite IHticks; reflexivity.
+Qed.
+Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
+
+Lemma countByCorrect ticks (i : Vector.t (Bvector 8) ticks) :
+  sequentialV (countBy i) = countBySpec i.
+Proof.
+  intros; cbv [countBy countBySpec].
+  destruct ticks; seqsimpl; [ reflexivity | ].
+  seqsimpl.
+  rewrite (countForkCorrect ticks).
+  reflexivity.
+Qed.

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -22,9 +22,7 @@ Import ListNotations.
 Require Import ExtLib.Structures.Monads.
 Export MonadNotation.
 
-Require Import Cava.Acorn.Identity.
 Require Import Cava.Cava.
-Require Import Cava.Tactics.
 Require Import Cava.Monad.CavaMonad.
 Require Import Cava.Lib.UnsignedAdders.
 
@@ -120,102 +118,3 @@ Definition pipelinedNAND_tb
   := testBench "pipelinedNAND_tb" pipelinedNANDInterface
      pipelinedNAND_tb_inputs pipelinedNAND_tb_expected_outputs.
 *)
-
-(******************************************************************************)
-(* countBy                                                                    *)
-(******************************************************************************) 
-
-(*
-
-The countBy circuit takes the current 8-bit input (in) and the current
-state value represented by the register (delay) which is output in the
-current cycle as the output of the circuit, and this value is also the
-next state value for the delay. The adder is an 8-bit adder with no
-bit-growth i.e. it computes (a + b) mod 256.
-
-        _______
-    ---| delay |------------
-   |   |_______|            |
-   |   ___                  |
-    --| + ---------------------- out
- in --|___|     
-
-*)
-
-Section WithCava.
-  Context {signal} {semantics:Cava signal} `{Monad cava}.
-
-  Definition countFork (i : signal (Vec Bit 8) * signal (Vec Bit 8))
-                       : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
-    newCount <- addN (fst i) (snd i) ;;
-    ret (newCount, newCount).
-
-  Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loop countFork.
-
-End WithCava.
-
-Example countBy_ex1: sequential (countBy [b14; b7; b3; b250]) = [b14; b21; b24; b18].
-Proof. reflexivity. Qed.
-
-Local Open Scope N_scope.
-
-Fixpoint countBySpec' (state: Bvector 8) (i : list (Bvector 8))
-                      : list (Bvector 8) :=
-  match i with
-  | [] => []
-  | x::xs =>
-    let newState := N2Bv_sized 8 (Bv2N x + Bv2N state) in
-    newState :: countBySpec' newState xs
-  end.
-
-Definition countBySpec := countBySpec' (N2Bv_sized 8 0).
-
-(* TODO: addN sequential seems to only return one result; shouldn't it be a map2? *)
-Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
-  match a,b with
-  | a :: _, b :: _ => [N2Bv_sized n ((Bv2N a + Bv2N b))]
-  | _,_ => []
-  end.
-
-Local Ltac seqsimpl_step :=
-  first [ progress cbn beta iota delta
-                   [fst snd hd sequential loopSeq' loop SequentialCombSemantics]
-        | progress cbv beta iota delta [loopSeq]; seqsimpl_step
-        | progress autorewrite with seqsimpl
-        | progress destruct_pair_let
-        | progress simpl_ident ].
-Local Ltac seqsimpl := repeat seqsimpl_step.
-
-(* TODO: rename typeclass arguments *)
-Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
-Admitted.
-Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
-
-Lemma countForkStep:
-  forall (i : Bvector 8) (s : Bvector 8),
-    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
-    = (countBySpec' s [i], countBySpec' s [i]).
-Proof.
-  intros; cbv [countFork countBySpec'].
-  seqsimpl; reflexivity.
-Qed.
-Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
-
-Lemma countForkCorrect:
-  forall (i : list (Bvector 8)) (s : Bvector 8),
-    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
-    = countBySpec' s i.
-Proof.
-  cbv [sequential]; induction i; intros; [ reflexivity | ].
-  seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.
-Qed.
-Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
-
-Lemma countByCorrect: forall (i : list (Bvector 8)),
-                      sequential (countBy i) = countBySpec i.
-Proof.
-  intros; cbv [countBy countBySpec].
-  seqsimpl; reflexivity.
-Qed.

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -9,3 +9,4 @@ Delay.v
 TestsExtraction.v
 
 CountBy/CountBy.v
+CountBy/ListProofs.v

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -7,3 +7,5 @@ Instantiate.v
 TestMultiply.v
 Delay.v
 TestsExtraction.v
+
+CountBy/CountBy.v


### PR DESCRIPTION
Progress for #371
Related to #374 

Proofs of `countBy` using the vector-based sequential semantics. The first two commits are just reorganizing; I moved the `countBy` example out of `Delay.v` and into its own file, and created a directory for all the `countBy` files since I anticipate we'll have a few more tests as well. So the only commit needing review is the third and final one, which adds `tests/CountBy/VectorProofs.v`.

The proof worked out pretty easily. The vector representation does trip up the proof automation a little bit, so I have to sometimes explicitly pass in the number of ticks to rewrites. But I think we can work around that, and all in all I was able to reuse most of the automation from lists, which I think is a good sign.