### PR TITLE
shift_rows/sub_bytes commutivity

### DIFF
--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -29,6 +29,15 @@ Section Misc.
 End Misc.
 
 Section Maps.
+  Lemma map_id_ext {A} (f : A -> A) (l : list A) :
+    (forall a, f a = a) -> map f l = l.
+  Proof.
+    intro Hf; induction l; [reflexivity|].
+    simpl.
+    rewrite Hf, IHl.
+    reflexivity.
+  Qed.
+
   Fixpoint map2 {A B C} (f : A -> B -> C) (ls1 : list A) ls2 :=
     match ls1, ls2 with
     | a :: ls1', b :: ls2' => f a b :: map2 f ls1' ls2'

--- a/silveroak-opentitan/aes/Spec/AddRoundKey.v
+++ b/silveroak-opentitan/aes/Spec/AddRoundKey.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/CipherRepresentationChange.v
+++ b/silveroak-opentitan/aes/Spec/CipherRepresentationChange.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/CommuteProperties.v
+++ b/silveroak-opentitan/aes/Spec/CommuteProperties.v
@@ -1,0 +1,72 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Coq.Init.Byte.
+Require Import Coq.Lists.List.
+
+Require Import AesSpec.ShiftRows.
+Require Import AesSpec.SubBytes.
+Require Import AesSpec.Sbox.
+
+Section Spec.
+  Section Properties.
+    Lemma sub_byte_shift_row_once_comm : forall row,
+      shift_row_once (map forward_sbox row) =
+      map forward_sbox (shift_row_once row).
+    Proof.
+      intros.
+      destruct row; [reflexivity|].
+      simpl.
+      rewrite map_app.
+      reflexivity.
+    Qed.
+
+    Lemma sub_byte_shift_row_comm : forall row shift,
+      shift_row (map forward_sbox row) shift =
+      map forward_sbox (shift_row row shift).
+    Proof.
+      intros.
+      generalize dependent row.
+      induction shift; [reflexivity|].
+      intros.
+      simpl.
+      rewrite <- IHshift.
+      rewrite sub_byte_shift_row_once_comm.
+      reflexivity.
+    Qed.
+
+    Lemma sub_bytes_shift_rows_start_comm : forall st n,
+      shift_rows_start (sub_bytes st) n =
+      sub_bytes (shift_rows_start st n).
+    Proof.
+      induction st; [reflexivity|].
+      intro n.
+      unfold shift_rows_start.
+      simpl.
+      rewrite sub_byte_shift_row_comm.
+      unfold shift_rows_start in IHst.
+      rewrite IHst.
+      reflexivity.
+    Qed.
+
+    Theorem sub_bytes_shift_rows_comm : forall st,
+      shift_rows (sub_bytes st) = sub_bytes (shift_rows st).
+    Proof.
+      intros.
+      apply (sub_bytes_shift_rows_start_comm st 0).
+    Qed.
+  End Properties.
+End Spec.

--- a/silveroak-opentitan/aes/Spec/Placeholder/MixColumns.v
+++ b/silveroak-opentitan/aes/Spec/Placeholder/MixColumns.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/Sbox.v
+++ b/silveroak-opentitan/aes/Spec/Sbox.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/ShiftRows.v
+++ b/silveroak-opentitan/aes/Spec/ShiftRows.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/ShiftRows.v
+++ b/silveroak-opentitan/aes/Spec/ShiftRows.v
@@ -34,8 +34,11 @@ Section Spec.
     | S r' => shift_row (shift_row_once w) r'
     end.
 
+  Definition shift_rows_start (st : state) (n : nat) :=
+    map2 shift_row st (List.seq n (length st)).
+
   Definition shift_rows (st : state) :=
-    map2 shift_row st (List.seq 0 (length st)).
+    shift_rows_start st 0.
 
   Definition inv_shift_row (w : word) (r : nat) :=
     rev (shift_row (rev w) r).
@@ -44,6 +47,15 @@ Section Spec.
     map2 inv_shift_row st (List.seq 0 (length st)).
 
   Section Properties.
+    Lemma shift_row_nil : forall shift,
+      shift_row nil shift = nil.
+    Proof.
+      induction shift; [reflexivity|].
+      simpl.
+      rewrite IHshift.
+      reflexivity.
+    Qed.
+
     Lemma inv_shift_row_hd w h : inv_shift_row (w ++ h :: nil) 1 = h :: w.
     Proof.
       unfold inv_shift_row.
@@ -106,6 +118,7 @@ Section Spec.
     Proof.
       unfold shift_rows.
       unfold inv_shift_rows.
+      unfold shift_rows_start.
 
       rewrite map2_length.
       rewrite seq_length.

--- a/silveroak-opentitan/aes/Spec/SubBytes.v
+++ b/silveroak-opentitan/aes/Spec/SubBytes.v
@@ -1,3 +1,4 @@
+(****************************************************************************)
 (* Copyright 2020 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)

--- a/silveroak-opentitan/aes/Spec/SubBytes.v
+++ b/silveroak-opentitan/aes/Spec/SubBytes.v
@@ -14,14 +14,15 @@
 (****************************************************************************)
 
 Require Import Coq.Init.Byte.
-Require Import Coq.Vectors.Vector.
-Require Import Cava.VectorUtils.
+Require Import Coq.Lists.List.
+
 Require Import AesSpec.Sbox.
+Require Import Cava.ListUtils.
 
 Section Spec.
   Variables bytes_per_word Nb : nat.
-  Local Notation word := (Vector.t byte bytes_per_word) (only parsing).
-  Local Notation state := (Vector.t word Nb) (only parsing).
+  Local Notation word := (list byte) (only parsing).
+  Local Notation state := (list word) (only parsing).
 
   Definition sub_bytes : state -> state :=
     map (map forward_sbox).
@@ -47,8 +48,9 @@ Section Spec.
       rewrite map_map.
       rewrite map_id_ext.
       { reflexivity. }
-      { intros.
-        destruct a; reflexivity. }
+      { intro b.
+        destruct b; reflexivity. }
     Qed.
+
   End Properties.
 End Spec.

--- a/silveroak-opentitan/aes/Spec/Tests/CipherTest.v
+++ b/silveroak-opentitan/aes/Spec/Tests/CipherTest.v
@@ -90,7 +90,7 @@ Definition add_round_key (k : round_key) (st : state) : state :=
   from_cols_bits (add_round_key bits_per_word Nb st k).
 
 Definition sub_bytes (st : state) : state :=
-  from_cols (SubBytes.sub_bytes _ _ (to_cols st)).
+  from_list_rows (SubBytes.sub_bytes (to_list_rows st)).
 
 Definition shift_rows (st : state) : state :=
   from_list_rows (shift_rows (to_list_rows st)).
@@ -99,7 +99,7 @@ Definition mix_columns (st : state) : state :=
   from_cols (mix_columns (to_cols st)).
 
 Definition inv_sub_bytes (st : state) : state :=
-  from_cols (SubBytes.inv_sub_bytes _ _ (to_cols st)).
+  from_list_rows (SubBytes.inv_sub_bytes (to_list_rows st)).
 
 Definition inv_shift_rows (st : state) : state :=
   from_list_rows (inv_shift_rows (to_list_rows st)).

--- a/silveroak-opentitan/aes/Spec/_CoqProject
+++ b/silveroak-opentitan/aes/Spec/_CoqProject
@@ -6,6 +6,7 @@ INSTALLDEFAULTROOT = AesSpec
 AddRoundKey.v
 Cipher.v
 CipherRepresentationChange.v
+CommuteProperties.v
 ExpandAllKeys.v
 InterleavedCipher.v
 InterleavedInverseCipher.v


### PR DESCRIPTION
Please leave suggestion for how to name 'CommuteProperties.v'. I'm not sure on this, but was imagining we'd have the mix columns/sub bytes commutativity property there as well.

closes #310 