### PR TITLE
Define a constant member to map bool values to SignalType values

### DIFF
--- a/cava/Cava/Acorn/CavaClass.v
+++ b/cava/Cava/Acorn/CavaClass.v
@@ -27,6 +27,7 @@ Local Open Scope type_scope.
 Class Cava (signal : SignalType -> Type) := {
   cava : Type -> Type;    
   (* Constant values. *)
+  constant : bool -> signal Bit;
   zero : cava (signal Bit); (* This component always returns the value 0. *)
   one : cava (signal Bit); (* This component always returns the value 1. *)
   (* Default values. *)

--- a/cava/Cava/Acorn/CombinationalMonad.v
+++ b/cava/Cava/Acorn/CombinationalMonad.v
@@ -158,6 +158,7 @@ Definition loopBool (A B C : SignalType)
 
  Instance CombinationalSemantics : Cava combType :=
   { cava := ident;
+    constant b := b;
     zero := ret false;
     one := ret true;
     defaultSignal t := @defaultCombValue t;

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -289,6 +289,7 @@ Definition instantiateNet (intf : CircuitInterface)
 
 Instance CavaCombinationalNet : Cava denoteSignal := {
     cava := state CavaState;
+    constant b := if b then Gnd else Vcc;
     zero := ret Gnd;
     one := ret Vcc;
     defaultSignal := defaultNetSignal;

--- a/cava/Cava/Acorn/Sequential.v
+++ b/cava/Cava/Acorn/Sequential.v
@@ -256,6 +256,7 @@ Definition delayEnableBoolList (t: SignalType) (en: list bool) (i : seqType t) :
 
  Instance SequentialCombSemantics : Cava seqType :=
   { cava := ident;
+    constant b := [b];
     zero := ret [false];
     one := ret [true];
     defaultSignal t := @defaultSeqValue t;

--- a/cava/Cava/Acorn/SequentialTimed.v
+++ b/cava/Cava/Acorn/SequentialTimed.v
@@ -152,6 +152,7 @@ Definition blackBoxF (intf : CircuitInterface)
 
  Instance TimedCombSemantics : Cava combType :=
   { cava := timed;
+    constant b := b;
     zero := ret false;
     one := ret true;
     defaultSignal t := defaultCombValue t;

--- a/cava/Cava/Acorn/SequentialV.v
+++ b/cava/Cava/Acorn/SequentialV.v
@@ -283,6 +283,7 @@ Definition delayV (ticks : nat) (t : SignalType) : seqVType ticks t -> ident (se
 
  Instance SequentialVectorCombSemantics {ticks: nat} : Cava (seqVType ticks) :=
   { cava := ident;
+    constant b := Vector.const b ticks;
     zero := ret (Vector.const false ticks);
     one := ret (Vector.const true ticks);
     defaultSignal t := Vector.const (@defaultCombValue t) ticks;

--- a/cava/Cava/Acorn/XilinxAdder.v
+++ b/cava/Cava/Acorn/XilinxAdder.v
@@ -66,8 +66,7 @@ Section WithCava.
   Definition xilinxAdder {n: nat}
               (a b: signal (Vec Bit n))
               : cava (signal (Vec Bit n)) :=
-    z <- zero ;;
-    '(sum, carry) <- xilinxAdderWithCarry (z, (a, b)) ;;
+    '(sum, carry) <- xilinxAdderWithCarry (constant false, (a, b)) ;;
     ret sum.
 
 End WithCava.

--- a/cava/Cava/Lib/UnsignedAdders.v
+++ b/cava/Cava/Lib/UnsignedAdders.v
@@ -49,8 +49,7 @@ Section WithCava.
   Definition adderWithGrowthNoCarryInV {n : nat}
             (inputs: Vector.t (signal Bit * signal Bit) n) :
             cava (Vector.t (signal Bit) (n + 1)) :=
-    const0 <- zero ;;    
-    adderWithGrowthV (const0, inputs).
+    adderWithGrowthV (constant false, inputs).
 
   Definition addLWithCinV {n : nat}
                           (cin : signal Bit)
@@ -68,9 +67,8 @@ Section WithCava.
   Definition addN {n : nat}
             (ab: signal (Vec Bit n) * signal (Vec Bit n)) :
             cava (signal (Vec Bit n)) :=
-    const0 <- zero ;;
     let (a, b) := ab in
-    '(sum, _) <- unsignedAdderV (const0, vcombine (peel a) (peel b)) ;;
+    '(sum, _) <- unsignedAdderV (constant false, vcombine (peel a) (peel b)) ;;
     ret (unpeel sum).
 
   (****************************************************************************)


### PR DESCRIPTION
Address #432 
Adds a `constant` member to Cava class to map `bool` values to values denoted via `SignalType`.