### PR TITLE
Groundwork for consolidating combinational semantics

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -121,8 +121,7 @@ Class CavaSeqMonad {signal : SignalType -> Type} (combinationalSemantics : Cava 
   (* A unit delay. *)
   delaym : forall {t: SignalType}, cava (signal t) -> cava (signal t);
   (* Feeback loop, with unit delay inserted into the feedback path. *)
-  loopDelaym : forall {A B C: SignalType},
-               (signal A * signal C -> cava (signal B * signal C)) ->
-               cava (signal A) ->
-               cava (signal B);
+  loopDelaySm : forall {A B: SignalType},
+      (signal A * signal B -> cava (signal B)) ->
+      cava (signal A) -> cava (signal B);
 }.

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -118,30 +118,6 @@ Definition sliceBool {t: SignalType}
                      Vector.t (combType t) len :=
   sliceVector v startAt len H.
 
-Definition unsignedAddBool {m n : nat}
-                           (av : Bvector m) (bv : Bvector n) :
-                           ident (Bvector (1 + max m n)) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let sumSize := 1 + max m n in
-  let sum := (a + b)%N in
-  ret (N2Bv_sized sumSize sum).
-
-Definition unsignedMultBool {m n : nat}
-                           (av : Bvector m) (bv : Bvector n) :
-                           ident (Bvector (m + n)) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let product := (a * b)%N in
-  ret (N2Bv_sized (m + n) product).
-
-Definition greaterThanOrEqualBool {m n : nat}
-                                  (av : Bvector m) (bv : Bvector n) :
-                                  ident bool :=
-  let a := N.to_nat (Bv2N av) in
-  let b := N.to_nat (Bv2N bv) in
-  ret (b <=? a).
-
 Definition bufBool (i : bool) : ident bool :=
   ret i.
 
@@ -185,9 +161,9 @@ Definition loopBool (A B C : SignalType)
     indexAt t sz isz := @indexAtBool t sz isz;
     indexConst t sz := @indexConstBool t sz;
     slice t sz := @sliceBool t sz;
-    unsignedAdd m n := @unsignedAddBool m n;
-    unsignedMult m n := @unsignedMultBool m n;
-    greaterThanOrEqual m n := @greaterThanOrEqualBool m n;
+    unsignedAdd m n := fun x  y => ret (@unsignedAddBool m n x y);
+    unsignedMult m n := fun x y => ret (@unsignedMultBool m n x y);
+    greaterThanOrEqual m n := fun x y => ret (@greaterThanOrEqualBool m n x y);
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefault (map port_type (circuitOutputs intf)));
 }.

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -599,7 +599,8 @@ Section WithCava.
     destruct_one_match; [ Lia.lia | ].
     erewrite tree_equiv' with (valid0:=valid) (id0:=id); eauto; [ | ].
     { rewrite MonadLaws.bind_of_return by auto.
-      autorewrite with push_to_list push_list_fold.
+      rewrite !fold_left_to_list, to_list_resize_default, to_list_append by lia.
+      autorewrite with push_list_fold.
       erewrite foldLM_of_ret_valid with (validA:=valid) (validB:=valid);
         eauto; [ | ].
       { apply fold_left_invariant with (I:=valid); auto; [ ].

--- a/cava/Cava/Acorn/Combinators.v
+++ b/cava/Cava/Acorn/Combinators.v
@@ -132,6 +132,21 @@ Section WithCava.
     rewrite IHinput. reflexivity.
   Qed.
 
+  Lemma foldLM_of_ret_valid {m} `{Monad m} `{MonadLaws.MonadLaws m} {A B}
+        (validA : A -> Prop) (validB : B -> Prop)
+        (f : B -> A -> m B) (g : B -> A -> B) input accum :
+    (forall b a, validA a -> validB b -> f b a = ret (g b a)) ->
+    (forall b a, validA a -> validB b -> validB (g b a)) ->
+    validB accum -> Forall validA input ->
+    foldLM f input accum = ret (fold_left g input accum).
+  Proof.
+    intro Hfg; revert accum; induction input; intros; [ reflexivity | ].
+    cbn [foldLM fold_left].
+    match goal with H : Forall _ (_ :: _) |- _ => inversion H; subst; clear H end.
+    rewrite Hfg, MonadLaws.bind_of_return; auto.
+  Qed.
+
+
   Lemma foldLM_of_ret {m} `{Monad m} `{MonadLaws.MonadLaws m} {A B}
         (f : B -> A -> m B) (g : B -> A -> B) input accum :
     (forall b a, f b a = ret (g b a)) ->
@@ -451,6 +466,53 @@ Section WithCava.
 
   Local Open Scope nat_scope.
 
+  Lemma tree_equiv'
+        {T}  {monad_laws : MonadLaws monad} (valid : T -> Prop)
+        (id : T)
+        (op : T -> T -> T)
+        (valid_id : valid id)
+        (op_preserves_valid : forall a b, valid a -> valid b -> valid (op a b))
+        (op_id_left : forall a : T, valid a -> op id a = a)
+        (op_id_right : forall a : T, valid a -> op a id = a)
+        (op_assoc :
+           forall a b c : T,
+             valid a -> valid b -> valid c ->
+             op a (op b c) = op (op a b) c)
+        (circuit : T -> T -> cava T)
+        (circuit_equiv :
+          forall a b : T, valid a -> valid b -> circuit a b = ret (op a b))
+        (default : T) (n : nat) :
+    forall v,
+      ForallV valid v ->
+      tree default n circuit v = ret (Vector.fold_left op id v).
+  Proof.
+    induction n; intros.
+    { change (2 ^ 1) with 2 in *.
+      cbn [tree]. autorewrite with push_vector_fold vsimpl.
+      rewrite hd_0. autorewrite with vsimpl. cbn [ForallV] in *.
+      rewrite circuit_equiv, op_id_left; try tauto; [ ].
+      constant_vector_simpl v. cbn; tauto. }
+    { cbn [tree]. destruct_pair_let.
+      assert (2 ^ (S (S n)) = 2 ^ (S n) + 2 ^ (S n)) as Heq
+        by abstract (rewrite Nat.pow_succ_r by lia; lia).
+      lazymatch goal with
+      | _ : ForallV ?P ?v |- context [divide ?d ?v] =>
+        let H' := fresh in
+        assert (ForallV P (fst (divide d v) ++ snd (divide d v))%vector) as H'
+            by (rewrite @append_divide with (H:=Heq);
+                apply ForallV_resize; auto);
+          apply ForallV_append in H'; destruct H'
+      end.
+      rewrite !IHn by eauto.
+      rewrite !bind_of_return by eauto.
+      rewrite circuit_equiv by (apply fold_left_preserves_valid; solve [eauto]).
+      erewrite <-fold_left_S_assoc' with (valid0:=valid); auto;
+        [ | apply fold_left_preserves_valid; solve [eauto] ].
+      rewrite <-fold_left_append by eauto.
+      rewrite @append_divide with (H:=Heq).
+      rewrite fold_left_resize. reflexivity. }
+  Qed.
+
   Lemma tree_equiv
         {T}  {monad_laws : MonadLaws monad}
         (id : T)
@@ -467,20 +529,7 @@ Section WithCava.
     forall v,
       tree default n circuit v = ret (Vector.fold_left op id v).
   Proof.
-    induction n; intros.
-    { change (2 ^ 1) with 2 in *.
-      cbn [tree]. autorewrite with push_vector_fold vsimpl.
-      rewrite hd_0. autorewrite with vsimpl.
-      rewrite circuit_equiv, op_id_left. reflexivity. }
-    { cbn [tree]. destruct_pair_let.
-      rewrite !IHn by eauto.
-      rewrite !bind_of_return by eauto.
-      rewrite circuit_equiv by eauto.
-      rewrite <-fold_left_S_assoc, <-fold_left_append by auto.
-      assert (2 ^ S (S n) = 2 ^ S n + 2 ^ S n)
-        by (rewrite Nat.pow_succ_r'; lia).
-      rewrite (append_divide _ _ ltac:(eassumption)).
-      rewrite fold_left_resize. reflexivity. }
+    intros. apply tree_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
   Qed.
 
   (* Version of tree combinator that accepts all sizes by creating a tree out of
@@ -507,15 +556,18 @@ Section WithCava.
                    end) v1 ;;
     foldLM circuit (to_list v2) tree_result.
 
-  Lemma tree_all_sizes_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
-    forall (id : T) (op : T -> T -> T),
-      (forall a : T, op id a = a) ->
-      (forall a : T, op a id = a) ->
-      (forall a b c : T, op a (op b c) = op (op a b) c) ->
+  Lemma tree_all_sizes_equiv' {T} {monad_laws : MonadLaws.MonadLaws monad}:
+    forall (id : T) (op : T -> T -> T) (valid : T -> Prop),
+      valid id ->
+      (forall a b, valid a -> valid b -> valid (op a b)) ->
+      (forall a : T, valid a -> op id a = a) ->
+      (forall a : T, valid a -> op a id = a) ->
+      (forall a b c : T, valid a -> valid b -> valid c ->
+                    op a (op b c) = op (op a b) c) ->
       forall circuit : T -> T -> cava T,
-        (forall a b : T, circuit a b = ret (op a b)) ->
+        (forall a b : T, valid a -> valid b -> circuit a b = ret (op a b)) ->
         forall (default : T) (n : nat) (v : t T n),
-          n <> 0 ->
+          n <> 0 -> ForallV valid v ->
           tree_all_sizes default circuit v = ret (Vector.fold_left op id v).
   Proof.
     cbv [tree_all_sizes]; intros. repeat destruct_pair_let.
@@ -540,14 +592,44 @@ Section WithCava.
         rewrite resize_default_resize_default, resize_default_id by Lia.lia.
         reflexivity. }
     pose proof (Nat.log2_pos n).
-    destruct n; [ congruence | ].
+    destruct n; [ congruence | ]. cbn [ForallV] in *.
+    repeat match goal with H : _ /\ _ |- _ => destruct H end.
     destruct n;[ subst; cbn in *; rewrite MonadLaws.bind_of_return by auto;
-                 match goal with H : _ |- _ => rewrite H; reflexivity end | ].
+                 match goal with H : _ |- _ => rewrite H; solve [auto] end | ].
     destruct_one_match; [ Lia.lia | ].
-    erewrite tree_equiv by eauto.
-    rewrite MonadLaws.bind_of_return by auto.
-    autorewrite with push_to_list push_list_fold.
-    erewrite foldLM_of_ret by eauto. reflexivity.
+    erewrite tree_equiv' with (valid0:=valid) (id0:=id); eauto; [ | ].
+    { rewrite MonadLaws.bind_of_return by auto.
+      autorewrite with push_to_list push_list_fold.
+      erewrite foldLM_of_ret_valid with (validA:=valid) (validB:=valid);
+        eauto; [ | ].
+      { apply fold_left_invariant with (I:=valid); auto; [ ].
+        intros *. rewrite InV_to_list_iff. intros.
+        match goal with H : forall a b, _ -> _ -> valid (op a b) |- _ => apply H end;
+          auto; [ ].
+        eapply ForallV_forall; [ | solve [eauto]].
+        intros. apply ForallV_splitat1.
+        erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
+        apply ForallV_resize. cbn [ForallV] in *; auto. }
+      { apply ForallV_to_list_iff, ForallV_splitat2.
+        erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
+        apply ForallV_resize. cbn [ForallV] in *; auto. } }
+    { intros. apply ForallV_splitat1.
+      erewrite <-(resize_default_eq _ _ _ (ltac:(eassumption))).
+      apply ForallV_resize. cbn [ForallV] in *; auto. }
+  Qed.
+
+  Lemma tree_all_sizes_equiv {T} {monad_laws : MonadLaws.MonadLaws monad}:
+    forall (id : T) (op : T -> T -> T),
+      (forall a : T, op id a = a) ->
+      (forall a : T, op a id = a) ->
+      (forall a b c : T, op a (op b c) = op (op a b) c) ->
+      forall circuit : T -> T -> cava T,
+        (forall a b : T, circuit a b = ret (op a b)) ->
+        forall (default : T) (n : nat) (v : t T n),
+          n <> 0 ->
+          tree_all_sizes default circuit v = ret (Vector.fold_left op id v).
+  Proof.
+    intros. apply tree_all_sizes_equiv' with (valid:=fun _ => True); auto using ForallV_trivial.
   Qed.
 
   Definition all {n} (v : signal (Vec Bit n)) : cava (signal Bit) :=

--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -221,17 +221,17 @@ Local Open Scope list_scope.
 Definition unsignedAddBoolList {m n : nat}
                                (av : list (Bvector m)) (bv : list (Bvector n)) :
                                ident (list (Bvector (1 + max m n))) :=
-  mapT (fun '(a, b) => unsignedAddBool a b) (combine av bv).
+  mapT (fun '(a, b) => ret (unsignedAddBool a b)) (combine av bv).
 
 Definition unsignedMultBoolList {m n : nat}
                                 (av : list (Bvector m)) (bv : list (Bvector n)) :
                                 ident (list (Bvector (m + n))) :=
-  mapT (fun '(a, b) => unsignedMultBool a b) (combine av bv).
+  mapT (fun '(a, b) => ret (unsignedMultBool a b)) (combine av bv).
 
 Definition greaterThanOrEqualBoolList {m n : nat}
                                       (av : list (Bvector m)) (bv : list (Bvector n)) :
                                       ident (list bool) :=
-  mapT (fun '(a, b) => greaterThanOrEqualBool a b) (combine av bv).
+  mapT (fun '(a, b) => ret (greaterThanOrEqualBool a b)) (combine av bv).
 
 Definition bufBoolList (i : list bool) : ident (list bool) :=
   ret i.

--- a/cava/Cava/Acorn/SequentialTimed.v
+++ b/cava/Cava/Acorn/SequentialTimed.v
@@ -53,16 +53,15 @@ Definition delay {A} (x : timed (combType A)) : timed (combType A) :=
 (* Loop combinator for feedback with delay.                                   *)
 (******************************************************************************)
 
-Definition loopSeqF' {A B C : SignalType}
-         (f : combType A * combType C -> combType B * combType C)
-         (a : timed (combType A)) : timed (combType B * combType C) :=
-  timedFold (fun bc a => f (a, snd bc)) (defaultCombValue B, defaultCombValue C) a.
-
-Definition loopSeqF {A B C : SignalType}
-         (f : combType A * combType C -> timed (combType B * combType C))
+Definition loopSeqF' {A B : SignalType}
+         (f : combType A * combType B -> combType B)
          (a : timed (combType A)) : timed (combType B) :=
-  '(b, _) <- loopSeqF' (fun ac => f ac 0) a ;;
-  ret b.
+  timedFold (fun b a => f (a, b)) (defaultCombValue B) a.
+
+Definition loopSeqF {A B : SignalType}
+         (f : combType A * combType B -> timed (combType B))
+         (a : timed (combType A)) : timed (combType B) :=
+  loopSeqF' (fun ac => f ac 0) a.
 
 (******************************************************************************)
 (* A boolean sequential logic interpretation for the Cava class               *)
@@ -102,42 +101,24 @@ Definition lut6BoolF (f: bool -> bool -> bool -> bool -> bool -> bool -> bool)
 Definition muxcyBoolF (s ci di : bool) : timed bool :=
   ret (if s then ci else di).
 
-Local Open Scope list_scope.
+Definition indexConstBoolF {t sz} (v : combType (Vec t sz)) (sel : nat) :=
+  nth_default (defaultCombValue _) sel v.
 
-Definition unsignedAddComb {m n : nat}
-                           (av : Bvector m) (bv : Bvector n) :
-                           Bvector (1 + max m n) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let sumSize := 1 + max m n in
-  let sum := (a + b)%N in
-  N2Bv_sized sumSize sum.
+Definition indexAtBoolF {t sz isz}
+           (v : combType (Vec t sz)) (sel : combType (Vec Bit isz)) :=
+  nth_default (defaultCombValue _) (N.to_nat (Bv2N sel)) v.
 
 Definition unsignedAddBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
   : timed (Bvector (1 + max m n)) :=
-  ret (unsignedAddComb av bv).
-
-Definition unsignedMultComb {m n : nat}
-           (av : Bvector m) (bv : Bvector n)
-  : Bvector (m + n) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let product := (a * b)%N in
-  N2Bv_sized (m + n) product.
+  ret (unsignedAddBool av bv).
 
 Definition unsignedMultBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
   : timed (Bvector (m + n)) :=
-  ret (unsignedMultComb av bv).
-
-Definition greaterThanOrEqualComb
-           {m n : nat} (av : Bvector m) (bv : Bvector n) : bool :=
-  let a := N.to_nat (Bv2N av) in
-  let b := N.to_nat (Bv2N bv) in
-  b <=? a.
+  ret (unsignedMultBool av bv).
 
 Definition greaterThanOrEqualBoolF {m n : nat} (av : Bvector m) (bv : Bvector n)
   : timed bool :=
-  ret (greaterThanOrEqualComb av bv).
+  ret (greaterThanOrEqualBool av bv).
 
 
 Definition blackBoxF (intf : CircuitInterface)
@@ -176,9 +157,9 @@ Definition blackBoxF (intf : CircuitInterface)
     peel _ _ v := v;
     unpeel _ _ v := v;
     pairSel _ v sel := pairSelBool v sel;
-    indexAt t sz isz := @indexAtBool t sz isz;
-    indexConst t sz := @indexConstBool t sz;
-    slice t sz := @sliceBool t sz;
+    indexAt t sz isz := @indexAtBoolF t sz isz;
+    indexConst t sz := @indexConstBoolF t sz;
+    slice t sz startAt len v H := sliceVector v startAt len H;
     unsignedAdd m n := @unsignedAddBoolF m n;
     unsignedMult m n := @unsignedMultBoolF m n;
     greaterThanOrEqual m n := @greaterThanOrEqualBoolF m n;
@@ -188,7 +169,7 @@ Definition blackBoxF (intf : CircuitInterface)
 
  Instance TimedSeqSemantics : CavaSeqMonad TimedCombSemantics :=
    { delaym k i := delay i;
-     loopDelaym A B C := @loopSeqF A B C;
+     loopDelaySm A B := @loopSeqF A B;
    }.
 
 (******************************************************************************)

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -182,20 +182,22 @@ Definition muxcyBoolVec (ticks: nat)
        | true => ci
      end) s_dici).
 
+Definition indexConstBoolVec {t: SignalType}
+                          {sz : nat}
+                          (ticks: nat)
+                          (i : Vector.t (Vector.t (combType t) sz) ticks)
+                          (sel : nat)
+                          : Vector.t (combType t) ticks :=
+  Vector.map (fun i => nth_default (defaultCombValue t) sel i) i.
+
 Definition indexAtBoolVec {t: SignalType}
                           {sz isz: nat}
                           (ticks: nat)
                           (i : Vector.t (Vector.t (combType t) sz) ticks)
                           (sel : Vector.t (Bvector isz) ticks)
                           : Vector.t (combType t) ticks :=
-  Vector.map (fun '(i, sel) => indexAtBool i sel) (vcombine i sel).
-
-Definition indexConstBoolVec {t: SignalType} {sz: nat}
-                             (ticks: nat)
-                             (i : Vector.t (Vector.t (combType t) sz) ticks)
-                             (sel : nat)
-                             : Vector.t (combType t) ticks :=
-  Vector.map (fun i => indexConstBool i sel) i.
+  Vector.map (fun '(i, sel) => nth_default (defaultCombValue t) (N.to_nat (Bv2N sel)) i)
+             (vcombine i sel).
 
 Definition sliceBoolVec {t: SignalType}
                         {sz: nat}
@@ -204,67 +206,21 @@ Definition sliceBoolVec {t: SignalType}
                         (v: Vector.t (Vector.t (combType t) sz) ticks)
                         (H: startAt + len <= sz) :
                         Vector.t (Vector.t (combType t) len) ticks :=
-  Vector.map (fun v => sliceBool startAt len v H) v.
+  Vector.map (fun v => sliceVector v startAt len H) v.
 
 Definition peelVecVec {t: SignalType} {s: nat}
                       (ticks: nat)
                       (v: Vector.t (Vector.t (combType t) s) ticks)
                       : Vector.t (Vector.t (combType t) ticks) s :=
- Vector.map (fun i => Vector.map (fun j => indexConstBool j i) v) (vseq 0 s).
+  Vector.map (indexConstBoolVec _ v) (vseq 0 s).
 
 Definition unpeelVecVec {t: SignalType} {s: nat}
                         (ticks: nat)
                         (v: Vector.t (Vector.t (combType t) ticks) s)
                         : Vector.t (Vector.t (combType t) s) ticks :=
-  Vector.map (fun ni => Vector.map (fun vi => indexConstBool vi ni) v) (vseq 0 ticks).
-
-
-Local Open Scope nat_scope.
-
-Definition unsignedAddComb {m n : nat}
-                           (av : Bvector m) (bv : Bvector n) :
-                           Bvector (1 + max m n) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let sumSize := 1 + max m n in
-  let sum := (a + b)%N in
-  N2Bv_sized sumSize sum.
-
-Definition unsignedAddBoolVec {m n : nat}
-                              (ticks: nat)
-                              (av : Vector.t (Bvector m) ticks)
-                              (bv : Vector.t (Bvector n) ticks) :
-                              ident (Vector.t (Bvector (1 + max m n)) ticks) :=
-  binOpV ticks unsignedAddComb (av, bv).
-
-Definition unsignedMultComb {m n : nat}
-                            (av : Bvector m) (bv : Bvector n) :
-                            Bvector (m + n) :=
-  let a := Bv2N av in
-  let b := Bv2N bv in
-  let product := (a * b)%N in
-  N2Bv_sized (m + n) product.
-
-Definition unsignedMultBoolVec {m n : nat}
-                               (ticks: nat)
-                               (av : Vector.t (Bvector m) ticks)
-                               (bv : Vector.t (Bvector n) ticks) :
-                               ident (Vector.t (Bvector (m + n)) ticks) :=
-  binOpV ticks unsignedMultComb (av, bv).
-
-Definition greaterThanOrEqualComb {m n : nat}
-                                  (av : Bvector m) (bv : Bvector n) :
-                                  bool :=
-  let a := N.to_nat (Bv2N av) in
-  let b := N.to_nat (Bv2N bv) in
-  b <=? a.
-
-Definition greaterThanOrEqualBoolVec {m n : nat}
-                                     (ticks: nat)
-                                     (av : Vector.t (Bvector m) ticks)
-                                     (bv : Vector.t (Bvector n) ticks) :
-                                     ident (Bvector ticks) :=
-  binOpV ticks greaterThanOrEqualComb (av, bv).
+  Vector.map
+    (fun ni => Vector.map (fun vi => nth_default (defaultCombValue t) ni vi) v)
+    (vseq 0 ticks).
 
 Definition bufBoolVec (ticks: nat)
            (i : Vector.t bool ticks) : ident (Vector.t bool ticks) :=
@@ -310,9 +266,9 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
     indexAt t sz isz := @indexAtBoolVec t sz isz ticks;
     indexConst t sz := @indexConstBoolVec t sz ticks;
     slice t sz := @sliceBoolVec t sz ticks;
-    unsignedAdd m n := @unsignedAddBoolVec m n ticks;
-    unsignedMult m n := @unsignedMultBoolVec m n ticks;
-    greaterThanOrEqual m n := @greaterThanOrEqualBoolVec m n ticks;
+    unsignedAdd m n x y := ret (Vector.map2 (@unsignedAddBool m n) x y);
+    unsignedMult m n x y := ret (Monad:=Monad_ident) (Vector.map2 (@unsignedMultBool m n) x y);
+    greaterThanOrEqual m n x y := ret (Vector.map2 (@greaterThanOrEqualBool m n) x y);
     instantiate _ circuit := circuit;
     blackBox intf _ := ret (tupleInterfaceDefaultSV ticks (map port_type (circuitOutputs intf)));
   }.

--- a/cava/Cava/BitArithmetic.v
+++ b/cava/Cava/BitArithmetic.v
@@ -575,3 +575,28 @@ Ltac constant_bitvec_cases vec :=
       destruct (Vector.hd vec)
   | Vector.t bool 0 => eapply Vector.case0 with (v := vec)
   end.
+
+(******************************************************************************)
+(* Arithmetic operations                                                      *)
+(******************************************************************************)
+
+Definition unsignedAddBool {m n : nat}
+                           (av : Bvector m) (bv : Bvector n)
+: Bvector (1 + max m n) :=
+  let a := Bv2N av in
+  let b := Bv2N bv in
+  let sumSize := 1 + max m n in
+  let sum := (a + b)%N in
+  N2Bv_sized sumSize sum.
+
+Definition unsignedMultBool {m n : nat}
+           (av : Bvector m) (bv : Bvector n)
+  : Bvector (m + n) :=
+  let a := Bv2N av in
+  let b := Bv2N bv in
+  let product := (a * b)%N in
+  N2Bv_sized (m + n) product.
+
+Definition greaterThanOrEqualBool {m n : nat}
+           (av : Bvector m) (bv : Bvector n) : bool :=
+  (Bv2N bv <=? Bv2N av)%N.

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -172,9 +172,18 @@ Section Nth.
     rewrite IHlen by lia.
     f_equal; lia.
   Qed.
+
+  Lemma map_nth_inbounds {A B} (f : A -> B) l d1 d2 n :
+    n < length l -> nth n (map f l) d1 = f (nth n l d2).
+  Proof.
+    revert l; induction n; intros;
+      (destruct l; autorewrite with push_length in *; [ lia | ]);
+      [ reflexivity | ].
+    cbn [map nth]. apply IHn. lia.
+  Qed.
 End Nth.
 Hint Rewrite @nth_step @nth_found @nth_nil using solve [eauto] : push_nth.
-Hint Rewrite @nth_map_seq using lia : push_nth.
+Hint Rewrite @nth_map_seq @map_nth_inbounds using lia : push_nth.
 
 Section Maps.
   Lemma map_id_ext {A} (f : A -> A) (l : list A) :

--- a/cava/Cava/ListUtils.v
+++ b/cava/Cava/ListUtils.v
@@ -74,6 +74,34 @@ Section Misc.
 End Misc.
 Hint Rewrite @seq_snoc using solve [eauto] : pull_snoc.
 
+(* Definition and proofs of [extend], which pads a list to a specified length *)
+Section Extend.
+  Definition extend {A} (l : list A) (d : A) (n : nat) : list A :=
+    l ++ repeat d (n - length l).
+
+  Lemma extend_nil {A} (d : A) n : extend [] d n = repeat d n.
+  Proof. cbv [extend]. autorewrite with push_length natsimpl. reflexivity. Qed.
+
+  Lemma extend_le {A} l (d : A) n : n <= length l -> extend l d n = l.
+  Proof.
+    cbv [extend]; intros.
+    rewrite (proj2 (Nat.sub_0_le _ _)) by lia.
+    cbn [repeat]; autorewrite with listsimpl.
+    reflexivity.
+  Qed.
+
+  Lemma extend_to_match {A B} l1 l2 (a : A) (b : B) :
+    length (extend l1 a (length l2)) = length (extend l2 b (length l1)).
+  Proof.
+    cbv [extend]; intros. autorewrite with push_length.
+    destruct (Nat.min_dec (length l1) (length l2));
+      [ rewrite (proj2 (Nat.sub_0_le (length l1) (length l2))) by lia
+      | rewrite (proj2 (Nat.sub_0_le (length l2) (length l1))) by lia ];
+      lia.
+  Qed.
+End Extend.
+
+
 (* Proofs about [split] *)
 Section Split.
   Lemma split_skipn {A B} n (l : list (A * B)) :

--- a/cava/Cava/VectorUtils.v
+++ b/cava/Cava/VectorUtils.v
@@ -117,16 +117,9 @@ End Transpose.
 (* Vector version of combine                                                  *)
 (******************************************************************************)
 
-Fixpoint vcombine {A B: Type} {s: nat} (a: Vector.t A s)
-                                       (b: Vector.t B s) :
-                                       Vector.t (A * B) s :=
-
-  match s, a, b with
-  | O, _, _ => []
-  | S n, a, b => let (x, xs) := Vector.uncons a in
-                 let (y, ys) := Vector.uncons b in
-                 (x, y) :: vcombine xs ys
-  end.
+Definition vcombine {A B: Type} {s: nat} (a: Vector.t A s) (b: Vector.t B s) :
+  Vector.t (A * B) s :=
+  Vector.map2 (fun a b => (a,b)) a b.
 
 (* Vector version of seq *)
 
@@ -340,35 +333,8 @@ Section VectorFacts.
     rewrite IHn. reflexivity.
   Qed.
 
-  Lemma fold_left_S_identity {A} (f : A -> A -> A) id
-        (left_identity : forall a, f id a = a) n (v : t A (S n)) :
-    Vector.fold_left f id v = Vector.fold_left f (Vector.hd v) (Vector.tl v).
-  Proof.
-    intros. rewrite (eta v).
-    rewrite !fold_left_S, left_identity.
-    reflexivity.
-  Qed.
-
   Hint Rewrite @fold_left_S @fold_left_0
        using solve [eauto] : push_vector_fold vsimpl.
-
-  Lemma fold_left_S_assoc {A} (f : A -> A -> A) id
-        (right_identity : forall a, f a id = a)
-        (left_identity : forall a, f id a = a)
-        (associative :
-           forall a b c, f a (f b c) = f (f a b) c) :
-    forall n start (v : t A n),
-      Vector.fold_left f start v = f start (Vector.fold_left f id v).
-  Proof.
-    induction n; intros; autorewrite with push_vector_fold.
-    { rewrite right_identity. reflexivity. }
-    { rewrite left_identity.
-      erewrite <-fold_left_S_identity by eauto.
-      rewrite IHn, <-associative.
-      rewrite fold_left_S with (b:=id).
-      f_equal. rewrite !left_identity, <-IHn.
-      reflexivity. }
-  Qed.
 
   Lemma nil_eq {A} (v1 v2 : t A 0) : v1 = v2.
   Proof.
@@ -596,6 +562,41 @@ Section VectorFacts.
     rewrite IHm. reflexivity.
   Qed.
 
+  Lemma map2_splitat1 {A B C} (f : A -> B -> C) n m (va : Vector.t A (n + m)) vb :
+    map2 f (fst (splitat _ va)) (fst (splitat _ vb))
+    = fst (splitat _ (map2 f va vb)).
+  Proof.
+    erewrite append_splitat with (vw:=va) by apply surjective_pairing.
+    erewrite append_splitat with (vw:=vb) by apply surjective_pairing.
+    rewrite map2_append, !splitat_append. cbn [fst snd].
+    reflexivity.
+  Qed.
+
+  Lemma map2_splitat2 {A B C} (f : A -> B -> C) n m (va : Vector.t A (n + m)) vb :
+    map2 f (snd (splitat _ va)) (snd (splitat _ vb))
+    = snd (splitat _ (map2 f va vb)).
+  Proof.
+    erewrite append_splitat with (vw:=va) by apply surjective_pairing.
+    erewrite append_splitat with (vw:=vb) by apply surjective_pairing.
+    rewrite map2_append, !splitat_append. cbn [fst snd].
+    reflexivity.
+  Qed.
+
+  Lemma map2_reshape {A B C} (f : A -> B -> C) n m
+        (va : t A (n * m)) (vb : t B (n * m)) :
+    map2 (map2 f) (reshape va) (reshape vb) = reshape (map2 f va vb).
+  Proof.
+    revert va vb; induction n; intros; [ apply nil_eq | ].
+    cbn [reshape].
+    repeat match goal with
+           | |- context [match ?p with pair _ _ => _ end] =>
+             rewrite (surjective_pairing p)
+           end.
+    rewrite !map2_cons, ?hd_cons, ?tl_cons.
+    rewrite IHn, map2_splitat1, map2_splitat2.
+    reflexivity.
+  Qed.
+
   Lemma hd_snoc {A} n (v : t A (S n)) x :
     hd (snoc v x) = hd v.
   Proof. rewrite (eta v). reflexivity. Qed.
@@ -759,6 +760,16 @@ Section VectorFacts.
     rewrite IHn; reflexivity.
   Qed.
 
+  Lemma to_list_inj {A n} (v1 v2 : t A n) :
+    to_list v1 = to_list v2 -> v1 = v2.
+  Proof.
+    revert v1 v2; induction n; [ intros; apply nil_eq | ].
+    intros v1 v2; rewrite (Vector.eta v1), (Vector.eta v2) in *.
+    rewrite !to_list_cons; intros.
+    match goal with H : (_ :: _)%list = _ |- _ => inversion H; clear H end.
+    f_equal; auto.
+  Qed.
+
   Lemma fold_left_to_list {A B} (f : B -> A -> B) n b (v : t A n) :
     fold_left f b v = List.fold_left f (to_list v) b.
   Proof.
@@ -845,7 +856,8 @@ Hint Rewrite @map_cons @map2_cons
    databases *)
 Hint Rewrite <- @reverse_map2 @snoc_map2 @unsnoc_map2 @snoc_map @unsnoc_map
      using solve [eauto] : push_vector_map.
-Hint Rewrite  @nth_map @map_to_const @map2_flatten
+Hint Rewrite  @nth_map @map_to_const @map2_flatten @map2_reshape @map2_splitat1
+     @map2_splitat2
      using solve [eauto] : push_vector_map.
 
 (* [eauto] might not solve map_id_ext, so add more power to the strategy *)
@@ -865,16 +877,36 @@ Section VcombineFacts.
   Lemma to_list_vcombine {A B n} (v1 : Vector.t A n) (v2 : Vector.t B n) :
     to_list (vcombine v1 v2) = combine (to_list v1) (to_list v2).
   Proof.
+    cbv [vcombine].
     induction n; intros.
     { eapply case0 with (v:=v1). eapply case0 with (v:=v2).
       reflexivity. }
     { rewrite (eta v1), (eta v2).
-      cbn [vcombine].
-      rewrite !uncons_cons, !to_list_cons.
-      cbn [combine]. rewrite IHn; reflexivity. }
+      autorewrite with push_vector_map vsimpl.
+      cbn [combine].
+      rewrite IHn; reflexivity. }
   Qed.
+
+  Lemma map_vcombine_map2 {A B C n} (f : A * B -> C)
+        (va : Vector.t A n) (vb : Vector.t B n) :
+    map f (vcombine va vb) = Vector.map2 (fun a b => f (a,b)) va vb.
+  Proof.
+    cbv [vcombine]. rewrite map_map2. reflexivity.
+  Qed.
+
+  Lemma vcombine_cons {A B n} (va : Vector.t A n) (vb : Vector.t B n) a b :
+    vcombine (a :: va)%vector (b :: vb)%vector = ((a,b) :: vcombine va vb)%vector.
+  Proof.
+    cbv [vcombine]; autorewrite with push_vector_map vsimpl.
+    reflexivity.
+  Qed.
+
+  Lemma vcombine_nil {A B} (va : Vector.t A 0) (vb : Vector.t B 0) :
+    vcombine va vb = Vector.nil _.
+  Proof. apply nil_eq. Qed.
 End VcombineFacts.
 Hint Rewrite @to_list_vcombine using solve [eauto] : push_to_list.
+Hint Rewrite @vcombine_cons @vcombine_nil using solve [eauto] : push_vcombine.
 
 Section VseqFacts.
   Lemma vseq_S start len :
@@ -971,6 +1003,250 @@ Section TransposeFacts.
     rewrite <-eta; reflexivity.
   Qed.
 End TransposeFacts.
+
+Section InV.
+  (* Version of Vector.In that is defined as a computable Prop rather than an
+     inductive (similar to List.In). The reason for defining this is that
+     Vector.In does not play nicely with [inversion] and requires using the
+     EqDep axioms to prove that In x (y :: v) -> y = x \/ In x v. *)
+  Fixpoint InV {A n} (x : A) : Vector.t A n -> Prop :=
+    match n with
+    | 0 => fun _ => False
+    | S n' => fun v => x = Vector.hd v \/ InV x (Vector.tl v)
+    end.
+
+  Lemma InV_cons_iff {A n} (v : Vector.t A n) (a x : A) :
+    InV x (a :: v)%vector <-> (x = a \/ InV x v).
+  Proof. reflexivity. Qed.
+
+  Lemma InV_map_iff {A B n} (f : A -> B) (v : Vector.t A n) x :
+    InV x (map f v)%vector <-> (exists y, f y = x /\ InV y v).
+  Proof.
+    revert v; induction n; intros *; [ eapply case0 with (v:=v) | rewrite (eta v) ].
+    all:cbn [InV] in *.
+    all:autorewrite with push_vector_map vsimpl.
+    all:split; intros;
+      repeat match goal with
+             | H : exists _, _ |- _ => destruct H
+             | H : _ /\ _ |- _ => destruct H
+             | H : _ \/ _ |- _ => destruct H
+             | H : InV _ (map _ _) |- _ => rewrite IHn in H
+             | _ => progress subst
+             | |- exists y, ?f y = ?f ?x /\ _ =>
+               exists x; split; [ reflexivity | ];
+                 constructor; solve [eauto]
+             | |- _ \/ InV _ (map _ _) =>
+               rewrite IHn; right; eexists; split; solve [eauto]
+             | _ => tauto
+             end.
+  Qed.
+
+  Lemma InV_map2_impl {A B C n} (f : A -> B -> C) (v1 : Vector.t A n) v2 x :
+    InV x (Vector.map2 f v1 v2)%vector -> (exists a b, f a b = x /\ InV a v1 /\ InV b v2).
+  Proof.
+    revert v1 v2; induction n; intros v1 v2;
+      [ eapply case0 with (v:=v1); eapply case0 with (v:=v2);
+        cbn [InV]; tauto | ].
+    rewrite (eta v1), (eta v2). cbn [InV]; intros.
+    repeat match goal with
+           | _ => progress subst
+           | _ => progress autorewrite with push_vector_map vsimpl in *
+           | H : exists _, _ |- _ => destruct H
+           | H : _ /\ _ |- _ => destruct H
+           | H : _ \/ _ |- _ => destruct H
+           | H : InV _ (Vector.map2 _ _ _) |- _ => apply IHn in H
+           | |- exists x y, ?f x y = ?f ?a ?b /\ _ =>
+             exists a, b; repeat split; cbn [InV]; solve [eauto]
+           end.
+  Qed.
+
+  Lemma InV_to_list_iff {A n} (v : Vector.t A n) x :
+    List.In x (to_list v)%vector <-> InV x v.
+  Proof.
+    revert v; induction n; intros;
+      [ eapply case0 with (v:=v); cbn [InV]; tauto | ].
+    rewrite (eta v). autorewrite with push_to_list.
+    cbn [InV List.In]; intros.
+    repeat match goal with
+           | _ => progress subst
+           | _ => progress autorewrite with push_vector_map vsimpl in *
+           | H : exists _, _ |- _ => destruct H
+           | H : _ /\ _ |- _ => destruct H
+           | H : _ \/ _ |- _ => destruct H
+           | _ => rewrite <-IHn
+           | |- _ <-> _ => split; intros
+           | |- ?x = ?x \/ _ => left; reflexivity
+           | H : ?P |- _ \/ ?P => right; assumption
+           end.
+  Qed.
+End InV.
+
+Section ForallV.
+  (* Non-inductive version of Vector.Forall; the standard library version is
+     hard to extract information from because it creates existT terms after
+     inversion in the cons case *)
+  Fixpoint ForallV {A n} (P : A -> Prop) : Vector.t A n -> Prop :=
+    match n with
+    | 0 => fun _ => True
+    | S n' => fun v => P (Vector.hd v) /\ ForallV P (Vector.tl v)
+    end.
+
+  Lemma ForallV_forall {A n} P (v : Vector.t A n) :
+    ForallV P v <-> (forall x, InV x v -> P x).
+  Proof.
+    revert v; induction n; intros; cbn [ForallV InV]; [ tauto | ].
+    rewrite IHn. split; intros.
+    all:repeat match goal with
+               | _ => progress subst
+               | H : _ \/ _ |- _ => destruct H
+               | H : _ /\ _ |- _ => destruct H
+               | _ => repeat split; solve [eauto]
+               end.
+  Qed.
+
+  Lemma ForallV_append {A n m} P (v1 : Vector.t A n) (v2 : Vector.t A m) :
+    ForallV P (v1 ++ v2) <-> (ForallV P v1 /\ ForallV P v2).
+  Proof.
+    revert v1 v2; induction n; intros v1 v2.
+    { eapply case0 with (v:=v1); cbn [Vector.append ForallV].
+      tauto. }
+    { rewrite (eta v1). rewrite <-append_comm_cons.
+      change (S n + m) with (S (n + m)) in *.
+      cbn [ForallV]. autorewrite with vsimpl.
+      rewrite IHn; tauto. }
+  Qed.
+
+  Lemma ForallV_const {A} n (P : A -> Prop) x :
+    P x -> ForallV P (const x n).
+  Proof.
+    induction n; intros; cbn [ForallV]; [ tauto | ].
+    rewrite const_cons. autorewrite with vsimpl. tauto.
+  Qed.
+
+  Lemma ForallV_resize {A n} m P (v : Vector.t A n) H :
+    ForallV P (resize m H v) <-> ForallV P v.
+  Proof. subst. rewrite <-resize_id. reflexivity. Qed.
+
+  Lemma ForallV_trivial {A} n (P : A -> Prop) (v : Vector.t A n) :
+    (forall x, P x) -> ForallV P v.
+  Proof.
+    induction n; intros; cbn [ForallV]; [ tauto | ].
+    split; auto.
+  Qed.
+
+  Lemma ForallV_splitat1 {A} (P : A -> Prop) n m (v : Vector.t A (n + m)) :
+    ForallV P v -> ForallV P (fst (splitat _ v)).
+  Proof.
+    intro Hv.
+    erewrite append_splitat in Hv by apply surjective_pairing.
+    apply ForallV_append in Hv. tauto.
+  Qed.
+
+  Lemma ForallV_splitat2 {A} (P : A -> Prop) n m (v : Vector.t A (n + m)) :
+    ForallV P v -> ForallV P (snd (splitat _ v)).
+  Proof.
+    intro Hv.
+    erewrite append_splitat in Hv by apply surjective_pairing.
+    apply ForallV_append in Hv. tauto.
+  Qed.
+
+  Lemma ForallV_to_list_iff {A} (P : A -> Prop) n (v : Vector.t A n) :
+    ForallV P v <-> List.Forall P (to_list v).
+  Proof.
+    revert v; induction n; intro v; intros;
+      [ eapply case0 with (v:=v) | rewrite (eta v) ].
+    all:repeat match goal with
+               | _ => progress cbn [ForallV]
+               | _ => progress autorewrite with push_to_list vsimpl
+               | H : _ /\ _ |- _ => destruct H
+               | H : List.Forall _ (_ :: _)%list |- _ =>
+                 inversion H; subst; clear H
+               | |- _ <-> _ => split; intros; [ constructor | ]
+               | |- _ /\ _ => split
+               | _ => apply IHn; solve [auto]
+               | _ => tauto
+               end.
+  Qed.
+End ForallV.
+
+Section AlgebraicFold.
+  Local Notation t := Vector.t.
+
+  Lemma fold_left_S_identity' {A} (f : A -> A -> A) id (valid : A -> Prop)
+        (left_identity : forall a, valid a -> f id a = a) n (v : t A (S n)) :
+    ForallV valid v ->
+    Vector.fold_left f id v = Vector.fold_left f (Vector.hd v) (Vector.tl v).
+  Proof.
+    cbn [ForallV]; destruct 1. rewrite (eta v).
+    autorewrite with push_vector_fold vsimpl.
+    rewrite left_identity by auto. reflexivity.
+  Qed.
+
+  Lemma fold_left_S_identity {A} (f : A -> A -> A) id
+        (left_identity : forall a, f id a = a) n (v : t A (S n)) :
+    Vector.fold_left f id v = Vector.fold_left f (Vector.hd v) (Vector.tl v).
+  Proof.
+    eapply fold_left_S_identity' with (valid:=fun _ => True); auto; [ ].
+    apply ForallV_trivial. tauto.
+  Qed.
+
+  Lemma fold_left_preserves_valid {A} (f : A -> A -> A) (valid : A -> Prop)
+        (preserves_valid : forall a b, valid a -> valid b -> valid (f a b)) :
+    forall n start (v : t A n),
+      ForallV valid v -> valid start ->
+      valid (Vector.fold_left f start v).
+  Proof.
+    intros. rewrite fold_left_to_list.
+    eapply ListUtils.fold_left_invariant with (I:=valid); eauto; [ ].
+    intros *. rewrite InV_to_list_iff. intros.
+    match goal with H : ForallV _ _ |- _ =>
+                    eapply ForallV_forall in H; [ | solve [eauto] ] end.
+    eauto.
+  Qed.
+
+  Lemma fold_left_S_assoc' {A} (f : A -> A -> A) (valid : A -> Prop) id
+        (identity_valid : valid id)
+        (preserves_valid : forall a b, valid a -> valid b -> valid (f a b))
+        (right_identity : forall a, valid a -> f a id = a)
+        (left_identity : forall a, valid a -> f id a = a)
+        (associative :
+           forall a b c,
+             valid a -> valid b -> valid c ->
+             f a (f b c) = f (f a b) c) :
+    forall n start (v : t A n),
+      ForallV valid v -> valid start ->
+      Vector.fold_left f start v = f start (Vector.fold_left f id v).
+  Proof.
+    induction n; intros; autorewrite with push_vector_fold.
+    { rewrite right_identity by auto. reflexivity. }
+    { match goal with H : ForallV _ _ |- _ => destruct H end.
+      rewrite left_identity by eauto.
+      erewrite <-fold_left_S_identity' by (cbn [ForallV]; eauto).
+      rewrite IHn, <-associative; auto;
+        [ | apply fold_left_preserves_valid with (valid0:=valid); solve [auto] ].
+      rewrite fold_left_S with (b:=id).
+      f_equal. rewrite !left_identity, <-IHn by auto.
+      reflexivity. }
+  Qed.
+
+  Lemma fold_left_S_assoc {A} (f : A -> A -> A) id
+        (right_identity : forall a, f a id = a)
+        (left_identity : forall a, f id a = a)
+        (associative :
+           forall a b c, f a (f b c) = f (f a b) c) :
+    forall n start (v : t A n),
+      Vector.fold_left f start v = f start (Vector.fold_left f id v).
+  Proof.
+    induction n; intros; autorewrite with push_vector_fold.
+    { rewrite right_identity. reflexivity. }
+    { rewrite left_identity.
+      erewrite <-fold_left_S_identity by eauto.
+      rewrite IHn, <-associative.
+      rewrite fold_left_S with (b:=id).
+      f_equal. rewrite !left_identity, <-IHn.
+      reflexivity. }
+  Qed.
+End AlgebraicFold.
 
 Section Vector.
   Context {A:Type}.


### PR DESCRIPTION
Part 1 of 2
Progress towards #422 

- Make `SequentialV` and `SequentialTimed` independent of `CombinationalMonad`
  - move some bit-arithmetic definitions from `CombinationalMonad` to `BitArithmetic`
  - update the timed monad to use `loopDelayS`
- New definition `extend` and a few proofs in `ListUtils`
- New definitions `InV` and `ForallV` in `VectorUtils`[0]
- Generalization of `VectorUtils` lemmas about "algebraic" loops with identity elements and group-like operations
- Generalization of `tree` lemmas to accept validity preconditions on algebraic elements
- Miscellaneous useful helper lemmas about vectors

I've now completed the task set out in #422, but the change is very large, so I've separated out some changes that are required for that change but still build when separated from it (for instance, helper lemmas in `VectorUtils.v` and `ListUtils.v`). I want to do a little more investigation into alternate strategies before merging part 2, to see if we can retain the ability to avoid list reasoning in combinational proofs. However, regardless of the outcome of that investigation, I think this part 1 should be merged, since it contains generally useful lemmas and updates.

[0] These serve the same purpose as `Vector.In` and `Vector.Forall`, but I had to redefine them because for some reason, the standard library `Vector.In` and `Vector.Forall` are defined in a way that simply makes them impossible to reason about in proofs without importing axioms. The new definitions are similar to the way the standard library's `List.In` works; they're fixpoints that compute a `Prop` based on the vector, rather than being an inductive type themselves.