### PR TITLE
More OpenTitan-like Acorn cipher

### DIFF
--- a/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
+++ b/silveroak-opentitan/aes/Acorn/AES256Equivalence.v
@@ -14,9 +14,14 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Vectors.Vector.
+Require Import Coq.Lists.List.
+Require Import coqutil.Tactics.destr.
 Require Import ExtLib.Structures.Monads.
+Require Import Cava.BitArithmetic.
 Require Import Cava.ListUtils.
+Require Import Cava.Tactics.
 Require Import Cava.VectorUtils.
 Require Import Cava.Acorn.Acorn.
 Require Import Cava.Acorn.MonadFacts.
@@ -25,12 +30,17 @@ Require Import Cava.Acorn.Identity.
 Require Import AesSpec.AES256.
 Require Import AesSpec.StateTypeConversions.
 Require Import AesSpec.CipherProperties.
+Require Import AesSpec.ExpandAllKeys.
 Require Import AcornAes.AddRoundKey.
 Require Import AcornAes.AddRoundKeyEquivalence.
 Require Import AcornAes.CipherRound.
 Require Import AcornAes.CipherEquivalence.
 Require Import AcornAes.Common.
+Import ListNotations.
 Import Common.Notations.
+
+Local Notation round_constant := (Vec Bit 8) (only parsing).
+Local Notation round_index := (Vec Bit 4) (only parsing).
 
 Axiom sub_bytes : forall {signal} {semantics : Cava signal} {monad : Monad cava},
     signal Bit -> signal state -> cava (signal state).
@@ -38,6 +48,30 @@ Axiom shift_rows : forall {signal} {semantics : Cava signal} {monad : Monad cava
     signal Bit -> signal state -> cava (signal state).
 Axiom mix_columns : forall {signal} {semantics : Cava signal} {monad : Monad cava},
     signal Bit -> signal state -> cava (signal state).
+
+Axiom key_expand : forall {signal} {semantics : Cava signal} {monad : Monad cava},
+    signal Bit -> signal round_index -> signal key * signal round_constant ->
+    cava (signal key * signal round_constant).
+Axiom key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8.
+Axiom inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8.
+
+(* convenience definition for converting to/from flat keys in key * round
+   constant pairs *)
+Definition flatten_key (kr : combType key * combType round_constant)
+  : t bool 128 * combType round_constant := (from_cols_bitvecs (fst kr), snd kr).
+Definition unflatten_key (kr : t bool 128 * combType round_constant)
+  : combType key * combType round_constant := (to_cols_bitvecs (fst kr), snd kr).
+Lemma flatten_unflatten kr : flatten_key (unflatten_key kr) = kr.
+Proof.
+  cbv [flatten_key unflatten_key]. destruct kr; cbn [fst snd].
+  autorewrite with conversions. reflexivity.
+Qed.
+Lemma unflatten_flatten kr : unflatten_key (flatten_key kr) = kr.
+Proof.
+  cbv [flatten_key unflatten_key]. destruct kr; cbn [fst snd].
+  autorewrite with conversions. reflexivity.
+Qed.
+Hint Rewrite @unflatten_flatten @flatten_unflatten using solve [eauto] : conversions.
 
 Axiom sub_bytes_equiv :
  forall st : t bool 128,
@@ -51,6 +85,12 @@ Axiom mix_columns_equiv :
   forall st : t bool 128,
     from_cols_bitvecs
       (combinational (mix_columns false (to_cols_bitvecs st))) = AES256.mix_columns st.
+Axiom key_expand_equiv :
+  forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    (i < 16)%nat ->
+    combinational (key_expand false (nat_to_bitvec_sized _ i) k)
+    = unflatten_key (key_expand_spec i (flatten_key k)).
+
 Axiom inv_sub_bytes_equiv :
  forall st : t bool 128,
    from_cols_bitvecs
@@ -63,42 +103,79 @@ Axiom inv_mix_columns_equiv :
   forall st : t bool 128,
     from_cols_bitvecs
       (combinational (mix_columns true (to_cols_bitvecs st))) = inv_mix_columns st.
+Axiom inv_key_expand_equiv :
+  forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    (i < 16)%nat ->
+    combinational (key_expand true (nat_to_bitvec_sized _ i) k)
+    = unflatten_key (inv_key_expand_spec i (flatten_key k)).
 
 Hint Resolve add_round_key_equiv sub_bytes_equiv shift_rows_equiv
      mix_columns_equiv inv_sub_bytes_equiv inv_shift_rows_equiv
      inv_mix_columns_equiv : subroutines_equiv.
 
 Definition full_cipher {signal} {semantics : Cava signal} {monad : Monad cava}
-  : signal Bit -> signal key -> signal key -> list (signal key) -> signal state
-    -> cava (signal state) :=
-  cipher sub_bytes shift_rows mix_columns add_round_key.
+           (num_rounds_regular round_0 : signal (Vec Bit 4))
+  : signal Bit -> signal key -> signal (Vec Bit 8) ->
+    list (signal (Vec Bit 4)) -> signal state -> cava (signal state) :=
+  cipher
+    (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+    sub_bytes shift_rows mix_columns add_round_key
+    (fun k => is_decrypt <- one ;; mix_columns is_decrypt k)
+    key_expand num_rounds_regular round_0.
 
 Lemma full_cipher_equiv
-      (is_decrypt : bool)
-      (first_key last_key : combType key) (middle_keys : list (combType key))
-      (input : combType state) :
+      (is_decrypt : bool) (first_rcon : t bool 8)
+      (first_key last_key : combType key)
+      middle_keys (input : combType state) :
+  let Nr := 14 in
+  let all_keys_and_rcons :=
+      all_keys (if is_decrypt
+                then (fun i k => unflatten_key (inv_key_expand_spec i (flatten_key k)))
+                else (fun i k => unflatten_key (key_expand_spec i (flatten_key k))))
+               Nr (first_key, first_rcon) in
+  let all_keys := List.map fst all_keys_and_rcons in
+  let round_indices := map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) in
+  let middle_keys_flat :=
+      if is_decrypt
+      then List.map AES256.inv_mix_columns (List.map from_cols_bitvecs middle_keys)
+      else List.map from_cols_bitvecs middle_keys in
+  all_keys = (first_key :: middle_keys ++ [last_key])%list ->
   combinational
-    (full_cipher is_decrypt first_key last_key middle_keys input)
+    (full_cipher (nat_to_bitvec_sized _ Nr) (nat_to_bitvec_sized _ 0) is_decrypt
+                 first_key first_rcon round_indices input)
   = to_cols_bitvecs
       ((if is_decrypt then aes256_decrypt else aes256_encrypt)
-         (from_cols_bitvecs first_key) (from_cols_bitvecs last_key)
-         (List.map from_cols_bitvecs middle_keys) (from_cols_bitvecs input)).
+         (from_cols_bitvecs first_key) (from_cols_bitvecs last_key) middle_keys_flat
+         (from_cols_bitvecs input)).
 Proof.
-  cbv [full_cipher].
+  cbv [full_cipher]; intros.
 
   destruct is_decrypt.
   { (* decryption *)
-    rewrite inverse_cipher_equiv. cbv [aes256_decrypt].
+    erewrite inverse_cipher_equiv with (Nr:=14);
+      [ |  lazymatch goal with
+           | |- _ = (_ :: _ ++ [_])%list =>
+             erewrite ?all_keys_ext
+               by (intros; rewrite inv_key_expand_equiv by Lia.lia;
+                   instantiate_app_by_reflexivity); solve [eauto]
+           | _ => change (2^4)%nat with 16; (reflexivity || Lia.lia)
+           end .. ].
+
+    cbv [aes256_decrypt].
 
     (* Change key and state representations so they match *)
     erewrite equivalent_inverse_cipher_change_state_rep
       by eapply to_cols_bitvecs_from_cols_bitvecs.
     erewrite equivalent_inverse_cipher_change_key_rep
       with (projkey:=to_cols_bitvecs)
-           (middle_keys_alt:=List.map from_cols_bitvecs middle_keys)
-      by (apply to_cols_bitvecs_from_cols_bitvecs ||
-          (rewrite List.map_map; apply ListUtils.map_id_ext;
-           intros; autorewrite with conversions; reflexivity)).
+           (middle_keys_alt:=
+              List.map inv_mix_columns (List.map from_cols_bitvecs middle_keys))
+           (first_key_alt:=from_cols_bitvecs first_key)
+           (last_key_alt:=from_cols_bitvecs last_key)
+      by (try apply to_cols_bitvecs_from_cols_bitvecs;
+          rewrite !List.map_map; apply List.map_ext;
+          intros; rewrite <-inv_mix_columns_equiv;
+          autorewrite with conversions; reflexivity).
 
     (* Prove that ciphers are equivalent because all subroutines are
        equivalent *)
@@ -106,7 +183,16 @@ Proof.
     eapply equivalent_inverse_cipher_subroutine_ext;
       eauto with subroutines_equiv. }
   { (* encryption *)
-    rewrite cipher_equiv. cbv [aes256_encrypt].
+    erewrite cipher_equiv with (Nr:=14);
+      [ |  lazymatch goal with
+           | |- _ = (_ :: _ ++ [_])%list =>
+             erewrite ?all_keys_ext
+               by (intros; rewrite key_expand_equiv by Lia.lia;
+                   instantiate_app_by_reflexivity); solve [eauto]
+           | _ => change (2^4)%nat with 16; (reflexivity || Lia.lia)
+           end .. ].
+
+    cbv [aes256_encrypt].
 
     (* Change key and state representations so they match *)
     erewrite cipher_change_state_rep
@@ -138,19 +224,58 @@ Proof.
   autorewrite with conversions; reflexivity.
 Qed.
 
+(* TODO: define a downto/upto loop combinator and then prove the cipher in terms of that *)
 Lemma full_cipher_inverse
-      (first_key last_key : combType key) (middle_keys : list (combType key))
-      (input : combType state) :
-  let decrypt_middle_keys :=
-      List.map (fun k => combinational (mix_columns true k)) (List.rev middle_keys) in
+      (is_decrypt : bool) (first_rcon last_rcon : t bool 8)
+      (first_key last_key : combType key) (input : combType state) :
+  let Nr := 14 in
+  let all_keys_and_rcons :=
+      all_keys (fun i k => unflatten_key (key_expand_spec i (flatten_key k)))
+               Nr (first_key, first_rcon) in
+  let round_indices := map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) in
+  (* last_key and last_rcon are correct *)
+  (exists keys, all_keys_and_rcons = keys ++ [(last_key, last_rcon)]) ->
+  (* inverse key expansion reverses key expansion *)
+  (forall i kr,
+      unflatten_key
+        (inv_key_expand_spec
+           (Nr - S i) (key_expand_spec i (flatten_key kr))) = kr) ->
   combinational
-    ((full_cipher false first_key last_key middle_keys >=>
-      full_cipher true last_key first_key decrypt_middle_keys) input) = input.
+    ((full_cipher (nat_to_bitvec_sized _ Nr) (nat_to_bitvec_sized _ 0)
+                  false first_key first_rcon round_indices >=>
+      full_cipher (nat_to_bitvec_sized _ Nr) (nat_to_bitvec_sized _ 0)
+                  true last_key last_rcon round_indices) input) = input.
 Proof.
-  cbv [mcompose]. simpl_ident.
-  rewrite !full_cipher_equiv.
+  cbv [mcompose]. intros [keys Hkeys] ?. simpl_ident.
+
+  (* extract the first key and middle keys to match full_cipher_equiv *)
+  lazymatch type of Hkeys with
+    ?all_keys = _ =>
+    let H := fresh in
+    assert (1 < length all_keys) as H by length_hammer;
+      rewrite Hkeys in H
+  end.
+  destruct keys; autorewrite with push_length in *; [ Lia.lia | ].
+  rewrite <-app_comm_cons in *.
+  let H := fresh in pose proof Hkeys as H; apply hd_all_keys in H; [ | Lia.lia ].
+  subst.
+
+  (* TODO(jadep): can ExpandAllKeys be improved to make this less awkward? *)
+  erewrite !full_cipher_equiv.
+  2:{
+    rewrite Hkeys. cbn [map]. rewrite map_app. cbn [map fst].
+    reflexivity. }
+  2:{
+    erewrite all_keys_inv_eq
+      by (intros; lazymatch goal with
+                  | |- _ = last _ _ => rewrite Hkeys, app_comm_cons, last_last; reflexivity
+                  | _ => cbv beta; autorewrite with conversions; auto
+                  end).
+    rewrite Hkeys. cbn [map rev]. rewrite map_app, rev_unit. cbn [map rev fst].
+    rewrite <-app_comm_cons. reflexivity. }
+
   autorewrite with conversions.
-  rewrite List.map_map, decrypt_middle_keys_equiv.
+  do 2 rewrite map_rev.
   rewrite aes256_decrypt_encrypt.
   autorewrite with conversions.
   reflexivity.

--- a/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
+++ b/silveroak-opentitan/aes/Acorn/CipherEquivalence.v
@@ -14,25 +14,50 @@
 (* limitations under the License.                                           *)
 (****************************************************************************)
 
+Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Vectors.Vector.
+Require Import Coq.Lists.List.
+Require Import Coq.NArith.NArith.
+Require Import Coq.NArith.Ndigits.
+Import VectorNotations.
+Import ListNotations.
+
 Require Import ExtLib.Structures.Monads.
+Open Scope monad_scope.
+
+Require Import coqutil.Tactics.Tactics.
+Require Import Cava.BitArithmetic.
+Require Import Cava.NatUtils.
 Require Import Cava.ListUtils.
+Require Import Cava.VectorUtils.
+Require Import Cava.Tactics.
+
 Require Import Cava.Acorn.MonadFacts.
+Require Import Cava.Acorn.CombinationalProperties.
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Identity.
 
 Require Import AesSpec.Cipher.
+Require Import AesSpec.CipherProperties.
+Require Import AesSpec.ExpandAllKeys.
+Require Import AesSpec.InterleavedCipher.
+Require Import AesSpec.InterleavedInverseCipher.
 Require Import AcornAes.CipherRound.
 
 Existing Instance CombinationalSemantics.
 
 Section WithSubroutines.
-  Local Notation byte := (t bool 8).
-  Local Notation state := (t (t byte 4) 4) (only parsing).
-  Local Notation key := (t (t byte 4) 4) (only parsing).
+  Local Notation byte := (Vector.t bool 8).
+  Local Notation state := (Vector.t (Vector.t byte 4) 4) (only parsing).
+  Local Notation key := (Vector.t (Vector.t byte 4) 4) (only parsing).
+  Local Notation round_index := (Vector.t bool 4) (only parsing).
+  Local Notation round_constant := byte (only parsing).
   Context (sub_bytes:     bool -> state -> ident state)
           (shift_rows:    bool -> state -> ident state)
           (mix_columns:   bool -> state -> ident state)
-          (add_round_key : key -> state -> ident state).
+          (add_round_key : key -> state -> ident state)
+          (key_expand : bool -> round_index -> (key * round_constant) ->
+                        cava (key * round_constant)).
 
   Let sub_bytes' : state -> state := (fun st => unIdent (sub_bytes false st)).
   Let shift_rows' : state -> state := (fun st => unIdent (shift_rows false st)).
@@ -40,39 +65,289 @@ Section WithSubroutines.
   Let inv_sub_bytes' : state -> state := (fun st => unIdent (sub_bytes true st)).
   Let inv_shift_rows' : state -> state := (fun st => unIdent (shift_rows true st)).
   Let inv_mix_columns' : state -> state := (fun st => unIdent (mix_columns true st)).
-  (* Note: argument order is switched for spec *)
+  Let inv_mix_columns_key' : key * round_constant -> key * round_constant :=
+    (fun '(k, rcon) => (inv_mix_columns' k, rcon)).
+  (* Note: argument order of add_round_key is switched for spec *)
   Let add_round_key' : state -> key -> state :=
     (fun st k => unIdent (add_round_key k st)).
+  Let add_round_key'' : state -> key * round_constant -> state :=
+    (fun st '(k, _) => unIdent (add_round_key k st)).
+  Let key_expand' : nat -> key * round_constant -> key * round_constant :=
+    (fun round_i k_rcon => unIdent (key_expand false (nat_to_bitvec_sized 4 round_i) k_rcon)).
+  Let inv_key_expand' : nat -> key * round_constant -> key * round_constant :=
+    (fun round_i k_rcon => unIdent (key_expand true (nat_to_bitvec_sized 4 round_i) k_rcon)).
+
+  Local Ltac simplify_step :=
+    first [ destruct_pair_let
+          | rewrite N2Nat.id
+          | rewrite N2Bv_sized_Bv2N
+          | rewrite pairSel_mkpair
+          | progress simpl_ident ]; [ ].
+  Local Ltac simplify := repeat simplify_step.
+
+  (* key_expand_and_round is equivalent to interleaved cipher rounds
+     (excluding the final round) *)
+  Lemma key_expand_and_round_equiv
+        (key_rcon_data : key * round_constant * state)
+        add_round_key_in_sel round_key_sel
+        round_i :
+    let round := key_expand_and_round
+                   (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+                   sub_bytes shift_rows mix_columns add_round_key
+                   (mix_columns true)
+                   key_expand false in
+    let round_spec := cipher_round_interleaved
+                        add_round_key'' sub_bytes' shift_rows' mix_columns'
+                        key_expand' in
+    let i := N.to_nat (Bv2N round_i) in
+    add_round_key_in_sel = nat_to_bitvec_sized 2 (if Nat.eqb i 0 then 1 else 0) ->
+    round_key_sel = false ->
+    unIdent (round key_rcon_data add_round_key_in_sel round_key_sel round_i)
+    = round_spec key_rcon_data i.
+  Proof.
+    cbv zeta; intros. subst_lets. subst.
+    cbv [key_expand_and_round cipher_round cipher_round_interleaved mcompose].
+    cbv [nat_to_bitvec_sized].
+    destruct key_rcon_data as [[key rcon] data]. simplify.
+    rewrite <-surjective_pairing.
+    destruct_one_match;
+      compute_expr (nat_to_bitvec_sized 2 0);
+      compute_expr (nat_to_bitvec_sized 2 1).
+    all:rewrite mux4_mkpair; autorewrite with vsimpl.
+    all:reflexivity.
+  Qed.
+
+  (* key_expand_and_round is equivalent to (inverse) interleaved cipher rounds
+     (excluding the final round) *)
+  Lemma inverse_key_expand_and_round_equiv
+        (key_rcon_data : key * round_constant * state)
+        add_round_key_in_sel round_key_sel
+        round_i :
+    let round := key_expand_and_round
+                   (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+                   sub_bytes shift_rows mix_columns add_round_key
+                   (mix_columns true) key_expand true in
+    let round_spec := equivalent_inverse_cipher_round_interleaved
+                        add_round_key'' inv_sub_bytes' inv_shift_rows' inv_mix_columns'
+                        inv_key_expand' inv_mix_columns_key' in
+    let i := N.to_nat (Bv2N round_i) in
+    add_round_key_in_sel = nat_to_bitvec_sized 2 (if Nat.eqb i 0 then 1 else 0) ->
+    (* round_key_sel is true if this is a "middle round" (in this context, not round 0) *)
+    (round_key_sel = if Nat.eqb i 0 then false else true) ->
+    unIdent (round key_rcon_data add_round_key_in_sel round_key_sel round_i)
+    = round_spec key_rcon_data i.
+  Proof.
+    cbv zeta; intros. subst_lets. subst.
+    cbv [key_expand_and_round
+           cipher_round equivalent_inverse_cipher_round_interleaved mcompose].
+    cbv [nat_to_bitvec_sized]. destruct key_rcon_data as [[key rcon] data].
+    simplify.
+    repeat destruct_one_match; autorewrite with boolsimpl in *; try congruence.
+    all: compute_expr (N2Bv_sized 2 (N.of_nat 0)).
+    all: compute_expr (N2Bv_sized 2 (N.of_nat 1)).
+    all: rewrite mux4_mkpair; autorewrite with vsimpl.
+    all: rewrite <-surjective_pairing.
+    all: reflexivity.
+  Qed.
+
+  Lemma key_expand_and_round_last_equiv
+        is_decrypt (round_i : round_index) round_key rcon data :
+    snd (unIdent
+           (key_expand_and_round
+              (semantics:=CombinationalSemantics)
+              (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+              sub_bytes shift_rows mix_columns add_round_key (mix_columns true) key_expand
+              is_decrypt (round_key, rcon, data) [false; true] false round_i))
+    = if is_decrypt
+      then add_round_key' (inv_shift_rows' (inv_sub_bytes' data)) round_key
+      else add_round_key' (shift_rows' (sub_bytes' data)) round_key.
+  Proof.
+    cbv [key_expand_and_round mcompose]; intros. subst_lets.
+    simplify. rewrite mux4_mkpair. autorewrite with vsimpl.
+    destruct is_decrypt; reflexivity.
+  Qed.
 
   Lemma cipher_equiv
+        (Nr : nat) (init_rcon : round_constant) (round_indices : list round_index)
+        (num_regular_rounds round0 : round_index)
         (first_key last_key : key) (middle_keys : list key) (input : state) :
-    let cipher := (cipher sub_bytes shift_rows mix_columns add_round_key false) in
-    let cipher_spec := (Cipher.cipher _ _ add_round_key'
-                                      sub_bytes' shift_rows' mix_columns') in
-    unIdent (cipher first_key last_key middle_keys input)
-    = cipher_spec first_key last_key middle_keys input.
+    let all_keys_and_rcons := all_keys key_expand' Nr (first_key, init_rcon) in
+    let all_keys := List.map fst all_keys_and_rcons in
+    all_keys = (first_key :: middle_keys ++ [last_key])%list ->
+    (* Nr must be at least two and small enough to fit in round_index size *)
+    1 < Nr < 2 ^ 4 ->
+    round_indices = map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) ->
+    num_regular_rounds = nat_to_bitvec_sized _ Nr ->
+    round0 = nat_to_bitvec_sized _ 0 ->
+    unIdent
+      (cipher
+         (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+         sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
+         key_expand num_regular_rounds round0 false
+         first_key init_rcon round_indices input)
+    = Cipher.cipher
+        _ _ add_round_key' sub_bytes' shift_rows' mix_columns'
+        first_key last_key middle_keys input.
   Proof.
-    cbv zeta. subst sub_bytes' shift_rows' mix_columns' add_round_key'.
-    cbv [cipher cipher_round Cipher.cipher]. cbn [mcompose bind ret Monad_ident unIdent].
-    repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
-    eapply fold_left_preserves_relation; [ reflexivity | ].
-    intros; subst. reflexivity.
+    cbv zeta; intro Hall_keys; intros. subst.
+    cbv [cipher cipher_step mcompose]. simplify.
+
+    (* Helpful rephrasing of Nr upper bound *)
+    assert (N.of_nat Nr < 2 ^ N.of_nat 4)%N
+      by (cbn; change (2^4)%nat with 16 in *; Lia.lia).
+    pose proof (N.size_nat_le 4 (N.of_nat Nr) ltac:(Lia.lia)).
+
+    (* simplify *)
+    cbn [unpeel nor2 and2 norBool andBool CombinationalSemantics
+                bind ret Monad_ident unIdent].
+
+    (* separate the last round *)
+    rewrite foldLM_ident_fold_left.
+    autorewrite with pull_snoc natsimpl.
+
+    (* simplify round-index comparisons *)
+    rewrite !eqb_nat_to_bitvec_sized, Nat.eqb_refl by Lia.lia.
+    match goal with |- context [?n =? 0] => destr (n =? 0); [ Lia.lia | ] end.
+    boolsimpl.
+
+    (* simplify expression within loop body and rephrase in terms of round spec *)
+    rewrite fold_left_map.
+    erewrite fold_left_ext_In.
+    2:{
+      intros *. intro Hin. apply in_seq in Hin.
+      autorewrite with natsimpl in *. repeat destruct_pair_let.
+      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
+      rewrite key_expand_and_round_equiv
+        by first [ boolsimpl; reflexivity
+                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
+                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
+      instantiate_app_by_reflexivity. }
+
+    (* Get all states from key expansion *)
+    map_inversion Hall_keys; subst.
+    match goal with H : @eq (list (_ * _)) _ (_ :: _ ++ [_])%list |- _ =>
+                    rename H into Hall_keys end.
+
+    (* representation change; use full key-expansion state (key * round_constant) *)
+    erewrite cipher_change_key_rep with (projkey:=@fst key round_constant)
+      by reflexivity.
+
+    erewrite <-cipher_interleaved_equiv by eassumption.
+    cbv [cipher_interleaved]. repeat destruct_pair_let.
+
+    (* rewrite last round in terms of subroutines *)
+    rewrite key_expand_and_round_last_equiv.
+
+    (* prove using loop invariant *)
+    factor_out_loops.
+    eapply fold_left_double_invariant_seq with (I:=fun _ x y => x = y).
+    { (* invariant holds at start of loop *)
+      reflexivity. }
+    { (* invariant holds through loop body *)
+      intros; subst. subst add_round_key''.
+      rewrite nat_to_bitvec_to_nat by Lia.lia.
+      cbv [cipher_round_interleaved].
+      repeat destruct_pair_let. subst_lets.
+      reflexivity. }
+    { (* invariant implies postcondition *)
+      intros; subst; reflexivity. }
+  Qed.
+
+  Lemma inv_mix_columns_key'_map keys :
+    map fst (map inv_mix_columns_key' keys) = map inv_mix_columns' (map fst keys).
+  Proof.
+    rewrite !map_map; apply map_ext.
+    intros; subst_lets. cbv beta.
+    repeat destruct_pair_let; reflexivity.
   Qed.
 
   Lemma inverse_cipher_equiv
+        (Nr : nat) (init_rcon : round_constant) (round_indices : list round_index)
+        (num_regular_rounds round0 : round_index)
         (first_key last_key : key) (middle_keys : list key) (input : state) :
-    let cipher := (cipher sub_bytes shift_rows mix_columns add_round_key true) in
-    let cipher_spec := (Cipher.equivalent_inverse_cipher
-                          _ _ add_round_key'
-                          inv_sub_bytes' inv_shift_rows' inv_mix_columns') in
-    unIdent (cipher first_key last_key middle_keys input)
-    = cipher_spec first_key last_key middle_keys input.
+    let all_keys_and_rcons := all_keys inv_key_expand' Nr (first_key, init_rcon) in
+    let all_keys := List.map fst all_keys_and_rcons in
+    all_keys = (first_key :: middle_keys ++ [last_key])%list ->
+    (* Nr must be at least two and small enough to fit in round_index size *)
+    1 < Nr < 2 ^ 4 ->
+    round_indices = map (fun i => nat_to_bitvec_sized 4 i) (List.seq 0 (S Nr)) ->
+    num_regular_rounds = nat_to_bitvec_sized _ Nr ->
+    round0 = nat_to_bitvec_sized _ 0 ->
+    unIdent
+      (cipher
+         (round_index:=Vec Bit 4) (round_constant:=Vec Bit 8)
+         sub_bytes shift_rows mix_columns add_round_key (mix_columns true)
+         key_expand num_regular_rounds round0 true
+         first_key init_rcon round_indices input)
+    = Cipher.equivalent_inverse_cipher
+        _ _ add_round_key' inv_sub_bytes' inv_shift_rows' inv_mix_columns'
+        first_key last_key (map inv_mix_columns' middle_keys) input.
   Proof.
-    cbv zeta. subst inv_sub_bytes' inv_shift_rows' inv_mix_columns' add_round_key'.
-    cbv [cipher cipher_round Cipher.equivalent_inverse_cipher].
-    cbn [mcompose bind ret Monad_ident unIdent].
-    repeat (f_equal; [ ]). rewrite foldLM_ident_fold_left.
-    eapply fold_left_preserves_relation; [ reflexivity | ].
-    intros; subst. reflexivity.
+    cbv zeta; intro Hall_keys; intros. subst.
+    cbv [cipher cipher_step mcompose]. simplify.
+
+    (* Helpful rephrasing of Nr upper bound *)
+    assert (N.of_nat Nr < 2 ^ N.of_nat 4)%N
+      by (cbn; change (2^4)%nat with 16 in *; Lia.lia).
+    pose proof (N.size_nat_le 4 (N.of_nat Nr) ltac:(Lia.lia)).
+
+    (* simplify *)
+    cbn [unpeel nor2 and2 norBool andBool CombinationalSemantics
+                bind ret Monad_ident unIdent].
+
+    (* separate the last round *)
+    rewrite foldLM_ident_fold_left.
+    autorewrite with pull_snoc natsimpl.
+
+    (* simplify round-index comparisons *)
+    rewrite !eqb_nat_to_bitvec_sized, Nat.eqb_refl by Lia.lia.
+    match goal with |- context [?n =? 0] => destr (n =? 0); [ Lia.lia | ] end.
+    boolsimpl.
+
+    (* simplify expression within loop body and rephrase in terms of round spec *)
+    rewrite fold_left_map.
+    erewrite fold_left_ext_In.
+    2:{
+      intros *. intro Hin. apply in_seq in Hin.
+      autorewrite with natsimpl in *. repeat destruct_pair_let.
+      rewrite !eqb_nat_to_bitvec_sized by Lia.lia.
+      rewrite inverse_key_expand_and_round_equiv
+        by first [ boolsimpl; reflexivity
+                 | rewrite nat_to_bitvec_to_nat by Lia.lia;
+                   repeat destruct_one_match; (reflexivity || Lia.lia) ].
+      instantiate_app_by_reflexivity. }
+
+    (* Extract information from key expansion expression *)
+    map_inversion Hall_keys. subst.
+    match goal with H : @eq (list (_ * _)) _ (_ :: _ ++ [_])%list |- _ =>
+                    rename H into Hall_keys end.
+
+    (* representation change; use full key-expansion state (key * round_constant) *)
+    erewrite equivalent_inverse_cipher_change_key_rep
+      with (projkey:=@fst key round_constant)
+           (middle_keys_alt:=List.map inv_mix_columns_key' _)
+      by (reflexivity || apply inv_mix_columns_key'_map).
+
+    erewrite <-equivalent_inverse_cipher_interleaved_equiv by eauto.
+    cbv [equivalent_inverse_cipher_interleaved].
+    repeat destruct_pair_let.
+
+    (* rewrite last round in terms of subroutines *)
+    rewrite key_expand_and_round_last_equiv.
+
+    (* prove using loop invariant *)
+    factor_out_loops.
+    eapply fold_left_double_invariant_seq with (I:=fun _ x y => x = y).
+    { (* invariant holds at start of loop *)
+      reflexivity. }
+    { (* invariant holds through loop body *)
+      intros; subst. subst add_round_key''.
+      rewrite nat_to_bitvec_to_nat by Lia.lia.
+      cbv [equivalent_inverse_cipher_round_interleaved].
+      repeat destruct_pair_let. subst_lets.
+      reflexivity. }
+    { (* invariant implies postcondition *)
+      intros; subst; reflexivity. }
   Qed.
+
 End WithSubroutines.

--- a/silveroak-opentitan/aes/Acorn/CipherRound.v
+++ b/silveroak-opentitan/aes/Acorn/CipherRound.v
@@ -24,19 +24,27 @@ Require Import ExtLib.Structures.Monads.
 Import MonadNotation.
 
 Require Import Cava.Acorn.Acorn.
+Require Import Cava.Acorn.Combinators.
 Require Import AcornAes.Common.
 Import Common.Notations.
 
 Local Open Scope monad_scope.
 
 Section WithCava.
-  Context {signal} {semantics : Cava signal}.
-  Context {monad: Monad cava}.
+  Context {signal} {semantics : Cava signal} {monad: Monad cava}.
+  Context {round_index round_constant : SignalType}.
 
   Context (sub_bytes:     signal Bit -> signal state -> cava (signal state))
           (shift_rows:    signal Bit -> signal state -> cava (signal state))
           (mix_columns:   signal Bit -> signal state -> cava (signal state))
-          (add_round_key: signal key -> signal state -> cava (signal state)).
+          (add_round_key: signal key -> signal state -> cava (signal state))
+          (inv_mix_columns_key : signal key -> cava (signal key)).
+  Context (key_expand : signal Bit -> signal round_index ->
+                        (signal key  * signal round_constant) ->
+                        cava (signal key * signal round_constant)).
+  Context (num_rounds_regular : signal (round_index))
+          (round_0 : signal (round_index)).
+  Local Infix "==?" := eqb (at level 40).
 
   Definition cipher_round
              (is_decrypt : signal Bit) (input: signal state) (key : signal key)
@@ -46,16 +54,58 @@ Section WithCava.
      mix_columns is_decrypt >=>
      add_round_key key) input.
 
+  Definition key_expand_and_round
+             (is_decrypt : signal Bit)
+             (key_rcon_input : signal key * signal round_constant * signal state)
+             (add_round_key_in_sel : signal (Vec Bit 2))
+             (round_key_sel : signal Bit)
+             (round_i : signal round_index)
+    : cava (signal key * signal round_constant * signal state) :=
+    let '(round_key, rcon, input) := key_rcon_input in
+    shift_rows_out <- (sub_bytes is_decrypt >=> shift_rows is_decrypt) input ;;
+    mix_columns_out <- mix_columns is_decrypt shift_rows_out ;;
+
+    (* Different rounds perform different operations on the state before adding
+       the round key; select the appropriate wire based on add_round_key_in_sel *)
+    let add_round_key_in :=
+        mux4 (mkpair (mkpair (mkpair mix_columns_out input) shift_rows_out) mix_columns_out)
+             add_round_key_in_sel in
+
+    (* Intermediate decryption rounds need to mix the key columns *)
+    mixed_round_key <- inv_mix_columns_key round_key ;;
+
+    out <- add_round_key (pairSel round_key_sel (mkpair round_key mixed_round_key))
+                        add_round_key_in ;;
+
+    (* Key expansion *)
+    '(round_key, rcon) <- key_expand is_decrypt round_i (round_key, rcon) ;;
+
+    ret (round_key, rcon, out).
+
+  Definition cipher_step
+             (is_decrypt : signal Bit) (* called op_i in OpenTitan *)
+             (key_rcon_data : signal key * signal round_constant * signal state)
+             (round_i : signal round_index)
+    : cava (signal key * signal round_constant * signal state) :=
+    let '(round_key, rcon, input) := key_rcon_data in
+    is_first_round <- round_i ==? round_0 ;;
+    is_final_round <- round_i ==? num_rounds_regular ;;
+    (* add_round_key_in_sel :
+       1 if round_i = 0, 2 if round_i = num_rounds_regular, 0 otherwise *)
+    let add_round_key_in_sel := unpeel [is_first_round; is_final_round]%vector in
+    is_middle_round <- nor2 (is_first_round, is_final_round) ;;
+    (* round_key_sel : 1 for a decryption middle round, 0 otherwise *)
+    round_key_sel <- and2 (is_middle_round, is_decrypt) ;;
+    key_expand_and_round is_decrypt (round_key, rcon, input)
+                         add_round_key_in_sel round_key_sel round_i.
+
   Definition cipher
-        (is_decrypt : signal Bit) (* called op_i in OpenTitan *)
-        (first_key last_key : signal key)
-        (middle_keys : list (signal key))
-        (input : signal state)
-        : cava (signal state) :=
-    (add_round_key first_key                      >=>
-     foldLM (cipher_round is_decrypt) middle_keys >=>
-     sub_bytes is_decrypt                         >=>
-     shift_rows is_decrypt                        >=>
-     add_round_key last_key) input.
+             (is_decrypt : signal Bit) (* called op_i in OpenTitan *)
+             (initial_key : signal key) (initial_rcon : signal round_constant)
+             (round_indices : list (signal round_index)) (input : signal state)
+    : cava (signal state) :=
+    '(_, _, out) <- foldLM (cipher_step is_decrypt) round_indices
+                          (initial_key, initial_rcon, input) ;;
+    ret out.
 
 End WithCava.

--- a/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherEquiv_Assumptions.out
@@ -30,6 +30,19 @@ mix_columns
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
+key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+key_expand_equiv
+  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    i < 16 ->
+    combinational (key_expand false (nat_to_bitvec_sized 4 i) k) =
+    unflatten_key (key_expand_spec i (flatten_key k))
+key_expand
+  : forall (signal : SignalType -> Type) (semantics : Cava signal),
+    Monad cava ->
+    signal Bit ->
+    signal (Vec Bit 4) ->
+    signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->
+    cava (signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8))
 inv_sub_bytes_equiv
   : forall st : t bool 128,
     from_cols_bitvecs (combinational (sub_bytes true (to_cols_bitvecs st))) =
@@ -42,3 +55,9 @@ inv_mix_columns_equiv
   : forall st : t bool 128,
     from_cols_bitvecs (combinational (mix_columns true (to_cols_bitvecs st))) =
     inv_mix_columns st
+inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+inv_key_expand_equiv
+  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    i < 16 ->
+    combinational (key_expand true (nat_to_bitvec_sized 4 i) k) =
+    unflatten_key (inv_key_expand_spec i (flatten_key k))

--- a/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
+++ b/silveroak-opentitan/aes/Acorn/FullCipherInverse_Assumptions.out
@@ -43,6 +43,19 @@ mix_columns
     signal Bit ->
     signal (Vec (Vec (Vec Bit 8) 4) 4) ->
     cava (signal (Vec (Vec (Vec Bit 8) 4) 4))
+key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+key_expand_equiv
+  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    i < 16 ->
+    combinational (key_expand false (nat_to_bitvec_sized 4 i) k) =
+    unflatten_key (key_expand_spec i (flatten_key k))
+key_expand
+  : forall (signal : SignalType -> Type) (semantics : Cava signal),
+    Monad cava ->
+    signal Bit ->
+    signal (Vec Bit 4) ->
+    signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8) ->
+    cava (signal (Vec (Vec (Vec Bit 8) 4) 4) * signal (Vec Bit 8))
 inverse_mix_columns
   : forall (Nb : nat) (st : t (t Byte.byte 4) Nb),
     MixColumns.inv_mix_columns (MixColumns.mix_columns st) = st
@@ -58,3 +71,9 @@ inv_mix_columns_equiv
   : forall st : t bool 128,
     from_cols_bitvecs (combinational (mix_columns true (to_cols_bitvecs st))) =
     inv_mix_columns st
+inv_key_expand_spec : nat -> t bool 128 * t bool 8 -> t bool 128 * t bool 8
+inv_key_expand_equiv
+  : forall (i : nat) (k : t (t (t bool 8) 4) 4 * t bool 8),
+    i < 16 ->
+    combinational (key_expand true (nat_to_bitvec_sized 4 i) k) =
+    unflatten_key (inv_key_expand_spec i (flatten_key k))

--- a/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
+++ b/silveroak-opentitan/aes/Spec/ExpandAllKeys.v
@@ -133,8 +133,25 @@ Section Spec.
         by eauto using key_expand_proper.
       congruence.
     Qed.
+
+    Lemma length_all_keys_direct (n : nat) (k : key) :
+      length (all_keys n k) = S n.
+    Proof. cbv [all_keys all_keys']. length_hammer. Qed.
   End Properties.
 End Spec.
+Hint Rewrite @length_all_keys_direct using solve [eauto] : push_length.
+
+Section Extensionality.
+  Lemma all_keys_ext {key} (key_expand key_expand' : nat -> key -> key) n k :
+    (forall i k, i < n -> key_expand i k = key_expand' i k) ->
+    all_keys key_expand n k = all_keys key_expand' n k.
+  Proof.
+    intro Hext. cbv [all_keys all_keys'].
+    f_equal. apply fold_left_accumulate_ext1_In.
+    intros *; intro Hseq. apply in_seq in Hseq.
+    apply Hext; lia.
+  Qed.
+End Extensionality.
 
 Section Inverse.
   Context {key : Type}.


### PR DESCRIPTION
Resolves #394 
Part 2 of 2 (Part 1 was #410)

There are two main changes in this PR that serve to make the Acorn AES implementation more similar to OpenTitan:
1. We now assume a key expansion circuit exists and call it on-the-fly to generate round keys.
2. The top-level cipher is now defined in terms of `cipher_step`, which given a round index and the current state performs one step of AES (including setting selectors based on the round index and then using them with muxes to choose the right data path).

Most of the changes are modifying the proofs to match the new structure. They're now a longer and more complicated-looking because of bookkeeping deal with the fact that the spec needs precomputed keys (previously, since the spec and the combinational interpretation of the circuit were basically identical, the proofs were very simple). With some additional effort I think that we can reduce the complexity  some (for instance. by making some changes to `ExpandAllKeys.v`), but this change was large enough already so that will be left to a future PR.

Currently, we loop `cipher_step` over a provided list of indices as bitvectors; as the next step, we should instead use a sequential loop that increments the index and stops when it reaches the correct number of rounds (I'll make an issue for this).