### PR TITLE
Add loopDelayS and loopDelaySEnable for state output

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -99,17 +99,32 @@ Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signa
   delay : forall {t: SignalType}, signal t -> cava (signal t);
   (* A unit delay with enable. *)
   delayEnable : forall {t: SignalType}, signal Bit -> signal t -> cava (signal t);
-  (* Feeback loop, with unit delay inserted into the feedback path. *)
+  (* Feedback loop, with unit delay inserted into the feedback path.
+     TODO(satnam6502, jadephilipoom): Define this in terms of loopDelayS and
+     then remove from typeclass. *) 
   loopDelay : forall {A B C: SignalType},
               (signal A * signal C -> cava (signal B * signal C)) ->
               signal A ->
               cava (signal B);
+  (* Feedback loop, with unit delay inserted into the feedback path and current
+     state available at output . *)
+  loopDelayS : forall {A B C: SignalType},
+               (signal A * signal C -> cava (signal B * signal C)) ->
+               signal A ->
+               cava (signal B * signal C);
   (* A version of loopDelay with a clock enable. *)
   loopDelayEnable : forall {A B C: SignalType},
                     signal Bit -> (* Clock enable *)
                     (signal A * signal C -> cava (signal B * signal C)) ->
                     signal A ->
                     cava (signal B);
+  (* A version of loopDelayEnable with a clock enable and current state at
+     the output. *)
+  loopDelaySEnable : forall {A B C: SignalType},
+                     signal Bit -> (* Clock enable *)
+                     (signal A * signal C -> cava (signal B * signal C)) ->
+                     signal A ->
+                     cava (signal B * signal C);
 }.
 
 (* Alternate version of sequential semantics which assumes the sequential part

--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -108,10 +108,10 @@ Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signa
               cava (signal B);
   (* Feedback loop, with unit delay inserted into the feedback path and current
      state available at output . *)
-  loopDelayS : forall {A B C: SignalType},
-               (signal A * signal C -> cava (signal B * signal C)) ->
+  loopDelayS : forall {A B: SignalType},
+               (signal A * signal B -> cava (signal B)) ->
                signal A ->
-               cava (signal B * signal C);
+               cava (signal B);
   (* A version of loopDelay with a clock enable. *)
   loopDelayEnable : forall {A B C: SignalType},
                     signal Bit -> (* Clock enable *)
@@ -120,11 +120,11 @@ Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signa
                     cava (signal B);
   (* A version of loopDelayEnable with a clock enable and current state at
      the output. *)
-  loopDelaySEnable : forall {A B C: SignalType},
+  loopDelaySEnable : forall {A B: SignalType},
                      signal Bit -> (* Clock enable *)
-                     (signal A * signal C -> cava (signal B * signal C)) ->
+                     (signal A * signal B -> cava (signal B)) ->
                      signal A ->
-                     cava (signal B * signal C);
+                     cava (signal B);
 }.
 
 (* Alternate version of sequential semantics which assumes the sequential part

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -295,6 +295,10 @@ Section WithCava.
 
   Definition fork2 `{Monad_m : Monad cava} {A} (a:A) := ret (a, a).
 
+  (****************************************************************************)
+  (* Operations over pairs.                                                   *)
+  (****************************************************************************)
+
   Definition first `{Monad_m : Monad cava} {A B C} (f : A -> cava C) (ab : A * B) : cava (C * B) :=
     let '(a, b) := ab in
     c <- f a ;;
@@ -304,6 +308,16 @@ Section WithCava.
     let '(a, b) := ab in
     c <- f b ;;
     ret (a, c).
+
+  (* Project out the first element of a pair. *)
+  Definition projFst `{Monad_m : Monad cava} {A B} (ab : A * B) : cava A :=
+    let '(a, _) := ab in
+    ret a.
+
+  (* Project out the second element of a pair. *)
+  Definition projSnd `{Monad_m : Monad cava} {A B} (ab : A * B) : cava B :=
+    let '(_, b) := ab in
+    ret b.
 
   (****************************************************************************)
   (* Swap                                                                     *)

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -258,6 +258,18 @@ Definition loopNet (A B C : SignalType)
   assignSignal o oDelay ;;
   ret b.
 
+(* Create a loop circuit with a delay element along the feedback path which
+   makes the current state available at the output. *)
+Definition loopNetS (A B C : SignalType)
+                    (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
+                    (a : Signal A)
+                    : state CavaState (Signal B * Signal C) :=
+  o <- @newSignal C ;;
+  '(b, cOut) <- f (a, o) ;;
+  oDelay <- delayNet C cOut ;;
+  assignSignal o oDelay ;;
+  ret (b, o).
+
 (* Create a loop circuit with a delay element with enable along the feedback path. *)
 Definition loopNetEnable (A B C : SignalType)
                          (en : Signal Bit)
@@ -269,6 +281,19 @@ Definition loopNetEnable (A B C : SignalType)
   oDelay <- delayEnableNet C en cOut ;;
   assignSignal o oDelay ;;
   ret b.
+
+(* Create a loop circuit with a delay element with enable along the feedback
+   path with the current state exposed at the output. *)
+Definition loopNetEnableS (A B C : SignalType)
+                          (en : Signal Bit)
+                          (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
+                          (a : Signal A)
+                         : state CavaState (Signal B * Signal C) :=
+  o <- @newSignal C ;;
+  '(b, cOut) <- f (a, o) ;;
+  oDelay <- delayEnableNet C en cOut ;;
+  assignSignal o oDelay ;;
+  ret (b, o).
 
 Definition instantiateNet (intf : CircuitInterface)
                           (circuit : tupleNetInterface (circuitInputs intf) ->
@@ -325,5 +350,7 @@ Instance CavaSequentialNet : CavaSeq CavaCombinationalNet :=
   { delay k := delayNet k;
     delayEnable k := delayEnableNet k;
     loopDelay a b c := loopNet a b c;
+    loopDelayS a b c := loopNetS a b c;
     loopDelayEnable en a b c := loopNetEnable en a b c;
+    loopDelaySEnable en a b c := loopNetEnableS en a b c;
   }.

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -260,15 +260,15 @@ Definition loopNet (A B C : SignalType)
 
 (* Create a loop circuit with a delay element along the feedback path which
    makes the current state available at the output. *)
-Definition loopNetS (A B C : SignalType)
-                    (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
+Definition loopNetS (A B : SignalType)
+                    (f : Signal A * Signal B -> state CavaState (Signal B))
                     (a : Signal A)
-                    : state CavaState (Signal B * Signal C) :=
-  o <- @newSignal C ;;
-  '(b, cOut) <- f (a, o) ;;
-  oDelay <- delayNet C cOut ;;
+                    : state CavaState (Signal B) :=
+  o <- @newSignal B ;;
+  out <- f (a, o) ;;
+  oDelay <- delayNet B out ;;
   assignSignal o oDelay ;;
-  ret (b, o).
+  ret out.
 
 (* Create a loop circuit with a delay element with enable along the feedback path. *)
 Definition loopNetEnable (A B C : SignalType)
@@ -284,16 +284,16 @@ Definition loopNetEnable (A B C : SignalType)
 
 (* Create a loop circuit with a delay element with enable along the feedback
    path with the current state exposed at the output. *)
-Definition loopNetEnableS (A B C : SignalType)
+Definition loopNetEnableS (A B : SignalType)
                           (en : Signal Bit)
-                          (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
+                          (f : Signal A * Signal B -> state CavaState (Signal B))
                           (a : Signal A)
-                         : state CavaState (Signal B * Signal C) :=
-  o <- @newSignal C ;;
-  '(b, cOut) <- f (a, o) ;;
-  oDelay <- delayEnableNet C en cOut ;;
+                         : state CavaState (Signal B) :=
+  o <- @newSignal B ;;
+  out <- f (a, o) ;;
+  oDelay <- delayEnableNet B en out ;;
   assignSignal o oDelay ;;
-  ret (b, o).
+  ret out.
 
 Definition instantiateNet (intf : CircuitInterface)
                           (circuit : tupleNetInterface (circuitInputs intf) ->
@@ -350,7 +350,7 @@ Instance CavaSequentialNet : CavaSeq CavaCombinationalNet :=
   { delay k := delayNet k;
     delayEnable k := delayEnableNet k;
     loopDelay a b c := loopNet a b c;
-    loopDelayS a b c := loopNetS a b c;
+    loopDelayS a b := loopNetS a b;
     loopDelayEnable en a b c := loopNetEnable en a b c;
-    loopDelaySEnable en a b c := loopNetEnableS en a b c;
+    loopDelaySEnable en a b := loopNetEnableS en a b;
   }.

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -111,6 +111,16 @@ Definition loopSeqV {A B C : SignalType}
                 a [defaultCombValue C]
   end.
 
+(* Dummy definition for loopSeqV for now.
+   TODO(satnam6502, defaultSignal): implement. *)
+Definition loopSeqSV {A B C : SignalType}
+                     (ticks : nat)
+    (f : seqVType ticks A * seqVType ticks C
+         -> ident ((seqVType ticks B) * (seqVType ticks C)))
+    (i : seqVType ticks A)
+    :  ident (seqVType ticks B * seqVType ticks C) :=
+  ret (Vector.const defaultSignal ticks, Vector.const defaultSignal ticks).
+
 (******************************************************************************)
 (* A boolean sequential logic interpretation for the Cava class               *)
 (******************************************************************************)
@@ -328,14 +338,17 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
    : CavaSeq SequentialVectorCombSemantics:=
    { delay k i := delayV ticks k i;
      (* Dummy definition now for delayEnable.
-        TODO(satnam6502, jadep): implement delayEnableV
+        TODO(satnam6502, jadephilipoom): implement delayEnableV
      *)
      delayEnable k en i := delayV ticks k i;
      loopDelay A B C := @loopSeqV A B C ticks;
+     (* Dummy definition for now for loopDelayS *)
+     loopDelayS A B C := @loopSeqSV A B C ticks;
      (* TODO(satnam6502, jadep): Placeholder definition for loopDelayEnable for
         now. Replace with actual definition that models clock enable behaviour.
      *)
      loopDelayEnable A B C en := @loopSeqV A B C ticks;
+     loopDelaySEnable A B C en := @loopSeqSV A B C ticks; (* Dummy *)
    }.
 
 (******************************************************************************)

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -113,13 +113,13 @@ Definition loopSeqV {A B C : SignalType}
 
 (* Dummy definition for loopSeqV for now.
    TODO(satnam6502, defaultSignal): implement. *)
-Definition loopSeqSV {A B C : SignalType}
+Definition loopSeqSV {A B : SignalType}
                      (ticks : nat)
-    (f : seqVType ticks A * seqVType ticks C
-         -> ident ((seqVType ticks B) * (seqVType ticks C)))
+    (f : seqVType ticks A * seqVType ticks B
+         -> ident (seqVType ticks B))
     (i : seqVType ticks A)
-    :  ident (seqVType ticks B * seqVType ticks C) :=
-  ret (Vector.const defaultSignal ticks, Vector.const defaultSignal ticks).
+    :  ident (seqVType ticks B) :=
+  ret (Vector.const defaultSignal ticks).
 
 (******************************************************************************)
 (* A boolean sequential logic interpretation for the Cava class               *)
@@ -343,12 +343,12 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
      delayEnable k en i := delayV ticks k i;
      loopDelay A B C := @loopSeqV A B C ticks;
      (* Dummy definition for now for loopDelayS *)
-     loopDelayS A B C := @loopSeqSV A B C ticks;
+     loopDelayS A B := @loopSeqSV A B ticks;
      (* TODO(satnam6502, jadep): Placeholder definition for loopDelayEnable for
         now. Replace with actual definition that models clock enable behaviour.
      *)
      loopDelayEnable A B C en := @loopSeqV A B C ticks;
-     loopDelaySEnable A B C en := @loopSeqSV A B C ticks; (* Dummy *)
+     loopDelaySEnable A B en := @loopSeqSV A B ticks; (* Dummy *)
    }.
 
 (******************************************************************************)

--- a/tests/SignallingCounter/SignallingCounter.v
+++ b/tests/SignallingCounter/SignallingCounter.v
@@ -109,8 +109,21 @@ Section WithCava.
   Definition counterWithEnable (en : signal Bit) :
                                signal (Vec Bit 8) ->
                                cava (signal (Vec Bit 8)) :=
-    loopDelayEnable en (addN >=> fork2).
+    loopDelaySEnable en (addN >=> fork2) >=> projSnd.
+
+
+  Definition counterWithEnableTop (i_en : signal (Pair (Vec Bit 8) Bit))
+                                  : cava (signal (Vec Bit 8)) :=
+  let '(i, en) := unpair i_en in
+  counterWithEnable en i.
+
 End WithCava.
+
+
+Compute map Bv2N (sequential (counterWithEnableTop
+                (combine
+                   (# [1;1;1;1;1;1;1;1])
+                   (map nat2bool [1;1;1;1;0;0;0;0])))).
 
 (* Note that the signalling counter with delay is slightly different than the
    one above, in that when not enabled it *does* add the input to the current
@@ -119,9 +132,10 @@ End WithCava.
    unsaved addition result. *)
 
 Example counterEnable_ex1:
-  sequential (counterWithEnable
-                (map nat2bool [1;1;1;1;0;0;0;0])
-                (# [1;1;1;1;1;1;1;1])) = # [1;2;3;4;5;5;5;5].
+  sequential (counterWithEnableTop
+                (combine
+                   (# [1;1;1;1;1;1;1;1])
+                   (map nat2bool [1;1;1;1;0;0;0;0]))) = # [1;2;3;4;4;4;4;4].
 Proof. reflexivity. Qed.
 
 Example counterEnable_ex2:

--- a/tests/SignallingCounter/SignallingCounter.v
+++ b/tests/SignallingCounter/SignallingCounter.v
@@ -109,7 +109,7 @@ Section WithCava.
   Definition counterWithEnable (en : signal Bit) :
                                signal (Vec Bit 8) ->
                                cava (signal (Vec Bit 8)) :=
-    loopDelaySEnable en (addN >=> fork2) >=> projSnd.
+    loopDelaySEnable en addN.
 
 
   Definition counterWithEnableTop (i_en : signal (Pair (Vec Bit 8) Bit))

--- a/tests/SignallingCounter/SignallingCounter.v
+++ b/tests/SignallingCounter/SignallingCounter.v
@@ -119,18 +119,6 @@ Section WithCava.
 
 End WithCava.
 
-
-Compute map Bv2N (sequential (counterWithEnableTop
-                (combine
-                   (# [1;1;1;1;1;1;1;1])
-                   (map nat2bool [1;1;1;1;0;0;0;0])))).
-
-(* Note that the signalling counter with delay is slightly different than the
-   one above, in that when not enabled it *does* add the input to the current
-   state, and returns this result, but does not save it. The directly defined
-   version of the counter returns the saved (unchanged) state instead of the
-   unsaved addition result. *)
-
 Example counterEnable_ex1:
   sequential (counterWithEnableTop
                 (combine
@@ -141,5 +129,5 @@ Proof. reflexivity. Qed.
 Example counterEnable_ex2:
   sequential (counterWithEnable
                 (map nat2bool [0;0;0;1;1;1;0;1])
-                (# [0;1;2;3;4;5;6;7]) ) = # [0;1;2;3;7;12;18;19].
+                (# [0;1;2;3;4;5;6;7]) ) = # [0;0;0;3;7;12;12;19].
 Proof. reflexivity. Qed.


### PR DESCRIPTION
This PR is a work in progress that attempts to add new loop combinators that expose the current state value directly at the output.
See  #371 for details.

The current formulation is wrong as illustrated by the failed `Example` in `SignallingCounter.v":
```coq
Compute map Bv2N (sequential (counterWithEnableTop
                (combine
                   (# [1;1;1;1;1;1;1;1])
                   (map nat2bool [1;1;1;1;0;0;0;0])))).
```
which gives:
```coq
= [4%N]
     : list N
```
i.e. only the last value in the current state stream. I think this is because I've made a wrong guess about how to adapt `loopSeq` to also expose the state stream:
```coq
Definition loopSeqS {A B C : SignalType}
                    (f : seqType A * seqType C -> ident (seqType B * seqType C))
                    (a : seqType A) : ident (seqType B * seqType C) :=
  snd (fold_left (loopSeq' f) a (0, ret ([], [defaultCombValue C]))).
```
It's late so I am going to go to sleep! @jadephilipoom perhaps you can properly adapt `loopSeqS` to also expose the output of the register, thank you.

Once this works we should make `loopDelaySEnable` the primitive loop combinator and define `loopDelay` and `loopDelayEnable` in terms of  `loopDelaySEnable` in the `Combinators.v` file.
