### PR TITLE
Groundwork for more OpenTitan-like Acorn cipher

### DIFF
--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -1,0 +1,69 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
+Require Import Cava.Acorn.CavaClass.
+Require Import Cava.Acorn.Combinators.
+Require Import Cava.Acorn.CombinationalMonad.
+Require Import Cava.Acorn.Identity.
+Require Import Cava.Signal.
+Require Import Cava.Tactics.
+Require Import Cava.VectorUtils.
+
+Existing Instance CombinationalSemantics.
+
+Lemma all_fold_left {n} v :
+  unIdent (all (n:=n) v) = Vector.fold_left andb true v.
+Proof.
+  destruct n; [ eapply Vector.case0 with (v:=v); reflexivity | ].
+  cbv [all]. cbn [one CombinationalSemantics].
+  rewrite MonadLaws.bind_of_return by apply MonadLaws_ident.
+  erewrite tree_all_sizes_equiv with (op:=andb) (id:=true);
+    auto using Bool.andb_true_r, Bool.andb_true_l, Bool.andb_assoc.
+Qed.
+
+Lemma eqb_eq {t} (x y : combType t) :
+  unIdent (eqb x y) = true <-> x = y.
+Proof.
+  revert x y.
+  induction t;
+    cbn [eqb combType and2 andBool xnor2 xnorBool one unpair
+             CombinationalSemantics] in *;
+    intros; simpl_ident; repeat destruct_pair_let;
+    (* handle easy cases first *)
+    repeat lazymatch goal with
+           | x : unit |- _ => destruct x
+           | x : bool |- _ => destruct x; cbn [xorb negb]
+           | |- (?x = ?x <-> ?y = ?y) => split; reflexivity
+           end;
+    try (split; congruence); [ | ].
+  { (* Vector case *)
+    match goal with
+    | |- context [@unIdent (Vector.t bool ?n) (zipWith _ _ _)] =>
+      change (Vector.t bool n) with (combType (Vec Bit n));
+        rewrite zipWith_unIdent
+    end.
+    rewrite <-fold_andb_eq_iff by apply IHt.
+    rewrite all_fold_left. reflexivity. }
+  { (* Pair case *)
+    simpl_ident. rewrite pair_equal_spec, <-IHt1, <-IHt2.
+    rewrite Bool.andb_true_iff. reflexivity. }
+Qed.
+
+Lemma eqb_refl {t} (x : combType t) : unIdent (eqb x x) = true.
+Proof. apply eqb_eq. reflexivity. Qed.
+
+Lemma eqb_neq {t} (x y : combType t) : x <> y ->  unIdent (eqb x y) = false.
+Proof. rewrite <-Bool.not_true_iff_false, eqb_eq. tauto. Qed.

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -14,10 +14,15 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.micromega.Lia.
+Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Acorn.CavaClass.
 Require Import Cava.Acorn.Combinators.
 Require Import Cava.Acorn.CombinationalMonad.
 Require Import Cava.Acorn.Identity.
+Require Import Cava.BitArithmetic.
+Require Import Cava.NatUtils.
 Require Import Cava.Signal.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
@@ -67,3 +72,15 @@ Proof. apply eqb_eq. reflexivity. Qed.
 
 Lemma eqb_neq {t} (x y : combType t) : x <> y ->  unIdent (eqb x y) = false.
 Proof. rewrite <-Bool.not_true_iff_false, eqb_eq. tauto. Qed.
+
+Lemma eqb_nat_to_bitvec_sized sz n m :
+  n < 2 ^ sz -> m < 2 ^ sz ->
+  unIdent (eqb (t:=Vec Bit sz) (nat_to_bitvec_sized sz n)
+               (nat_to_bitvec_sized sz m))
+  = if Nat.eqb n m then true else false.
+Proof.
+  intros; destruct_one_match; subst; [ solve [apply eqb_refl] | ].
+  apply eqb_neq. cbv [nat_to_bitvec_sized].
+  rewrite N2Bv_sized_eq_iff with (n:=sz) by auto using N.size_nat_le_nat.
+  lia.
+Qed.

--- a/cava/Cava/Acorn/CombinationalProperties.v
+++ b/cava/Cava/Acorn/CombinationalProperties.v
@@ -84,3 +84,33 @@ Proof.
   rewrite N2Bv_sized_eq_iff with (n:=sz) by auto using N.size_nat_le_nat.
   lia.
 Qed.
+
+Lemma pairSel_mkpair {t} (x y : combType t) (sel : bool) :
+  pairSel sel (mkpair x y) = if sel then y else x.
+Proof. reflexivity. Qed.
+
+Lemma pairAssoc_mkpair {A B C} a b c :
+  @pairAssoc _ _ A B C (mkpair (mkpair a b) c) = mkpair a (mkpair b c).
+Proof. reflexivity. Qed.
+
+Lemma mux4_mkpair {t} (i0 i1 i2 i3 : combType t) sel :
+  mux4 (mkpair (mkpair (mkpair i0 i1) i2) i3) sel =
+  if Vector.hd (Vector.tl sel)
+  then if Vector.hd sel then i3 else i2
+  else if Vector.hd sel then i1 else i0.
+Proof.
+  cbv in sel. constant_vector_simpl sel.
+  cbv [mux4 indexConst CombinationalSemantics].
+  autorewrite with vsimpl.
+  repeat
+    match goal with
+    | |- context [(@indexConstBool ?t ?sz ?v ?n)] =>
+      let x := constr:(@indexConstBool t sz v n) in
+      let y := (eval cbn in x) in
+      progress change x with y
+    | _ => rewrite pairAssoc_mkpair
+    | _ => rewrite pairSel_mkpair
+    | _ => destruct_one_match
+    | _ => reflexivity
+    end.
+Qed.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -569,4 +569,16 @@ Section WithCava.
                   eq_results <- zipWith (fun '(a, b) => eqb a b) x y ;;
                   all eq_results
     end.
+
+  Definition pairAssoc {A B C} (x : signal (Pair (Pair A B) C))
+    : signal (Pair A (Pair B C)) :=
+    let '(ab, c) := unpair x in
+    let '(a, b) := unpair ab in
+    mkpair a (mkpair b c).
+
+  Definition mux4 {t} (input : signal (Pair (Pair (Pair t t) t) t))
+             (sel : signal (Vec Bit 2)) :=
+    let x := pairAssoc input in
+    pairSel (indexConst sel 0) (pairSel (indexConst sel 1) x).
+
  End WithCava.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -22,6 +22,7 @@ Import ListNotations.
 
 Require Import ExtLib.Structures.Monads.
 Require Import ExtLib.Structures.Traversable.
+Require Import coqutil.Tactics.Tactics.
 Require Import Coq.Arith.PeanoNat.
 
 Export MonadNotation.
@@ -40,8 +41,7 @@ Local Open Scope monad_scope.
 Local Open Scope type_scope.
 
 Section WithCava.
-  Context {signal} `{m: Cava signal}.
-  Context {monad: Monad cava}.
+  Context {signal} {semantics: Cava signal} {monad: Monad cava}.
 
   (****************************************************************************)
   (* Lava-style circuit combinators.                                          *)
@@ -130,6 +130,16 @@ Section WithCava.
     cbn [foldLM List.fold_right].
     eapply bind_ext; intros.
     rewrite IHinput. reflexivity.
+  Qed.
+
+  Lemma foldLM_of_ret {m} `{Monad m} `{MonadLaws.MonadLaws m} {A B}
+        (f : B -> A -> m B) (g : B -> A -> B) input accum :
+    (forall b a, f b a = ret (g b a)) ->
+    foldLM f input accum = ret (fold_left g input accum).
+  Proof.
+    intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
+    cbn [foldLM fold_left]. rewrite Hfg, MonadLaws.bind_of_return by auto.
+    apply IHinput.
   Qed.
 
   Lemma foldLM_ident_fold_left
@@ -460,6 +470,7 @@ Section WithCava.
     induction n; intros.
     { change (2 ^ 1) with 2 in *.
       cbn [tree]. autorewrite with push_vector_fold vsimpl.
+      rewrite hd_0. autorewrite with vsimpl.
       rewrite circuit_equiv, op_id_left. reflexivity. }
     { cbn [tree]. destruct_pair_let.
       rewrite !IHn by eauto.
@@ -472,4 +483,90 @@ Section WithCava.
       rewrite fold_left_resize. reflexivity. }
   Qed.
 
+  (* Version of tree combinator that accepts all sizes by creating a tree out of
+     the elements based on the closest power of two, and then tacking on the
+     remaining elements one by one.
+
+     The result will not be maximally efficient for non-powers of two; for
+     example, for an and-tree with 6 elements i0..i5, this definition will
+     produce:
+
+     (((i0 & i1) & (i2 & i3)) & i4) & i5
+
+     ...instead of &-ing i4 and i5 together before combining them with the
+     tree. *)
+  Definition tree_all_sizes {m} {monad : Monad m} {A}
+             (default : A) (circuit : A -> A -> m A) {n} (v : Vector.t A n) : m A :=
+    let '(v1, v2) := Vector.splitat (2 ^ Nat.log2 n)
+                                    (resize_default
+                                       default (2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
+                                       v) in
+    tree_result <- (match Nat.log2 n as n0 return Vector.t A (2 ^ n0) -> m A with
+                   | 0 => fun v : Vector.t A 1 => ret (Vector.hd v)
+                   | S n' => fun v : Vector.t A (2 ^ S n') => tree default n' circuit v
+                   end) v1 ;;
+    foldLM circuit (to_list v2) tree_result.
+
+  Lemma tree_all_sizes_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
+    forall (id : T) (op : T -> T -> T),
+      (forall a : T, op id a = a) ->
+      (forall a : T, op a id = a) ->
+      (forall a b c : T, op a (op b c) = op (op a b) c) ->
+      forall circuit : T -> T -> cava T,
+        (forall a b : T, circuit a b = ret (op a b)) ->
+        forall (default : T) (n : nat) (v : t T n),
+          n <> 0 ->
+          tree_all_sizes default circuit v = ret (Vector.fold_left op id v).
+  Proof.
+    cbv [tree_all_sizes]; intros. repeat destruct_pair_let.
+    assert (n = 2 ^ Nat.log2 n + (n - 2 ^ Nat.log2 n))
+      by (apply Minus.le_plus_minus, Nat.log2_spec; Lia.lia).
+    (* change the vector expression on the RHS to match LHS *)
+    lazymatch goal with
+      |- ?lhs = ?rhs =>
+      lazymatch lhs with
+        context [splitat ?n (resize_default ?d (?n + ?m) ?v)] =>
+          let rhsF := lazymatch (eval pattern v in rhs) with
+                      | ?F _ => F end in
+          transitivity
+            (rhsF
+               (resize_default
+                  d _
+                  ((fst (splitat n (resize_default d (n + m) v)))
+                      ++ snd (splitat n (resize_default d (n + m) v)))%vector))
+      end
+    end.
+    2:{ erewrite <-append_splitat by (rewrite <-surjective_pairing; reflexivity).
+        rewrite resize_default_resize_default, resize_default_id by Lia.lia.
+        reflexivity. }
+    pose proof (Nat.log2_pos n).
+    destruct n; [ congruence | ].
+    destruct n;[ subst; cbn in *; rewrite MonadLaws.bind_of_return by auto;
+                 match goal with H : _ |- _ => rewrite H; reflexivity end | ].
+    destruct_one_match; [ Lia.lia | ].
+    erewrite tree_equiv by eauto.
+    rewrite MonadLaws.bind_of_return by auto.
+    autorewrite with push_to_list push_list_fold.
+    erewrite foldLM_of_ret by eauto. reflexivity.
+  Qed.
+
+  Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=
+    default <- one ;;
+    tree_all_sizes default (fun x y => and2 (x,y)) (peel v).
+
+  Fixpoint eqb {t : SignalType} : signal t -> signal t -> cava (signal Bit) :=
+    match t as t0 return signal t0 -> signal t0 -> cava (signal Bit) with
+    | Void => fun _ _ => one
+    | Bit => fun x y => xnor2 (x, y)
+    | ExternalType s => fun x y => one
+    | Pair a b => fun x y : signal (Pair a b) =>
+                   let '(x1,x2) := unpair x in
+                   let '(y1, y2) := unpair y in
+                   eq1 <- eqb x1 y1 ;;
+                   eq2 <- eqb x2 y2 ;;
+                   and2 (eq1, eq2)
+    | Vec a n => fun x y : signal (Vec a n) =>
+                  eq_results <- zipWith (fun '(a, b) => eqb a b) x y ;;
+                  all eq_results
+    end.
  End WithCava.

--- a/cava/Cava/Acorn/Identity.v
+++ b/cava/Cava/Acorn/Identity.v
@@ -16,6 +16,7 @@
 
 Require Import Coq.Vectors.Vector.
 Require Import ExtLib.Structures.Monad.
+Require Import ExtLib.Structures.MonadLaws.
 Require Import Cava.Signal.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
@@ -55,6 +56,9 @@ Section Vectors.
     rewrite <-IHn. reflexivity.
   Qed.
 End Vectors.
+
+Instance MonadLaws_ident : MonadLaws Monad_ident.
+Proof. econstructor; intros; exact eq_refl. Defined.
 
 (* Automation to help simplify expressions using the identity monad *)
 Create HintDb simpl_ident discriminated.

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -727,57 +727,6 @@ Section MapInversionTests.
   Qed.
 End MapInversionTests.
 
-(* tactic that help infer information from hypotheses with list expressions *)
-Ltac list_inversion :=
-  repeat lazymatch goal with
-         | H : map _ _ = _ :: _ |- _ =>
-           apply map_eq_cons in H; destruct H as [? [? [? [? ?]]]]
-         | H : rev _ = _ :: _ |- _ =>
-           apply rev_eq_cons in H
-         | H : map _ _ = _ ++ _ |- _ =>
-           apply map_eq_app in H; destruct H as [? [? [? [? ?]]]]
-         | H : rev _ = _ ++ _ |- _ =>
-           apply rev_eq_app in H
-         | H : map _ _ = [] |- _ => apply map_eq_nil in H
-         | H : rev _ = [] |- _ => apply rev_eq_nil in H
-         | H : context [rev (_ ++ [_])] |- _ => rewrite rev_unit in H
-         end.
-
-Section ListInversionTests.
-  (* simple application of map_eq_nil *)
-  Goal (forall (f : nat -> nat) (l : list nat), map f l = nil -> l = nil).
-  Proof.
-    intros. list_inversion.
-    assumption.
-  Qed.
-
-  (* simple application of rev_eq_nil *)
-  Goal (forall (l : list nat), rev l = nil -> l = nil).
-  Proof.
-    intros. list_inversion.
-    assumption.
-  Qed.
-
-  (* cons/snoc, recursive pattern *)
-  Goal (forall (f : nat -> nat) (l1 l2 : list nat) (x y : nat),
-           map f l1 = x :: l2 ++ [y] ->
-           exists a b l3, f a = x /\ f b = y /\ map f l3 = l2).
-  Proof.
-    intros. list_inversion.
-    repeat eexists; eauto.
-  Qed.
-
-  (* cons/snoc, recursive pattern, mix of map and rev *)
-  Goal (forall (f : nat -> nat) (l1 l2 : list nat) (x y : nat),
-           map f (rev l1) = x :: l2 ++ [y] ->
-           exists a b l3, f a = x /\ f b = y /\ map f (rev l3) = l2).
-  Proof.
-    intros. list_inversion. subst.
-    repeat eexists; eauto.
-    rewrite rev_involutive. reflexivity.
-  Qed.
-End ListInversionTests.
-
 (* Factor out loops from a goal in preparation for using fold_left_invariant *)
 Ltac factor_out_loops :=
   lazymatch goal with

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -1,20 +1,12 @@
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
+Require Import Cava.NatUtils.
 Import ListNotations.
 Local Open Scope list_scope.
 
 (* Generic rewrite database for common list simplifications *)
 Hint Rewrite @app_nil_l @app_nil_r @last_last @rev_app_distr : listsimpl.
-
-(* Natural number simplifications are also useful for lists *)
-Lemma sub_succ_l_same n : S n - n = 1.
-Proof. lia. Qed.
-Hint Rewrite Nat.add_0_l Nat.add_0_r Nat.sub_0_r Nat.sub_0_l Nat.sub_diag
-     using solve [eauto] : natsimpl.
-Hint Rewrite Nat.sub_succ sub_succ_l_same using solve [eauto] : natsimpl.
-Hint Rewrite Min.min_r Min.min_l Nat.add_sub using lia : natsimpl.
-Hint Rewrite (fun n m => proj2 (Nat.sub_0_le n m)) using lia : natsimpl.
 
 Section Length.
   Lemma nil_length {A} : @length A nil = 0.
@@ -60,6 +52,9 @@ Section Misc.
     cbn [rev app] in *. inversion Hrev; subst.
     rewrite rev_involutive. reflexivity.
   Qed.
+
+  Lemma eta_list {A} (l : list A) d : 0 < length l -> l = hd d l :: tl l.
+  Proof. destruct l; length_hammer. Qed.
 End Misc.
 Hint Rewrite @seq_snoc using solve [eauto] : pull_snoc.
 

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -1,3 +1,19 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.

--- a/cava/Cava/NatUtils.v
+++ b/cava/Cava/NatUtils.v
@@ -1,0 +1,60 @@
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.NArith.NArith.
+Require Import Coq.micromega.Lia.
+
+(* Natural number simplifications are also useful for lists *)
+Lemma sub_succ_l_same n : S n - n = 1.
+Proof. lia. Qed.
+Hint Rewrite Nat.add_0_l Nat.add_0_r Nat.sub_0_r Nat.sub_0_l Nat.sub_diag
+     using solve [eauto] : natsimpl.
+Hint Rewrite Nat.sub_succ sub_succ_l_same using solve [eauto] : natsimpl.
+Hint Rewrite Min.min_r Min.min_l Nat.add_sub using lia : natsimpl.
+Hint Rewrite (fun n m => proj2 (Nat.sub_0_le n m)) using lia : natsimpl.
+
+Module Nat2N.
+  Lemma inj_pow a n : (N.of_nat a ^ N.of_nat n)%N = N.of_nat (a ^ n).
+  Proof.
+    induction n; intros; [ reflexivity | ].
+    rewrite Nat.pow_succ_r by Lia.lia.
+    rewrite Nat2N.inj_succ, N.pow_succ_r by lia.
+    rewrite IHn. lia.
+  Qed.
+End Nat2N.
+
+Module Pos.
+  Lemma size_nat_equiv (x : positive) :
+    Pos.size_nat x = Pos.to_nat (Pos.size x).
+  Proof.
+    induction x; intros; cbn [Pos.size_nat Pos.size];
+      rewrite ?Pnat.Pos2Nat.inj_succ; (reflexivity || congruence).
+  Qed.
+End Pos.
+
+Module N.
+  Lemma size_nat_equiv (x : N) :
+    N.size_nat x = N.to_nat (N.size x).
+  Proof.
+    destruct x as [|p]; [ reflexivity | ].
+    apply Pos.size_nat_equiv.
+  Qed.
+
+  Lemma size_nat_le (n : nat) (x : N) :
+    (x < 2 ^ N.of_nat n)%N ->
+    N.size_nat x <= n.
+  Proof.
+    destruct (N.eq_dec x 0);
+      [ intros; subst; cbn [N.size_nat]; lia | ].
+    destruct n; [ rewrite N.pow_0_r; lia | ].
+    intros. rewrite size_nat_equiv, N.size_log2 by auto.
+    pose proof (proj1 (N.log2_lt_pow2 x (N.of_nat (S n)) ltac:(lia))
+                      ltac:(eassumption)).
+    lia.
+  Qed.
+
+  Lemma size_nat_le_nat sz n : n < 2 ^ sz -> N.size_nat (N.of_nat n) <= sz.
+  Proof.
+    clear; intros. apply size_nat_le.
+    change 2%N with (N.of_nat 2).
+    rewrite Nat2N.inj_pow. lia.
+  Qed.
+End N.

--- a/cava/Cava/NatUtils.v
+++ b/cava/Cava/NatUtils.v
@@ -1,3 +1,19 @@
+(****************************************************************************)
+(* Copyright 2020 The Project Oak Authors                                   *)
+(*                                                                          *)
+(* Licensed under the Apache License, Version 2.0 (the "License")           *)
+(* you may not use this file except in compliance with the License.         *)
+(* You may obtain a copy of the License at                                  *)
+(*                                                                          *)
+(*     http://www.apache.org/licenses/LICENSE-2.0                           *)
+(*                                                                          *)
+(* Unless required by applicable law or agreed to in writing, software      *)
+(* distributed under the License is distributed on an "AS IS" BASIS,        *)
+(* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *)
+(* See the License for the specific language governing permissions and      *)
+(* limitations under the License.                                           *)
+(****************************************************************************)
+
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.NArith.
 Require Import Coq.micromega.Lia.

--- a/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanCipherEquivalence.v
@@ -21,6 +21,7 @@ Require Import Coq.Vectors.Vector.
 Require Import Cava.Arrow.ArrowExport.
 Require Import Cava.Arrow.CombinatorProperties.
 Require Import Cava.BitArithmetic.
+Require Import Cava.NatUtils.
 Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
@@ -127,7 +128,7 @@ Section Equivalence.
       repeat destruct_pair_let; cbn [fst snd].
       rewrite denote_kind_eqb_refl. cbn [mux].
       fold fstkey sndkey. repeat (f_equal; [ ]).
-      rewrite denote_kind_eqb_N2Bv_sized by (apply N_size_nat_le; cbn; Lia.lia).
+      rewrite denote_kind_eqb_N2Bv_sized by (apply N.size_nat_le; cbn; Lia.lia).
       cbv [mux]. change 0%N with (N.of_nat 0).
       rewrite N.eqb_compare, N2Nat.inj_compare, !Nat2N.id, <-Nat.eqb_compare.
       reflexivity. }

--- a/silveroak-opentitan/aes/Arrow/OpenTitanInverseCipherEquivalence.v
+++ b/silveroak-opentitan/aes/Arrow/OpenTitanInverseCipherEquivalence.v
@@ -23,6 +23,7 @@ Require Import coqutil.Tactics.Tactics.
 Require Import Cava.Arrow.ArrowExport.
 Require Import Cava.Arrow.CombinatorProperties.
 Require Import Cava.BitArithmetic.
+Require Import Cava.NatUtils.
 Require Import Cava.ListUtils.
 Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
@@ -233,6 +234,6 @@ Section Equivalence.
       reflexivity. }
     { (* equivalence holds through loop body *)
       intros. eapply key_expand_and_round_spec_equiv_inverse; eauto; [ ].
-      apply N_size_nat_le. cbn. lia. }
+      apply N.size_nat_le. cbn. lia. }
   Qed.
 End Equivalence.


### PR DESCRIPTION
Progress on #394 

Our current Acorn AES cipher is based on the spec and uses precomputed keys. This PR is part 1 of 2 in changing that design to one that mirrors OpenTitan more closely. In particular, the new version will:
- expand keys on-the-fly by routing through a key expansion circuit (nonexistent, for now)
-  operate more like a state machine; more details in the next PR.

I've separated out all the general-purpose infrastructure (i.e. the changes to `cava`) required fro the change into this "part 1" PR. It's kind of a random mix, but some of the highlights include:
- new tactics - these might be useful for others to take a look at for future proofs!
  -  `subst_lets` (inlines all hypotheses bound with `:=`)
  - `compute_expr` (replaces a particular subexpression with the computed version of itself)
  -  `boolsimpl` (simplifies boolean expressions)
- new Acorn combinators
  -  `all` (produces a bit indicating whether vector of bits is all true),
  - `eqb` (compares *any* two signals of a particular type and produces a bit indicating whether they are equal)
  - `pairAssoc` (associates signal pairs)
  -  `mux4` (a generic 4-input mux)
  - `tree_all_sizes` (variant of the tree combinator which doesn't require the input vector length to be expressed as a power of 2)
- `NatUtils.v` file for generic proofs about `nat` and `N` (and conversions between the two)

Smaller changes include:
- much-improved error messages for the `factor_out_loops` tactic
- misc. bit-arithmetic and list helper lemmas