### PR TITLE
Fix SystemVerilog test execution

### DIFF
--- a/acorn-examples/Makefile
+++ b/acorn-examples/Makefile
@@ -27,6 +27,8 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
+.PRECIOUS: $(VCDS)
+
 all:		coq $(VCDS)
 xilinx:		adder8.vcd
 
@@ -58,7 +60,7 @@ ExamplesSV:	coq ExamplesSV.hs
 		ghc --make ExamplesSV.hs
 		./ExamplesSV
 
-$(SV) $(BENCHES) $(VCDS):	coq ExamplesSV
+$(SV) $(BENCHES) $(CPPS):	ExamplesSV
 
 
 %_tb.vcd:	%.sv %_tb.sv %_tb.cpp

--- a/acorn-examples/xilinx/Makefile
+++ b/acorn-examples/xilinx/Makefile
@@ -32,7 +32,10 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
-all:		coq $(VCDS)
+.PRECIOUS: $(VCDS)
+
+all:		coq $(BENCHES)
+tests:		$(VCDS)
 small:		xadder_tree4_8_tb.vcd
 
 extraction:	$(SV)
@@ -65,13 +68,14 @@ ExamplesSV:	coq ExamplesSV.hs
 		ghc -O2 --make ExamplesSV.hs
 		./ExamplesSV
 
-$(SV) $(BENCHES) $(VCDS):	coq ExamplesSV
+$(SV) $(BENCHES) $(CPPS):	ExamplesSV
 
-%_tb.vcd:	%.sv %_tb.sv %_tb.cpp
+obj_dir/V%_tb:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
 		make -C obj_dir -f V$*_tb.mk V$*_tb
-		obj_dir/V$*_tb
 
+%_tb.vcd:	obj_dir/V%_tb
+		$<
 
 lutNAND_tb.vcd:	lutNAND.sv lutNAND_tb.sv lutNAND_tb.tcl
 		vivado -mode tcl -source lutNAND_tb.tcl

--- a/acorn-examples/xilinx/XilinxAdderTree.v
+++ b/acorn-examples/xilinx/XilinxAdderTree.v
@@ -40,10 +40,8 @@ Section WithCava.
   (****************************************************************************)
   Definition adderTree {sz: nat}
                        (n: nat) (v: signal (Vec (Vec Bit sz) (2^(S n)))):
-                      cava (signal (Vec Bit sz)) :=
-    z <- zero ;;
-    let def := unpeel (Vector.const z sz) in
-    tree def n xilinxAdder (peel v).
+                       cava (signal (Vec Bit sz)) :=
+    tree defaultSignal n xilinxAdder (peel v).
 
   (****************************************************************************)
   (* An adder tree with 2 inputs.                                             *)

--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -1,5 +1,5 @@
 (****************************************************************************)
-(* Copyright 2020 The Project Oak Authors                                   *)
+(* Copyright 2021 The Project Oak Authors                                   *)
 (*                                                                          *)
 (* Licensed under the Apache License, Version 2.0 (the "License")           *)
 (* you may not use this file except in compliance with the License.         *)
@@ -289,7 +289,7 @@ Definition instantiateNet (intf : CircuitInterface)
 
 Instance CavaCombinationalNet : Cava denoteSignal := {
     cava := state CavaState;
-    constant b := if b then Gnd else Vcc;
+    constant b := if b then Vcc else Gnd;
     zero := ret Gnd;
     one := ret Vcc;
     defaultSignal := defaultNetSignal;

--- a/cava/Cava2SystemVerilog.hs
+++ b/cava/Cava2SystemVerilog.hs
@@ -476,7 +476,7 @@ checkOutputs ports = concat (map checkOutput ports)
 checkOutput :: PortDeclaration -> [String]
 checkOutput port
   = ["      if(" ++ name ++ " != " ++ name ++ "_vectors[i_cava]) begin",
-     "        $fatal (\"For " ++ name ++ " expected " ++ fmt ++ " but got " ++
+     "        $error (\"For " ++ name ++ " expected " ++ fmt ++ " but got " ++
      fmt ++ "\", " ++ name ++ "_vectors[i_cava], " ++ name ++ ");",
      "      end;"
     ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,6 +26,8 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
+.PRECIOUS: $(VCDS)
+
 all:		coq $(VCDS)
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt
@@ -55,16 +57,14 @@ TestsSV:	coq TestsSV.hs
 		ghc --make TestsSV
 		./TestsSV
 
-$(SV) $(BENCHES) $(VCDS):	coq TestsSV
+$(SV) $(BENCHES) $(CPPS):	coq TestsSV
 
-%_tb.vcd:	%.sv %_tb.sv %_tb.cpp
-		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
-		make -C obj_dir -f V$*_tb.mk V$*_tb
-		obj_dir/V$*_tb
+obj_dir/V%_tb:		%.sv %_tb.sv %_tb.cpp
+			$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
+			make -C obj_dir -f V$*_tb.mk V$*_tb
 
-*_tb.cpp:
-		make -C obj_dir -f V$*_tb.mk V$*_tb
-		obj_dir/V$*_tb
+%_tb.vcd:	obj_dir/V%_tb
+		$<
 
 clean:
 	-@$(MAKE) -f Makefile.coq clean

--- a/tests/xilinx/Makefile
+++ b/tests/xilinx/Makefile
@@ -28,7 +28,10 @@ BENCHES = $(SV:.sv=_tb.sv)
 CPPS = $(SV:.sv=_tb.cpp)
 VCDS = $(SV:.sv=_tb.vcd)
 
-all:		coq $(VCDS)
+.PRECIOUS: $(VCDS)
+
+all:		coq $(BENCHES)
+tests:		$(VCDS)
 extraction:	$(SV)
 
 VERILATOR = verilator +1800-2012ext+sv verilator.vlt -y $(XILINX)/data/verilog/src/xeclib
@@ -59,12 +62,14 @@ VivadoTestsSV:	coq VivadoTestsSV.hs
 		ghc -O2 --make VivadoTestsSV.hs
 		./VivadoTestsSV
 
-$(SV) $(BENCHES) $(VCDS):	coq VivadoTestsSV
+$(SV) $(BENCHES) $(CPPS):	VivadoTestsSV
 
-%_tb.vcd:	%.sv %_tb.sv %_tb.cpp
+obj_dir/V%_tb:	%.sv %_tb.sv %_tb.cpp
 		$(VERILATOR) --trace --cc --top-module $*_tb $*_tb.sv $*.sv --exe $*_tb.cpp
 		make -C obj_dir -f V$*_tb.mk V$*_tb
-		obj_dir/V$*_tb
+
+%_tb.vcd:	obj_dir/V%_tb
+		$<
 
 %_tb_xsim.vcd:	%.sv
 		xvlog -sv $*.sv $*_tb.sv


### PR DESCRIPTION
Addresses part of  #440
This adjusts the Makefiles for SystemVerilog test generation to correctly handle the generated C++ files as part of the Verilator compile chain. This PR also fixes a mistake in the netlist generation for the new `constant` Cava class method.