### PR TITLE
Use loopDelayS as the primary loop definition

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -99,25 +99,12 @@ Class CavaSeq {signal : SignalType -> Type} (combinationalSemantics : Cava signa
   delay : forall {t: SignalType}, signal t -> cava (signal t);
   (* A unit delay with enable. *)
   delayEnable : forall {t: SignalType}, signal Bit -> signal t -> cava (signal t);
-  (* Feedback loop, with unit delay inserted into the feedback path.
-     TODO(satnam6502, jadephilipoom): Define this in terms of loopDelayS and
-     then remove from typeclass. *) 
-  loopDelay : forall {A B C: SignalType},
-              (signal A * signal C -> cava (signal B * signal C)) ->
-              signal A ->
-              cava (signal B);
   (* Feedback loop, with unit delay inserted into the feedback path and current
      state available at output . *)
   loopDelayS : forall {A B: SignalType},
                (signal A * signal B -> cava (signal B)) ->
                signal A ->
                cava (signal B);
-  (* A version of loopDelay with a clock enable. *)
-  loopDelayEnable : forall {A B C: SignalType},
-                    signal Bit -> (* Clock enable *)
-                    (signal A * signal C -> cava (signal B * signal C)) ->
-                    signal A ->
-                    cava (signal B);
   (* A version of loopDelayEnable with a clock enable and current state at
      the output. *)
   loopDelaySEnable : forall {A B: SignalType},

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -30,28 +30,6 @@ Require Import Cava.Signal.
 Require Import Cava.Acorn.CavaClass.
 
 (******************************************************************************)
-(* Combinational denotion of the SignalType and default values.               *)
-(******************************************************************************)
-
-Fixpoint combType (t: SignalType) : Type :=
-  match t with
-  | Void => unit
-  | Bit => bool
-  | Vec vt sz => Vector.t (combType vt) sz
-  | Pair t1 t2 => (combType t1 * combType t2)%type
-  | ExternalType _ => unit (* No semantics for combinational interpretation. *)
-  end.
-
-Fixpoint defaultCombValue (t: SignalType) : combType t :=
-  match t  with
-  | Void => tt
-  | Bit => false
-  | Vec t2 sz => Vector.const (defaultCombValue t2) sz
-  | Pair t1 t2 => (defaultCombValue t1, defaultCombValue t2)
-  | ExternalType _ => tt
-  end.
-
-(******************************************************************************)
 (* A boolean combinational logic interpretation for the Cava class            *)
 (******************************************************************************)
 

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -581,4 +581,34 @@ Section WithCava.
     let x := pairAssoc input in
     pairSel (indexConst sel 0) (pairSel (indexConst sel 1) x).
 
+  Section Sequential.
+    Context {seqsemantics : CavaSeq semantics}.
+
+    (* Alternate form of feedback loop with feedback and output types separated *)
+    Definition loopDelay {A B C: SignalType}
+               (body : signal A * signal C -> cava (signal B * signal C))
+               (input : signal A) : cava (signal B) :=
+      bc <- loopDelayS
+             (fun (a_bc : signal A * signal (Pair B C)) =>
+                let '(a, bc) := a_bc in
+                let '(b,c) := unpair bc in
+                '(b,c) <- body (a,c) ;;
+                ret (mkpair b c))
+             input ;;
+      ret (fst (unpair bc)).
+
+    (* Alternate form of enabled feedback loop with feedback and output types separated *)
+    Definition loopDelayEnable {A B C: SignalType} (enable : signal Bit)
+        (body : signal A * signal C -> cava (signal B * signal C))
+        (input : signal A) : cava (signal B) :=
+      bc <- loopDelaySEnable
+             enable
+             (fun (a_bc : signal A * signal (Pair B C)) =>
+                let '(a, bc) := a_bc in
+                let '(b,c) := unpair bc in
+                '(b,c) <- body (a,c) ;;
+                ret (mkpair b c))
+             input ;;
+      ret (fst (unpair bc)).
+  End Sequential.
  End WithCava.

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -247,17 +247,6 @@ Definition delayEnableNet (t : SignalType)
 
 Local Open Scope type_scope.
 
-(* Create a loop circuit with a delay element along the feedback path. *)
-Definition loopNet (A B C : SignalType)
-                   (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
-                   (a : Signal A)
-                   : state CavaState (Signal B) :=
-  o <- @newSignal C ;;
-  '(b, cOut) <- f (a, o) ;;
-  oDelay <- delayNet C cOut ;;
-  assignSignal o oDelay ;;
-  ret b.
-
 (* Create a loop circuit with a delay element along the feedback path which
    makes the current state available at the output. *)
 Definition loopNetS (A B : SignalType)
@@ -269,18 +258,6 @@ Definition loopNetS (A B : SignalType)
   oDelay <- delayNet B out ;;
   assignSignal o oDelay ;;
   ret out.
-
-(* Create a loop circuit with a delay element with enable along the feedback path. *)
-Definition loopNetEnable (A B C : SignalType)
-                         (en : Signal Bit)
-                         (f : Signal A * Signal C -> state CavaState (Signal B * Signal C))
-                         (a : Signal A)
-                         : state CavaState (Signal B) :=
-  o <- @newSignal C ;;
-  '(b, cOut) <- f (a, o) ;;
-  oDelay <- delayEnableNet C en cOut ;;
-  assignSignal o oDelay ;;
-  ret b.
 
 (* Create a loop circuit with a delay element with enable along the feedback
    path with the current state exposed at the output. *)
@@ -349,8 +326,6 @@ Instance CavaCombinationalNet : Cava denoteSignal := {
 Instance CavaSequentialNet : CavaSeq CavaCombinationalNet :=
   { delay k := delayNet k;
     delayEnable k := delayEnableNet k;
-    loopDelay a b c := loopNet a b c;
     loopDelayS a b := loopNetS a b;
-    loopDelayEnable en a b c := loopNetEnable en a b c;
     loopDelaySEnable en a b := loopNetEnableS en a b;
   }.

--- a/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
+++ b/tests/AccumulatingAdderEnable/AccumulatingAdderEnable.v
@@ -72,11 +72,10 @@ Section WithCava.
     ret (pairSel sel (mkpair f t)).
 
   Definition accumulatingAdderEnable : signal (Pair (Vec Bit 8) Bit) -> cava (signal (Vec Bit 8))
-    := loopDelay (fun '(inp_and_valid, state) =>
+    := loopDelayS (fun '(inp_and_valid, state) =>
                     let '(inp, valid) := unpair inp_and_valid in
                     (addN >=>
-                     mux2 valid state >=>
-                     fork2) (inp, state)).
+                     mux2 valid state) (inp, state)).
 
 End WithCava.
 

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -78,7 +78,7 @@ Proof.
   intros; cbv [accumulatingAdderEnable].
   eapply loopDelayS_invariant
     with (I:=fun t acc =>
-               acc = map (signallingCounterSpec
+               acc = map (accumulatingCounterEnableSpec
                             (fun n => nth n i (bvzero, false)))
                          (seq 0 t)).
   { (* invariant holds after first step *)
@@ -96,8 +96,6 @@ Proof.
     autorewrite with push_nth.
     rewrite seq_S, map_app. cbn [map].
     autorewrite with natsimpl push_nth.
-    destruct t; [ lia | ].
-    autorewrite with natsimpl.
     cbn [accumulatingCounterEnableSpec].
     destruct t;
       [ cbn; repeat destruct_pair_let;

--- a/tests/AccumulatingAdderEnable/ListProofs.v
+++ b/tests/AccumulatingAdderEnable/ListProofs.v
@@ -76,36 +76,35 @@ Lemma accumulatingCounterEnableCorrect (i : list (Bvector 8 * bool)) :
       (seq 0 (length i)).
 Proof.
   intros; cbv [accumulatingAdderEnable].
-  eapply loop_invariant_alt
-    with (I:=fun t acc feedback =>
-               feedback = [nth (t-1) acc bvzero]
-               /\ acc = map (accumulatingCounterEnableSpec
-                              (fun n => nth n i (bvzero, false)))
-                              (seq 0 t)).
-  { (* postcondition hold for nil input, and invariant holds after first step *)
-
-    destruct i; cbn [map seq nth length]; [ reflexivity | ].
-    seqsimpl. cbv [addNSpec accumulatingCounterEnableSpec].
-    cbn [combine map2 fst snd]. autorewrite with natsimpl push_nth.
-    seqsimpl. split; reflexivity. }
+  eapply loopDelayS_invariant
+    with (I:=fun t acc =>
+               acc = map (signallingCounterSpec
+                            (fun n => nth n i (bvzero, false)))
+                         (seq 0 t)).
+  { (* invariant holds after first step *)
+    reflexivity. }
   { (* invariant holds through loop body *)
-    intros *; intros [Hfeedback Hacc]. subst.
+    intros *; intros Hacc. subst.
     cbv zeta; intros. seqsimpl. cbv [addNSpec].
     autorewrite with push_length natsimpl push_nth.
     cbn [repeat app].
     match goal with
-    | |- context [Signal.defaultCombValue ?t] =>
-      change (Signal.defaultCombValue t) with (@bvzero 8, false)
+    | |- context [defaultCombValue ?t] =>
+      change (defaultCombValue t) with (@bvzero 8, false)
     end.
     seqsimpl. cbn [combine map2 fst snd].
     autorewrite with push_nth.
-    ssplit; [ reflexivity | ].
     rewrite seq_S, map_app. cbn [map].
     autorewrite with natsimpl push_nth.
     destruct t; [ lia | ].
     autorewrite with natsimpl.
     cbn [accumulatingCounterEnableSpec].
+    destruct t;
+      [ cbn; repeat destruct_pair_let;
+        reflexivity | ].
+    autorewrite with natsimpl push_nth.
+    cbn [accumulatingCounterEnableSpec].
     seqsimpl. reflexivity. }
   { (* invariant implies postcondition *)
-    intros *; intros [Hfeedback Hacc]. subst; reflexivity. }
+    intros; subst; reflexivity. }
 Qed.

--- a/tests/AddWithDelay/AddWithDelay.v
+++ b/tests/AddWithDelay/AddWithDelay.v
@@ -68,7 +68,7 @@ Section WithCava.
           {semantics: CavaSeq combsemantics} `{Monad cava}.
 
   Definition addWithDelay : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loopDelay (addN >=> delay >=> fork2).
+    := loopDelayS (addN >=> delay).
 
 End WithCava.
 

--- a/tests/CountBy/CountBy.v
+++ b/tests/CountBy/CountBy.v
@@ -52,7 +52,7 @@ Section WithCava.
           {semantics: CavaSeq combsemantics} `{Monad cava}.
 
   Definition countBy : signal (Vec Bit 8) -> cava (signal (Vec Bit 8))
-    := loopDelay (addN >=> fork2).
+    := loopDelayS addN.
 
 End WithCava.
 

--- a/tests/CountBy/ListProofs.v
+++ b/tests/CountBy/ListProofs.v
@@ -64,19 +64,15 @@ Lemma countByCorrect: forall (i : list (Bvector 8)),
                       sequential (countBy i) = countBySpec i.
 Proof.
   intros; cbv [countBy].
-  eapply (loop_invariant (B:=Vec Bit 8) (C:=Vec Bit 8)) with
-      (I:=fun t acc feedback =>
-            feedback = [bvsum (firstn t i)]
-            /\ acc = countBySpec (firstn t i)).
+  eapply (loopDelayS_invariant (B:=Vec Bit 8)) with
+      (I:=fun t acc => acc = countBySpec (firstn t i)).
   { (* invariant holds at start *)
-    ssplit; reflexivity. }
+    reflexivity. }
   { (* invariant holds through body *)
-    cbv zeta. intros *.
-    intros [Hfeedback Hacc]; intros; subst. seqsimpl.
+    cbv zeta. intros; subst. seqsimpl.
     cbv [addNSpec countBySpec bvsum map2].
     rewrite firstn_succ_snoc with (d:=N2Bv_sized 8 0) by length_hammer.
     autorewrite with push_list_fold.
-    ssplit; [ cbv [bvadd]; rewrite N.add_comm; reflexivity | ].
     cbv [seqType Signal.combType Bvector] in *.
     repeat first [ rewrite Nat.add_1_r
                  | rewrite seq_S, map_app; cbn [map]
@@ -89,8 +85,10 @@ Proof.
       match goal with H : _ |- _ => apply in_seq in H end.
       autorewrite with push_length natsimpl push_firstn push_list_fold.
       reflexivity. }
-    { cbv [bvadd]. rewrite N.add_comm. reflexivity. } }
+    { cbv [bvadd]. rewrite N.add_comm.
+      destruct t; autorewrite with push_nth push_firstn push_list_fold natsimpl;
+        reflexivity. } }
   { (* invariant implies postcondition *)
-    intros *; intros [Hfeedback Hacc]; seqsimpl; subst.
+    intros; seqsimpl; subst.
     rewrite firstn_all; reflexivity. }
 Qed.


### PR DESCRIPTION
Resolves a TODO in `CavaClass.v`. The story here is that we initially defined `loopDelay`, a loop whose body has separate output and feedback results; the body's signature is something like like `A * C -> B * C`. We later added `loopDelayS`, which assumes the output and feedback are the same and expects a body with the form `A * B -> B`. There was a TODO to remove `loopDelay` from the typeclass and simply define it in terms of `loopDelayS`, which is what this PR does.

There is a significant proof component here because we had written invariant infrastructure for `loopDelay`, so I redid these proofs for `loopDelayS` instead and then used them to re-prove the top-level invariant proofs for `loopDelay`. Since the existing examples in `tests/` do in fact use the same thing for feedback and output, I went ahead and switched them over to `loopDelayS`.

I also removed the `defaultCombType` and `combType` definitions from `CombinationalMonad.v` because they are exact duplicates of the ones in `Signal.v` and it's confusing to have both.