### PR TITLE
Cava class hierarchy

### DIFF
--- a/cava/Cava/Monad/CavaClass.v
+++ b/cava/Cava/Monad/CavaClass.v
@@ -87,9 +87,9 @@ Class Cava (signal : SignalType -> Type) := {
   blackBox : forall (intf: CircuitInterface),
              tupleInterface signal (map port_type (circuitInputs intf)) ->
              cava (tupleInterface signal ((map port_type (circuitOutputs intf))));
-  (* These members should really be in a class that extends Cava with sequential
-     operations, but I (satnam6502) can't get that to work, so they are linlined
-     here instrad.  *)
+}.
+
+Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signal) := {
   (* A unit delay. *)
   delay : forall {t: SignalType}, signal t -> cava (signal t);
   (* Feeback loop, with unit delay inserted into the feedback path. *)
@@ -97,4 +97,4 @@ Class Cava (signal : SignalType -> Type) := {
          (signal A * signal C -> cava (signal B * signal C)) ->
          signal A ->
          cava (signal B);
-}.               
+}.

--- a/cava/Cava/Monad/CombinationalMonad.v
+++ b/cava/Cava/Monad/CombinationalMonad.v
@@ -203,9 +203,6 @@ Definition loopBool (A B C : SignalType)
     greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefault (map port_type (circuitOutputs intf)));
-    (* Members that ought to be in a Sequential class. Dummy definitions. *)
-    delay _ i := ret i;
-    loop a b c := @loopBool a b c;
 }.
 
 (******************************************************************************)

--- a/cava/Cava/Monad/NetlistGeneration.v
+++ b/cava/Cava/Monad/NetlistGeneration.v
@@ -288,7 +288,9 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
     greaterThanOrEqual m n := @greaterThanOrEqualNet m n;
     instantiate := instantiateNet;
     blackBox := blackBoxNet;
-    delay k := delayNet k;
-    loop a b c := loopNet a b c;
 }.
-  
+
+Instance CavaSequentialNet : CavaSeq CavaCombinationalNet :=
+  { delay k := delayNet k;
+    loop a b c := loopNet a b c;
+  }.

--- a/cava/Cava/Monad/Sequential.v
+++ b/cava/Cava/Monad/Sequential.v
@@ -243,9 +243,12 @@ Definition bufBoolList (i : list bool) : ident (list bool) :=
     greaterThanOrEqual m n := @greaterThanOrEqualBoolList m n;
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultS (map port_type (circuitOutputs intf)));
-    delay k i := ret (@defaultCombValue k :: i);
-   loop _ _ _ := loopSeq;
-}.
+  }.
+
+ Instance SequentialSemantics : CavaSeq SequentialCombSemantics :=
+   { delay k i := ret (@defaultCombValue k :: i);
+     loop _ _ _ := loopSeq;
+   }.
 
 (******************************************************************************)
 (* A function to run a monadic circuit description and return the boolean     *)

--- a/cava/Cava/Monad/SequentialV.v
+++ b/cava/Cava/Monad/SequentialV.v
@@ -281,7 +281,7 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
 (* interpretation.                                                            *)
 (******************************************************************************)
 
- Instance SequentialVectorSemantics {ticks: nat} : Cava (seqVType ticks) :=
+ Instance SequentialVectorCombSemantics {ticks: nat} : Cava (seqVType ticks) :=
   { cava := ident;
     zero := ret (Vector.const false ticks);
     one := ret (Vector.const true ticks);
@@ -312,9 +312,13 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
     greaterThanOrEqual m n := @greaterThanOrEqualBoolVec m n ticks;
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultSV ticks (map port_type (circuitOutputs intf)));
-    delay k i := delayV ticks k i;
-    loop A B C := @loopSeqV A B C ticks;
-}.
+  }.
+
+ Instance SequentialVectorSemantics {ticks: nat}
+   : CavaSeq SequentialVectorCombSemantics:=
+   { delay k i := delayV ticks k i;
+     loop A B C := @loopSeqV A B C ticks;
+   }.
 
 (******************************************************************************)
 (* A function to run a monadic circuit description and return the boolean     *)

--- a/monad-examples/NandGate.v
+++ b/monad-examples/NandGate.v
@@ -31,7 +31,8 @@ Local Open Scope monad_scope.
 Local Open Scope string_scope.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} {combsemantics : Cava signal}
+          {seqsemantics: CavaSeq combsemantics} `{Monad cava}.
 
   (* NAND gate example. First, let's define an overloaded NAND gate
      description. *)
@@ -42,7 +43,7 @@ Section WithCava.
   Definition pipelinedNAND :=
     nand2_gate >=> delay >=> inv >=> delay.
 
- (* An contrived example of loopBit *)     
+ (* An contrived example of loopBit *)
   Definition loopedNAND :=
     loop (second delay >=> nand2 >=> fork2).
 

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -48,7 +48,8 @@ bit-growth i.e. it computes (a + b) mod 256.
 *)
 
 Section WithCava.
-  Context {signal} {semantics:Cava signal} `{Monad cava}.
+  Context {signal} {combsemantics: Cava signal}
+          {semantics: CavaSeq combsemantics} `{Monad cava}.
 
   Definition countFork (i : signal (Vec Bit 8) * signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -49,7 +49,7 @@ Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
 
 Local Ltac seqsimpl_step :=
   first [ progress cbn beta iota delta
-                   [fst snd hd sequential loopSeq' loop SequentialCombSemantics]
+                   [fst snd hd sequential loopSeq' loop SequentialSemantics]
         | progress cbv beta iota delta [loopSeq]; seqsimpl_step
         | progress autorewrite with seqsimpl
         | progress destruct_pair_let
@@ -64,7 +64,7 @@ Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 
 Lemma countForkStep:
   forall (i : Bvector 8) (s : Bvector 8),
-    sequential (countFork (semantics:=SequentialCombSemantics) ([i], [s]))
+    sequential (countFork ([i], [s]))
     = (countBySpec' s [i], countBySpec' s [i]).
 Proof.
   intros; cbv [countFork countBySpec'].
@@ -74,7 +74,7 @@ Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
 
 Lemma countForkCorrect:
   forall (i : list (Bvector 8)) (s : Bvector 8),
-    sequential (loopSeq' (countFork (semantics:=SequentialCombSemantics)) i [s])
+    sequential (loopSeq' (countFork (combsemantics:=SequentialCombSemantics)) i [s])
     = countBySpec' s i.
 Proof.
   cbv [sequential]; induction i; intros; [ reflexivity | ].
@@ -86,5 +86,5 @@ Lemma countByCorrect: forall (i : list (Bvector 8)),
                       sequential (countBy i) = countBySpec i.
 Proof.
   intros; cbv [countBy countBySpec].
-  seqsimpl; reflexivity.
+  seqsimpl. reflexivity.
 Qed.

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -64,7 +64,7 @@ Local Ltac seqsimpl := repeat seqsimpl_step.
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect ticks n (a b : Vector.t (Bvector n) ticks) :
-  unIdent (addN (H:=SequentialVectorSemantics) a b) = addNSpec a b.
+  unIdent (addN (H:=SequentialVectorCombSemantics) a b) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 
@@ -72,7 +72,7 @@ Lemma countForkStepOnce (ticks: nat) (i s : Vector.t (Bvector 8) 1) :
   unIdent
     (stepOnce
        (ticks:=ticks)
-       (countFork (semantics:=SequentialVectorSemantics))
+       (countFork (combsemantics:=SequentialVectorCombSemantics))
        (i, s))
   = (countBySpec' (Vector.hd s) i, countBySpec' (Vector.hd s) i).
 Proof.
@@ -85,7 +85,7 @@ Lemma countForkCorrect ticks :
   forall(i : Vector.t (Bvector 8) ticks) (s : Vector.t (Bvector 8) 1),
     unIdent
       (loopSeqV' ticks (stepOnce (ticks:=ticks)
-                                 (countFork (semantics:=SequentialVectorSemantics)))
+                                 (countFork (combsemantics:=SequentialVectorCombSemantics)))
                  i s)
     = countBySpec' (Vector.hd s) i.
 Proof.

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -33,7 +33,8 @@ From Coq Require Import Bool.Bvector.
 (******************************************************************************)
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context `{CavaSeq} `{Monad cava}.
+
 
   Definition delayByte (i : signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8)) :=
@@ -84,7 +85,7 @@ Definition delayByte_tb
 (******************************************************************************)
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context `{semantics: CavaSeq} `{Monad cava}.
 
  (* A nand-gate with registers after the AND gate and the INV gate. *)
   Definition pipelinedNAND : signal Bit * signal Bit -> cava (signal Bit) :=


### PR DESCRIPTION
Following up on discussion with Satnam (and my own ambitions to do more sequential representation experiments), this PR makes the sequential Cava semantics into a class that "extends" the combinational one.

We had previously discussed putting the combinational semantics inside the class as a field, i.e.
```coq
Class CavaSeq signal :=
  { combinationalSemanatics :> Cava signal;
    ....
   }
```
However, I ran into two problems with that approach in contexts that looked like:
```
Context {signal} {semantics : Sequential signal}.
```
The first problem was that typeclass inference wanted to plug in every concrete instance it could possibly find before trying `(combinationalSemantics semantics)`. Since there are several such instances exported by `CavaMonad`, it was picking up all of those. However, I was able to work around this by decreasing the priority of those instances with `| 10`.

Then I ran into the second problem. In the pipelined nand example, we define a combinational nand and then compose it with delays, so we have a sequential instance in context and pull the combinational instance out of that. However, that now means that the nand we defined expects a _sequential instance_, meaning we can't call `combinational` on it. Already a little unhappy with the `| 10`s, I restructured a bit to make the combinational semantics an _argument_:
```coq
Class CavaSeq {signal}  (combinationalSemanatics : Cava signal) :=
   { ....
   }
```
Later, it can be added to context with
```
Context `{semantics : CavaSeq}.
```
...so the overhead didn't end up being terrible, although it's less than ideal. I ended up plugging in some explicit names for the count-by definition because I wanted to reference them for proofs later.