### PR TITLE
Deliberately sabotage build to check CI [DO NOT MERGE]

### DIFF
--- a/cava/Cava/Acorn/NetlistGeneration.v
+++ b/cava/Cava/Acorn/NetlistGeneration.v
@@ -289,7 +289,7 @@ Definition instantiateNet (intf : CircuitInterface)
 
 Instance CavaCombinationalNet : Cava denoteSignal := {
     cava := state CavaState;
-    constant b := if b then Vcc else Gnd;
+    constant b := if b then Gnd else Vcc;
     zero := ret Gnd;
     one := ret Vcc;
     defaultSignal := defaultNetSignal;


### PR DESCRIPTION
This PR contains a commit with a sabotaged tests for `countBy` which should fail, and in turn make the CI fail.
```
clang++ -L/usr/local/opt/sqlite/lib    countBy_tb.o verilated.o verilated_vcd_c.o VcountBy_tb__ALL.a    -o VcountBy_tb -lm -lstdc++
obj_dir/VcountBy_tb
                  10: tick = 0, i = 14, o = 15
[10] %Error: countBy_tb.sv:41: Assertion failed in TOP.countBy_tb: For o expected 14 but got 15
%Error: countBy_tb.sv:41: Verilog $stop
Aborting...
make: *** [countBy_tb.vcd] Abort trap: 6
```

Investigating #440 
