### PR TITLE
Proofs for add-with-delay

### DIFF
--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -282,4 +282,4 @@ Definition bufBoolList (i : list bool) : ident (list bool) :=
 (* behavioural simulation result.                                             *)
 (******************************************************************************)
 
-Definition sequential {a} (circuit : cava a) : a := unIdent circuit.
+ Definition sequential {A} (circuit : cava A) : A := unIdent circuit.

--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -282,4 +282,4 @@ Definition bufBoolList (i : list bool) : ident (list bool) :=
 (* behavioural simulation result.                                             *)
 (******************************************************************************)
 
- Definition sequential {A} (circuit : cava A) : A := unIdent circuit.
+Definition sequential {A} (circuit : cava A) : A := unIdent circuit.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -31,7 +31,7 @@ Require Import Cava.Lib.FullAdder.
 Local Open Scope vector_scope.
 
 Section WithCava.
-  Context {signal} `{Cava signal} `{Monad cava}.
+  Context {signal} {semantics: Cava signal} `{Monad cava}.
 
   (* Vector version *)
 

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -8,8 +8,11 @@ Local Open Scope list_scope.
 Hint Rewrite @app_nil_l @app_nil_r @last_last @rev_app_distr : listsimpl.
 
 (* Natural number simplifications are also useful for lists *)
+Lemma sub_succ_l_same n : S n - n = 1.
+Proof. lia. Qed.
 Hint Rewrite Nat.add_0_l Nat.add_0_r Nat.sub_0_r Nat.sub_0_l Nat.sub_diag
      using solve [eauto] : natsimpl.
+Hint Rewrite Nat.sub_succ sub_succ_l_same using solve [eauto] : natsimpl.
 Hint Rewrite Min.min_r Min.min_l Nat.add_sub using lia : natsimpl.
 Hint Rewrite (fun n m => proj2 (Nat.sub_0_le n m)) using lia : natsimpl.
 
@@ -26,6 +29,9 @@ Hint Rewrite @nil_length @cons_length @seq_length @repeat_length @rev_length
      using solve [eauto] : push_length.
 Ltac length_hammer :=
   autorewrite with push_length; eauto; lia.
+
+(* The push_nth database simplifies goals including [nth] *)
+Hint Rewrite @app_nth1 @app_nth2 using length_hammer : push_nth.
 
 (* Miscellaneous proofs about lists *)
 Section Misc.
@@ -117,7 +123,7 @@ Section FirstnSkipn.
   Proof.
     revert n x; induction m; intros; [ rewrite skipn_nil; reflexivity | ].
     destruct n; autorewrite with natsimpl; [ reflexivity | ].
-    cbn [repeat skipn]. rewrite Nat.sub_succ.
+    cbn [repeat skipn].
     rewrite IHm; reflexivity.
   Qed.
 

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -765,6 +765,10 @@ Section VectorFacts.
     rewrite IHv; reflexivity.
   Qed.
 
+  Lemma const_cons {A n} (a : A) :
+    const a (S n) = Vector.cons _ a _ (const a n).
+  Proof. reflexivity. Qed.
+
   Lemma const_nil {A n} (v : t (t A 0) n) : v = const (nil _) _.
   Proof.
     revert v; induction n; [ solve [vnil] | ].

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -67,14 +67,8 @@ Section WithCava.
   Context {signal} {combsemantics: Cava signal}
           {semantics: CavaSeq combsemantics} `{Monad cava}.
 
-  Definition addWithDelayStep (i : signal (Vec Bit 8) * signal (Vec Bit 8))
-                       : cava (signal (Vec Bit 8) * signal (Vec Bit 8)) :=
-    newCount <- addN i ;;
-    newCount <- delay newCount ;;
-    ret (newCount, newCount).
-
   Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loopDelay addWithDelayStep.
+    := loopDelay (addN >=> delay >=> fork2).
 
 End WithCava.
 

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -58,7 +58,7 @@ Definition addNSpec {n} (a b : seqType (Vec Bit n)) :=
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (H:=SequentialCombSemantics) (a, b)) = addNSpec a b.
+  sequential (addN (semantics:=SequentialCombSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -56,7 +56,6 @@ Definition addWithDelaySpecF
 Definition addNSpec {n} (a b : seqType (Vec Bit n)) :=
   map2 bvadd a b.
 
-(* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : list (Bvector n)) :
   sequential (addN (semantics:=SequentialCombSemantics) (a, b)) = addNSpec a b.
 Admitted.

--- a/tests/AddWithDelay/ListProofs.v
+++ b/tests/AddWithDelay/ListProofs.v
@@ -1,0 +1,124 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+From Coq Require Import Arith.PeanoNat NArith.NArith Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.Bool.Bvector.
+Import ListNotations.
+
+Require Import ExtLib.Structures.Monads.
+Export MonadNotation.
+
+Require Import coqutil.Tactics.Tactics.
+
+Require Import Cava.Cava.
+Require Import Cava.ListUtils.
+Require Import Cava.Tactics.
+Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Identity.
+Require Import Cava.Acorn.SequentialProperties.
+Require Import Cava.Lib.UnsignedAdders.
+
+Require Import Tests.AddWithDelay.AddWithDelay.
+Local Open Scope nat_scope.
+
+Definition bvadd {n} (a b : Signal.combType (Vec Bit n)) : Signal.combType (Vec Bit n) :=
+  N2Bv_sized n (Bv2N a + Bv2N b).
+
+Definition bvzero {n} : Signal.combType (Vec Bit n) := N2Bv_sized n 0.
+
+Definition addWithDelaySpecF
+           (input : nat -> Signal.combType (Vec Bit 8)) : nat -> Signal.combType (Vec Bit 8) :=
+  fix out (t : nat) :=
+    match t with
+    | 0 => bvzero (* first round is just a delay *)
+    | 1 =>
+      (* second round is first input (because initial feedback = 0) *)
+      input 0
+    | S (S t') =>
+      (* if t > 2, out(t) = in(t-1) + out(t-2) *)
+      bvadd (input (S t')) (out t')
+    end.
+
+Definition addNSpec {n} (a b : seqType (Vec Bit n)) :=
+  map2 bvadd a b.
+
+(* TODO: rename typeclass arguments *)
+Lemma addNCorrect n (a b : list (Bvector n)) :
+  sequential (addN (H:=SequentialCombSemantics) (a, b)) = addNSpec a b.
+Admitted.
+Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
+
+Lemma addWithDelayStepCorrect :
+  forall (i : Bvector 8) (s : Bvector 8),
+    sequential ((addN >=> delay >=> fork2) ([i], [s]))
+    = ([bvzero; bvadd i s], [bvzero; bvadd i s]).
+Proof.
+  intros. seqsimpl. reflexivity.
+Qed.
+Hint Rewrite addWithDelayStepCorrect using solve [eauto] : seqsimpl.
+
+Lemma Bv2N_bvzero n : Bv2N (@bvzero n) = 0%N.
+Proof.
+  cbv [bvzero N2Bv_sized Bvect_false].
+  induction n; intros; [ reflexivity | ].
+  rewrite const_cons. cbn [Bv2N].
+  rewrite IHn. reflexivity.
+Qed.
+
+Lemma bvadd_bvzero_l {n} (x : Bvector n) : bvadd x bvzero = x.
+Proof.
+  cbv [bvadd]. rewrite Bv2N_bvzero.
+  rewrite N.add_0_r, N2Bv_sized_Bv2N.
+  reflexivity.
+Qed.
+
+Lemma addWithDelayCorrect (i : list (Bvector 8)) :
+  sequential (addWithDelay i) = map (fun t => addWithDelaySpecF (fun n => nth n i bvzero) t)
+                                    (seq 0 (if length i =? 0 then 0 else S (length i))).
+Proof.
+  intros; cbv [addWithDelay].
+  eapply (loop_invariant_alt (B:=Vec Bit 8) (C:=Vec Bit 8))
+    with (I:=fun t acc feedback =>
+               0 < t
+               /\ feedback = [nth (t-1) acc bvzero; nth t acc bvzero]
+               /\ acc = map (fun t => addWithDelaySpecF
+                                    (fun n => nth n i bvzero) t) (seq 0 (S t))).
+  { (* invariant is satisfied at start *)
+    destruct i; [ ssplit; reflexivity | ].
+    seqsimpl. autorewrite with natsimpl.
+    cbn [nth map seq addWithDelaySpecF].
+    change (Signal.defaultCombValue (Vec Bit 8)) with (@bvzero 8).
+    rewrite bvadd_bvzero_l. ssplit; (reflexivity || lia). }
+  { (* invariant holds through loop *)
+    intros *. intros [Ht [Hfeedback Hacc]]. cbv zeta; intros.
+    subst. seqsimpl.
+    rewrite seq_S, map_app. cbn [map].
+    rewrite !overlap_snoc_cons by length_hammer.
+    autorewrite with push_nth push_length natsimpl.
+    cbn [nth]. ssplit; [ lia | reflexivity | ].
+    rewrite !seq_S, !map_app. cbn [map].
+    autorewrite with natsimpl. cbn [addWithDelaySpecF].
+    destruct t; [ lia | ].
+    rewrite !seq_S, !map_app. cbn [map].
+    autorewrite with natsimpl push_length push_nth.
+    cbn [nth]. rewrite <-!app_assoc.
+    reflexivity. }
+  { (* invariant implies postcondition *)
+    intros *; intros [Ht [Hfeedback Hacc]]; intros.
+    subst. destruct i; autorewrite with push_length in *; [ lia | ].
+    reflexivity. }
+Qed.

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -45,9 +45,8 @@ Definition countBySpec (i : list (Bvector 8)) : list (Bvector 8) :=
 Definition addNSpec {n} (a b : list (Bvector n)) : list (Bvector n) :=
   map2 bvadd a b.
 
-(* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : list (Bvector n)) :
-  sequential (addN (H:=SequentialCombSemantics) (a, b)) = addNSpec a b.
+  sequential (addN (semantics:=SequentialCombSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/TimedProofs.v
+++ b/tests/CountBy/TimedProofs.v
@@ -67,9 +67,8 @@ Local Ltac seqsimpl_step :=
         | progress simpl_timed ].
 Local Ltac seqsimpl := repeat seqsimpl_step.
 
-(* TODO: rename typeclass arguments *)
 Lemma addNCorrect n (a b : Bvector n) t :
-  addN (H:=TimedCombSemantics) (a, b) t = addNSpec a b.
+  addN (semantics:=TimedCombSemantics) (a, b) t = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/CountBy/VectorProofs.v
+++ b/tests/CountBy/VectorProofs.v
@@ -68,7 +68,7 @@ Local Ltac seqsimpl := repeat seqsimpl_step.
 
 (* TODO: rename typeclass arguments *)
 Lemma addNCorrect ticks n (a b : Vector.t (Bvector n) ticks) :
-  unIdent (addN (H:=SequentialVectorCombSemantics) (a, b)) = addNSpec a b.
+  unIdent (addN (semantics:=SequentialVectorCombSemantics) (a, b)) = addNSpec a b.
 Admitted.
 Hint Rewrite addNCorrect using solve [eauto] : seqsimpl.
 

--- a/tests/_CoqProject
+++ b/tests/_CoqProject
@@ -14,3 +14,4 @@ CountBy/TimedProofs.v
 CountBy/VectorProofs.v
 
 AddWithDelay/AddWithDelay.v
+AddWithDelay/ListProofs.v


### PR DESCRIPTION
Resolves #387 
Related: #371

I ended up using a pretty non-mechanical specification after all, which follows the function-from-nat model of sequential semantics similar to the timed monad. It was just the most natural way (for me) to encode what this contrived circuit is doing. Nonetheless, the proof went through just fine, although with more list-manipulation reasoning. I've been gradually improving our automation for list proofs, so if we end up wanting to go this direction the proofs should get less annoying over time.