### PR TITLE
Loop with sequential subcircuit

### DIFF
--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -1,0 +1,94 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import NArith.NArith Lists.List.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+
+Require Import Cava.Cava.
+Require Import Cava.Monad.CavaMonad.
+Require Import Cava.Lib.UnsignedAdders.
+
+(******************************************************************************)
+(* Add with delay                                                             *)
+(******************************************************************************)
+
+(*
+
+The add-with-delay circuit takes the current 8-bit input (in) and the current
+state value (on the wire labeled s), and adds them. After a one-cycle delay, the
+sum is passed on to the [out] wire, and then after another delay it becomes the
+new state. The adder is an 8-bit adder with no bit-growth i.e. it computes (a +
+b) mod 256.
+        _______
+    ---| delay |------------
+ s |   |_______|            |
+   |   ___      _______     |
+    --| + |----| delay |---------- out
+ in --|___|    |_______|
+
+
+Values at timestep t can be expressed in terms of previous values (assuming t > 2):
+
+out(t) = in(t-1) + s(t-1)
+s(t) = out(t-1) = in(t-2) + s(t-2)
+
+Examples:
+
+in  : 0 1 2 3 4 5 6  7  8
+out : 0 0 1 2 4 6 9 12 16 20
+s   : 0 0 0 1 2 4 6  9 12 16 20
+
+in  : 1 1 1 1 1 1 1 1 1
+out : 0 1 1 2 2 3 3 4 4 5
+s   : 0 0 1 1 2 2 3 3 4 4 5
+
+in  : 14 7 3 250
+out :  0 14 7 17 1
+s   :  0 0 14  7 17 1
+*)
+
+Section WithCava.
+  Context {signal} {combsemantics: Cava signal}
+          {semantics: CavaSeq combsemantics} `{Monad cava}.
+
+  Definition addWithDelayStep (i : signal (Vec Bit 8) * signal (Vec Bit 8))
+                       : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
+    newCount <- addN (fst i) (snd i) ;;
+    newCount <- delay newCount ;;
+    ret (newCount, newCount).
+
+  Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
+    := loop addWithDelayStep.
+
+End WithCava.
+
+(* Convenience notation for turning a list of nats into a list of 8-bit bitvectors *)
+Local Notation "'#' l" := (map (fun i => N2Bv_sized 8 (N.of_nat i)) l)
+                            (at level 40, only parsing).
+
+Local Open Scope list_scope.
+
+Example addWithDelay_ex1: sequential (addWithDelay (# [0;1;2;3;4;5;6;7;8])) = # [0;0;1;2;4;6;9;12;16;20].
+Proof. reflexivity. Qed.
+
+Example addWithDelay_ex2: sequential (addWithDelay (# [1;1;1;1;1;1;1;1;1])) = # [0;1;1;2;2;3;3;4;4;5].
+Proof. reflexivity. Qed.
+
+Example addWithDelay_ex3: sequential (addWithDelay (# [14; 7; 3; 250])) = # [0; 14; 7; 17; 1].
+Proof. reflexivity. Qed.

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -72,10 +72,15 @@ Proof.
 Qed.
 Hint Rewrite countForkStep using solve [eauto] : seqsimpl.
 
+(* TODO: this should live in a more general location *)
+Lemma overlap_nil {A} (x : seqType A) : overlap 0 [] x = x.
+Proof. reflexivity. Qed.
+Hint Rewrite @overlap_nil using solve [eauto] : seqsimpl.
+
 Lemma countForkCorrect:
   forall (i : list (Bvector 8)) (s : Bvector 8),
     sequential (loopSeq' (countFork (combsemantics:=SequentialCombSemantics)) i [s])
-    = countBySpec' s i.
+    = (countBySpec' s i, countBySpec' s i).
 Proof.
   cbv [sequential]; induction i; intros; [ reflexivity | ].
   seqsimpl. cbn [countBySpec']; rewrite IHi; reflexivity.

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -12,3 +12,5 @@ CountBy/CountBy.v
 CountBy/ListProofs.v
 CountBy/TimedProofs.v
 CountBy/VectorProofs.v
+
+AddWithDelay/AddWithDelay.v


### PR DESCRIPTION
I think (although not thoroughly tested by any means) I have figured out how to run sequential subcircuits inside of loops for the list-based representation. The key here is the observation that, because delays are represented in the value list, running the loop body on a single input gives me the values on the feedback wire from t=1 onward (1 because of the loop-feedback delay). If there are already values queued on the feedback wire, then my circuit is malformed if it produces anything but delays in those cases -- I can safely overwrite them with the values I already have.

The operation `overlap` performs this chaining of loop step outputs. I've added a test (no proofs yet) that is pretty much `countBy` but with an extra delay inserted inside the loop body.

What do people think of this representation? Especially keen to hear if either of you have any insights about whether it will generalize to subcircuits that are more complicated (I did try with two delays also, and it seems to work, but have not tried loops-within-loops or anything with variable delay).

