### PR TITLE
 Change addN to take a pair for better use in combinators

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@
 -Q third_party/coq-ext-lib/theories ExtLib
 -Q third_party/bedrock2/bedrock2/src/bedrock2 bedrock2
 -Q third_party/bedrock2/deps/coqutil/src/coqutil coqutil
+-Q tests Tests
 -Q monad-examples MonadExamples
 -Q monad-examples/xilinx XilinxExamples
 -Q arrow-examples ArrowExamples

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -67,4 +67,4 @@ Ltac simpl_ident :=
                                   instantiate_app_by_reflexivity ]
           | erewrite fold_left_ext; [ | intros; progress simpl_ident;
                                         instantiate_app_by_reflexivity ]
-          | progress cbn [fst snd mcompose bind ret Monad_ident unIdent] ].
+          | progress cbn [fst snd bind ret Monad_ident unIdent] ].

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -64,11 +64,12 @@ Section WithCava.
             cava (Vector.t (signal Bit) (n + 1)) :=
     adderWithGrowthNoCarryInV (vcombine a b).
 
-  (* Curried add with no carry in and no bit-growth, as signal. *)
+  (* Adder with a pair of inputs of the same size and no bit-growth, as signal. *)
   Definition addN {n : nat}
-            (a b: signal (Vec Bit n)) :
+            (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
             cava (signal (Vec Bit n)) :=
     const0 <- zero ;;
+    let (a, b) := ab in
     '(sum, _) <- unsignedAdderV (const0, vcombine (peel a) (peel b)) ;;
     ret (unpeel sum).
 

--- a/cava/Cava/Monad/Combinators.v
+++ b/cava/Cava/Monad/Combinators.v
@@ -330,20 +330,6 @@ Section WithCava.
     Vector.t A (2 ^ n) * Vector.t A (2 ^ n) :=
     splitat _ (@resize_default A (2 ^ (S n)) default (2 ^ n + 2 ^ n) v).
 
-  Fixpoint treeS {t: SignalType}
-                          {n : nat}
-                          (circuit: signal t -> signal t -> cava (signal t))
-                          (v : Vector.t (signal t) (2^(S n))) :
-                          cava (signal t) :=
-    match n, v return cava (signal t) with
-    | O, v2 => circuit (@Vector.nth_order _ 2 v2 0 (ltac:(lia)))
-                       (@Vector.nth_order _ 2 v2 1 (ltac:(lia)))
-    | S n', vR => let '(vL, vH) := divide defaultSignal vR in
-                  aS <- treeS circuit vL ;;
-                  bS <- treeS circuit vH ;;
-                  circuit aS bS
-    end.
-
   Fixpoint tree {T: Type} {m} `{Monad m}
                           (default : T) (n : nat)
                           (circuit: T -> T -> m T)
@@ -372,6 +358,15 @@ Section WithCava.
     rewrite resize_default_eq with (d0:=d).
     reflexivity.
   Qed.
+
+  (* A specialization of tree that is constrained to take Cava signal types
+    i.e. only types that we support as values over wires for Cava circuits.
+    This allows the default value to be computed automatically. *)
+  Definition treeS {t: SignalType} {n}
+                   (circuit: signal t * signal t -> cava (signal t))
+                   (v : Vector.t (signal t) (2^(S n))) :
+                   cava (signal t) :=
+  tree defaultSignal n (fun a b => circuit (a, b)) v.
 
   Local Open Scope nat_scope.
 

--- a/cava/Cava/Monad/Sequential.v
+++ b/cava/Cava/Monad/Sequential.v
@@ -62,7 +62,6 @@ parameter. The result of the loopSeq' is a list in the identity monad that
 represented the list of computed values and states at each tick.
 *)
 
-<<<<<<< HEAD
 Local Open Scope type_scope.
 
 Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
@@ -76,19 +75,6 @@ Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
     '(b', c') <- loopSeq' f xs ys ;; (* remaining steps of f *)
     ret (overlap 1 b b', overlap 1 c c')
   | _, _ => ret ([], [])
-=======
-Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
-         (f : seqType A * seqType C -> m (seqType B * seqType C)%type)
-         (a : seqType A) (feedback: seqType C)
-  : m (seqType B) :=
-  match a with
-  | [] => ret []
-  | x :: xs =>
-    '(yL, nextState) <- f ([x], feedback) ;; (* One step of f. *)
-    let y := hd defaultSignal yL in
-    ys <- loopSeq' f xs nextState ;; (* remaining steps of f *)
-    ret (y :: ys)
->>>>>>> 4a727e1 (parameterize loopSeq' over all monads and don't simplify mcompose in simpl_ident)
   end.
 
 (*

--- a/cava/Cava/Monad/Sequential.v
+++ b/cava/Cava/Monad/Sequential.v
@@ -62,10 +62,12 @@ parameter. The result of the loopSeq' is a list in the identity monad that
 represented the list of computed values and states at each tick.
 *)
 
-Fixpoint loopSeq' {A B C : SignalType}
-                  (f : seqType A * seqType C -> ident (seqType B * seqType C))
+Local Open Scope type_scope.
+
+Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
+                  (f : seqType A * seqType C -> m (seqType B * seqType C))
                   (a : seqType A) (feedback: seqType C)
-  : ident (seqType B * seqType C) :=
+  : m (seqType B * seqType C) :=
   match a, feedback with
   | x :: xs, y :: ys =>
     '(b, c) <- f ([x], [y]) ;; (* Process one input *)

--- a/cava/Cava/Monad/Sequential.v
+++ b/cava/Cava/Monad/Sequential.v
@@ -62,6 +62,7 @@ parameter. The result of the loopSeq' is a list in the identity monad that
 represented the list of computed values and states at each tick.
 *)
 
+<<<<<<< HEAD
 Local Open Scope type_scope.
 
 Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
@@ -75,6 +76,19 @@ Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
     '(b', c') <- loopSeq' f xs ys ;; (* remaining steps of f *)
     ret (overlap 1 b b', overlap 1 c c')
   | _, _ => ret ([], [])
+=======
+Fixpoint loopSeq' {m} `{Monad m} {A B C : SignalType}
+         (f : seqType A * seqType C -> m (seqType B * seqType C)%type)
+         (a : seqType A) (feedback: seqType C)
+  : m (seqType B) :=
+  match a with
+  | [] => ret []
+  | x :: xs =>
+    '(yL, nextState) <- f ([x], feedback) ;; (* One step of f. *)
+    let y := hd defaultSignal yL in
+    ys <- loopSeq' f xs nextState ;; (* remaining steps of f *)
+    ret (y :: ys)
+>>>>>>> 4a727e1 (parameterize loopSeq' over all monads and don't simplify mcompose in simpl_ident)
   end.
 
 (*

--- a/monad-examples/UnsignedAdderExamples.v
+++ b/monad-examples/UnsignedAdderExamples.v
@@ -46,11 +46,11 @@ Definition bv5_30 := N2Bv_sized 5 30.
 (******************************************************************************)
 
 (* Check 0 + 0 = 0 *)
-Example add0_0 : combinational (addN bv4_0 bv4_0) = bv4_0.
+Example add0_0 : combinational (addN (bv4_0, bv4_0)) = bv4_0.
 Proof. reflexivity. Qed.
 
 (* Check 15 + 1 = 0 *)
-Example add15_1 : combinational (addN bv4_15 bv4_1) = bv4_0.
+Example add15_1 : combinational (addN (bv4_15, bv4_1)) = bv4_0.
 Proof. reflexivity. Qed.
 
 Section WithCava.

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -69,7 +69,7 @@ Section WithCava.
 
   Definition addWithDelayStep (i : signal (Vec Bit 8) * signal (Vec Bit 8))
                        : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
-    newCount <- addN (fst i) (snd i) ;;
+    newCount <- addN i ;;
     newCount <- delay newCount ;;
     ret (newCount, newCount).
 

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -51,13 +51,8 @@ Section WithCava.
   Context {signal} {combsemantics: Cava signal}
           {semantics: CavaSeq combsemantics} `{Monad cava}.
 
-  Definition countFork (i : signal (Vec Bit 8) * signal (Vec Bit 8))
-                       : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
-    newCount <- addN (fst i) (snd i) ;;
-    ret (newCount, newCount).
-
   Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loop countFork.
+    := loop (addN >=> fork2).
 
 End WithCava.
 

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -58,16 +58,17 @@ Local Ltac seqsimpl := repeat seqsimpl_step.
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (H:=SequentialCombSemantics) a b) = addNSpec a b.
+  sequential (addN (H:=SequentialCombSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 
 Lemma countForkStep:
   forall (i : Bvector 8) (s : Bvector 8),
-    sequential (countFork ([i], [s]))
+    sequential ((addN >=> fork2) ([i], [s]))
     = (countBySpec' s [i], countBySpec' s [i]).
 Proof.
-  intros; cbv [countFork countBySpec'].
+  unfold mcompose.
+  intros; cbv [countBySpec'].
   seqsimpl; reflexivity.
 Qed.
 Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
@@ -79,11 +80,12 @@ Hint Rewrite @overlap_nil using solve [eauto] : seqsimpl.
 
 Lemma countForkCorrect:
   forall (i : list (Bvector 8)) (s : Bvector 8),
-    sequential (loopSeq' (countFork (combsemantics:=SequentialCombSemantics)) i [s])
+    sequential (loopSeq' (addN >=> fork2) i [s])
     = (countBySpec' s i, countBySpec' s i).
 Proof.
+  unfold mcompose.
   cbv [sequential]; induction i; intros; [ reflexivity | ].
-  seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.
+  seqsimpl. cbn [countBySpec']; simpl; rewrite IHi; reflexivity.
 Qed.
 Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -67,8 +67,7 @@ Lemma countForkStep:
     sequential ((addN >=> fork2) ([i], [s]))
     = (countBySpec' s [i], countBySpec' s [i]).
 Proof.
-  unfold mcompose.
-  intros; cbv [countBySpec'].
+  intros; cbv [countBySpec' mcompose].
   seqsimpl; reflexivity.
 Qed.
 Hint Rewrite countForkStep using solve [eauto] : seqsimpl.

--- a/tests/CountBy/TimedProofs.v
+++ b/tests/CountBy/TimedProofs.v
@@ -23,6 +23,7 @@ Export MonadNotation.
 
 Require Import Cava.Acorn.Identity.
 Require Import Cava.Cava.
+Require Import Cava.Monad.Combinators.
 Require Import Cava.ListUtils.
 Require Import Cava.Signal.
 Require Import Cava.Tactics.

--- a/tests/CountBy/TimedProofs.v
+++ b/tests/CountBy/TimedProofs.v
@@ -38,6 +38,11 @@ Require Import Tests.CountBy.CountBy.
 Section WithCava.
   Context `{semantics:CavaSeqMonad} `{Monad cava}.
 
+  Definition countFork (ab: signal (Vec Bit 8) * signal (Vec Bit 8)) :
+                       cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
+    sum <- addN ab;;
+    ret (sum, sum).
+
   Definition countBy : cava (signal (Vec Bit 8)) -> cava (signal (Vec Bit 8))
     := loopm countFork.
 End WithCava.
@@ -63,7 +68,7 @@ Local Ltac seqsimpl := repeat seqsimpl_step.
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : Bvector n) t :
-  addN (H:=TimedCombSemantics) a b t = addNSpec a b.
+  addN (H:=TimedCombSemantics) (a, b) t = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -66,9 +66,6 @@ Local Ltac seqsimpl_step :=
         | progress simpl_ident ].
 Local Ltac seqsimpl := repeat seqsimpl_step.
 
-(* TODO: because sequentialV ignores the ticks argument, using sequentialV
-   instead of unIdent means autorewrite doesn't work without explicit ticks. *)
-
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect ticks n (a b : Vector.t (Bvector n) ticks) :
   unIdent (addN (H:=SequentialVectorCombSemantics) (a, b)) = addNSpec a b.
@@ -96,8 +93,7 @@ Lemma countForkCorrect ticks :
                  i s)
     = countBySpec' (Vector.hd s) i.
 Proof.
-  unfold mcompose. 
-  cbv [sequentialV];  
+  cbv [sequentialV].
   induction ticks; intros; [ reflexivity | ].
   seqsimpl. cbn [countBySpec']. rewrite IHticks. reflexivity.
 Qed.

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -83,7 +83,7 @@ Lemma countForkStepOnce (ticks: nat) (i s : Vector.t (Bvector 8) 1) :
        (i, s))
   = (countBySpec' (Vector.hd s) i, countBySpec' (Vector.hd s) i).
 Proof.
-  intros; cbv [countBySpec' stepOnce].
+  intros. unfold mcompose. cbv [countBySpec' stepOnce].
   seqsimpl. reflexivity.
 Qed.
 Hint Rewrite countForkStepOnce using solve [eauto] : seqsimpl.
@@ -96,8 +96,10 @@ Lemma countForkCorrect ticks :
                  i s)
     = countBySpec' (Vector.hd s) i.
 Proof.
-  cbv [sequentialV]; induction ticks; intros; [ reflexivity | ].
-  seqsimpl. cbn [countBySpec']; rewrite IHticks; reflexivity.
+  unfold mcompose. 
+  cbv [sequentialV];  
+  induction ticks; intros; [ reflexivity | ].
+  seqsimpl. cbn [countBySpec']. rewrite IHticks. reflexivity.
 Qed.
 Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -25,6 +25,7 @@ Require Import Cava.Acorn.Identity.
 Require Import Cava.Cava.
 Require Import Cava.Tactics.
 Require Import Cava.Monad.CavaClass.
+Require Import Cava.Monad.Combinators.
 Require Import Cava.Monad.SequentialV.
 Require Import Cava.Lib.UnsignedAdders.
 
@@ -55,6 +56,12 @@ Local Ltac seqsimpl_step :=
                    [fst snd hd loopSeqV' loop SequentialVectorSemantics]
         | progress cbv beta iota delta [loopSeqV]; seqsimpl_step
         | progress autorewrite with seqsimpl
+        | lazymatch goal with
+          | |- context [(@SequentialVectorCombSemantics ?ticks)] =>
+            progress (change ident with (@cava _ (@SequentialVectorCombSemantics ticks));
+                      change @unIdent with (@sequentialV ticks));
+            seqsimpl_step
+          end
         | progress destruct_pair_let
         | progress simpl_ident ].
 Local Ltac seqsimpl := repeat seqsimpl_step.
@@ -64,28 +71,28 @@ Local Ltac seqsimpl := repeat seqsimpl_step.
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect ticks n (a b : Vector.t (Bvector n) ticks) :
-  unIdent (addN (H:=SequentialVectorCombSemantics) a b) = addNSpec a b.
+  unIdent (addN (H:=SequentialVectorCombSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 
 Lemma countForkStepOnce (ticks: nat) (i s : Vector.t (Bvector 8) 1) :
-  unIdent
+  sequentialV
     (stepOnce
        (ticks:=ticks)
-       (countFork (combsemantics:=SequentialVectorCombSemantics))
+       (addN >=> fork2)
        (i, s))
   = (countBySpec' (Vector.hd s) i, countBySpec' (Vector.hd s) i).
 Proof.
-  intros; cbv [countFork countBySpec' stepOnce].
+  intros; cbv [countBySpec' stepOnce].
   seqsimpl. reflexivity.
 Qed.
 Hint Rewrite countForkStepOnce using solve [eauto] : seqsimpl.
 
 Lemma countForkCorrect ticks :
   forall(i : Vector.t (Bvector 8) ticks) (s : Vector.t (Bvector 8) 1),
-    unIdent
+    sequentialV
       (loopSeqV' ticks (stepOnce (ticks:=ticks)
-                                 (countFork (combsemantics:=SequentialVectorCombSemantics)))
+                                 (addN >=> fork2))
                  i s)
     = countBySpec' (Vector.hd s) i.
 Proof.
@@ -97,9 +104,8 @@ Hint Rewrite countForkCorrect using solve [eauto] : seqsimpl.
 Lemma countByCorrect ticks (i : Vector.t (Bvector 8) ticks) :
   sequentialV (countBy i) = countBySpec i.
 Proof.
+  unfold mcompose.
   intros; cbv [countBy countBySpec].
   destruct ticks; seqsimpl; [ reflexivity | ].
-  seqsimpl.
-  rewrite (countForkCorrect ticks).
-  reflexivity.
+  seqsimpl. reflexivity.
 Qed.

--- a/tests/Delay.v
+++ b/tests/Delay.v
@@ -112,9 +112,8 @@ Definition pipelinedNAND_tb_inputs
 Definition pipelinedNAND_tb_expected_outputs
   := sequential (pipelinedNAND pipelinedNAND_tb_inputs).
 
-Compute list (tupleSimInterface (circuitInputs pipelinedNANDInterface)).
-
 (* TODO(satnam6502): Sequential interface for test-bench generation.
+Compute list (tupleSimInterface (circuitInputs pipelinedNANDInterface)).
 Definition pipelinedNAND_tb
   := testBench "pipelinedNAND_tb" pipelinedNANDInterface
      pipelinedNAND_tb_inputs pipelinedNAND_tb_expected_outputs.


### PR DESCRIPTION
This PR attempts to change the type of `addN` to take a pair rather than be a curried function, which lets me write `countBy` the way I want to:
```coq
  Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
    := loop (addN >=> fork2).
```
However, I run into trouble when I try to adapt the List proof. Specifically at:
```coq
Lemma countForkCorrect:
  forall (i : list (Bvector 8)) (s : Bvector 8),
    sequential (loopSeq' (addN >=> fork2) i [s])
    = countBySpec' s i.
```
Before the `sequential` line was:
```coq
    sequential (loopSeq' (countFork (combsemantics:=SequentialCombSemantics)) i [s])
```
which seems to use an annotation to make sure the `countFork` function is interpreted in the `ident` monad.
I can't work out how to write the equivalent thing for `addN >=> fork2` and currently get the error:
```
File "./CountBy/ListProofs.v", line 77, characters 26-40:
Error:
In environment
i : list (Bvector 8)
s : Bvector 8
The term "addN >=> fork2" has type
 "seqType (Vec Bit ?n) * seqType (Vec Bit ?n) ->
  cava (seqType (Vec Bit ?n) * seqType (Vec Bit ?n))"
while it is expected to have type
 "seqType (Vec Bit ?n) * seqType (Vec Bit ?n) ->
  ident (seqType ?B * seqType (Vec Bit ?n))".
```
@jadephilipoom do you know how to fix this? Thank you kindly.